### PR TITLE
🔧 Update dependencies and package version

### DIFF
--- a/github_action/pom.xml
+++ b/github_action/pom.xml
@@ -25,7 +25,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>2.16.6.Final</quarkus.platform.version>
+    <quarkus.platform.version>3.0.1.Final</quarkus.platform.version>
     <skipITs>true</skipITs>
     <surefire-plugin.version>3.0.0-M8</surefire-plugin.version>
     <quarkus.package.type>uber-jar</quarkus.package.type>
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>io.quarkiverse.githubaction</groupId>
       <artifactId>quarkus-github-action</artifactId>
-      <version>1.0.3</version>
+      <version>2.0.1</version>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/github_action/src/main/java/io/github/chains_project/maven_lockfile/GithubAction.java
+++ b/github_action/src/main/java/io/github/chains_project/maven_lockfile/GithubAction.java
@@ -6,7 +6,7 @@ import io.quarkiverse.githubaction.Context;
 import io.quarkiverse.githubaction.Inputs;
 import java.util.ArrayList;
 import java.util.List;
-import javax.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.ApplicationScoped;
 import org.buildobjects.process.ProcBuilder;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 


### PR DESCRIPTION
The dependencies and package version have been updated to quarkus-github-action:2.0.1 and quarkus-platform:3.0.1.Final in pom.xml. The code has also been modified to import jakarta.enterprise.context.ApplicationScoped instead of javax.enterprise.context.ApplicationScoped.