### PR TITLE
♻️  Remove redundant code comments in ValidateChecksumMojo

### DIFF
--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/ValidateChecksumMojo.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/ValidateChecksumMojo.java
@@ -27,9 +27,7 @@ import org.apache.maven.shared.transfer.dependencies.resolve.DependencyResolver;
         requiresDependencyResolution = ResolutionScope.COMPILE,
         requiresOnline = true)
 public class ValidateChecksumMojo extends AbstractMojo {
-    /**
-     * The Maven project for which we are generating a lock file.
-     */
+
     /**
      * The Maven project for which we are generating a lock file.
      */


### PR DESCRIPTION
The unnecessary Javadoc comment for a private field has been removed from ValidateChecksumMojo.