### PR TITLE
♻️  Add version field and configure injection of extension version in GithubAction class

### DIFF
--- a/github_action/src/main/java/io/github/chains_project/maven_lockfile/GithubAction.java
+++ b/github_action/src/main/java/io/github/chains_project/maven_lockfile/GithubAction.java
@@ -13,8 +13,10 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 @ApplicationScoped
 public class GithubAction {
 
+    // Injects the version of the extension from the pom.xml
+    // this field is intentionally set to package private instead of private to reduce reflection usage
     @ConfigProperty(name = "quarkus.application.version")
-    public String version;
+    String version;
 
     private static final String COMMAND_GENERATE = "io.github.chains-project:maven-lockfile:%s:generate";
     private static final String COMMAND_VALIDATE = "io.github.chains-project:maven-lockfile:%s:validate";


### PR DESCRIPTION
This commit adds a new version field to GithubAction class and configures the injection of extension version from the pom.xml. The field's access level is set to package-private to avoid excessive reflection usage. This will make it possible for the class to read the version of the extension and will allow for more efficient reflection usage.