### PR TITLE
🔼 Update renovate.json with squash strategy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,7 @@
         "fix"
       ],
       "automerge": true,
+      "automergeStrategy" : "squash",
       "semanticCommitType": ":arrow_up:"
     },
     {


### PR DESCRIPTION
Change the automerge strategy in renovate.json to "squash" for cleaner commit logs.