### PR TITLE
✨ Add null checks for dependencies & mavenPlugins

### DIFF
--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/LockFile.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/LockFile.java
@@ -39,11 +39,11 @@ public class LockFile {
             VersionNumber versionNumber,
             List<DependencyNode> dependencies,
             List<MavenPlugin> mavenPlugins) {
-        this.dependencies = dependencies;
+        this.dependencies = dependencies == null ? Collections.emptyList() : dependencies;
         this.name = name;
         this.version = versionNumber;
         this.groupId = groupId;
-        this.mavenPlugins = mavenPlugins;
+        this.mavenPlugins = mavenPlugins == null ? Collections.emptyList() : mavenPlugins;
     }
     /**
      * Create a lock file object from a serialized JSON string.

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/graph/NodeId.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/graph/NodeId.java
@@ -7,9 +7,9 @@ import java.util.Objects;
 
 public class NodeId {
 
-    private GroupId groupId;
-    private ArtifactId artifactId;
-    private VersionNumber version;
+    private final GroupId groupId;
+    private final ArtifactId artifactId;
+    private final VersionNumber version;
 
     NodeId(GroupId groupId, ArtifactId artifactId, VersionNumber version) {
         this.groupId = groupId;


### PR DESCRIPTION
This commit updates LockFile.java to add a check to see if the passed-in dependency and plugin lists are null before setting them. If they are, return an empty list instead. NodeId.java also declares groupId, artifactId, and version variables as final.