### PR TITLE
📌 Update instancio version to 2.12.1

### DIFF
--- a/maven_plugin/pom.xml
+++ b/maven_plugin/pom.xml
@@ -106,8 +106,8 @@
     </dependency>
     <dependency>
       <groupId>org.instancio</groupId>
-      <artifactId>instancio</artifactId>
-      <version>1.0.4</version>
+      <artifactId>instancio-junit</artifactId>
+      <version>2.12.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
I noticed that Maven Lockfile depends on an older version of Instancio. I updated the version to the latest `instancio-junit` artifact (since Maven Lockfile uses JUnit Jupiter).
