### PR TITLE
feat: ✨ Add metadata to lockfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@
 
 ![My new creation-min](https://user-images.githubusercontent.com/25300639/229370974-7071d818-e094-4959-8b2f-e2050368ee1c.png)
 
-This plugin is a state-of-the-art solution that validates the integrity of a maven build. 
-It does this by generating a lock file that contains the checksums of all the artifacts in the repository. 
+This plugin is a state-of-the-art solution that validates the integrity of a maven build.
+It does this by generating a lock file that contains the checksums of all the artifacts in the repository.
 The lock file can then be used to validate the integrity prior to building.
 This guards the supply chain against malicious actors that might tamper with the artifacts in the repository.
 
 # Features:
 
-* Generative Maven lockfiles 
+* Generative Maven lockfiles
 * Checking Maven lockfiles against the local dependencies.
 * Lockfile format in readable JSON
 * Support for application, test, plugin dependencies

--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@
 
 ![My new creation-min](https://user-images.githubusercontent.com/25300639/229370974-7071d818-e094-4959-8b2f-e2050368ee1c.png)
 
-This plugin is a state-of-the-art solution that validates the integrity of a maven build.
-It does this by generating a lock file that contains the checksums of all the artifacts in the repository.
+This plugin is a state-of-the-art solution that validates the integrity of a maven build. 
+It does this by generating a lock file that contains the checksums of all the artifacts in the repository. 
 The lock file can then be used to validate the integrity prior to building.
 This guards the supply chain against malicious actors that might tamper with the artifacts in the repository.
 
 # Features:
 
-* Generative Maven lockfiles
+* Generative Maven lockfiles 
 * Checking Maven lockfiles against the local dependencies.
 * Lockfile format in readable JSON
 * Support for application, test, plugin dependencies

--- a/maven_plugin/lockfile.json
+++ b/maven_plugin/lockfile.json
@@ -229,29 +229,19 @@
     {
       "groupId": "org.apache.maven",
       "artifactId": "maven-artifact",
-      "version": "3.9.2",
+      "version": "3.2.5",
       "checksumAlgorithm": "SHA-256",
-      "checksum": "f2174221d412a79572817b5aa77125348f43266670b6329a9881cdccf7bbc4b1",
-      "id": "org.apache.maven:maven-artifact:3.9.2",
+      "checksum": "270385907ecfbcb256fe5afb883869fd57a5c021b5242693743ef787605c6335",
+      "id": "org.apache.maven:maven-artifact:3.2.5",
       "children": [
-        {
-          "groupId": "org.apache.commons",
-          "artifactId": "commons-lang3",
-          "version": "3.12.0",
-          "checksumAlgorithm": "SHA-256",
-          "checksum": "d919d904486c037f8d193412da0c92e22a9fa24230b9d67a57855c5c31c7e94e",
-          "id": "org.apache.commons:commons-lang3:3.12.0",
-          "parent": "org.apache.maven:maven-artifact:3.9.2",
-          "children": []
-        },
         {
           "groupId": "org.codehaus.plexus",
           "artifactId": "plexus-utils",
-          "version": "3.5.1",
+          "version": "3.0.20",
           "checksumAlgorithm": "SHA-256",
-          "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-          "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-          "parent": "org.apache.maven:maven-artifact:3.9.2",
+          "checksum": "8f3a655545fc5b4cbf12b5eb8a154fccb0c1144423a1450511f44005a3d574a2",
+          "id": "org.codehaus.plexus:plexus-utils:3.0.20",
+          "parent": "org.apache.maven:maven-artifact:3.2.5",
           "children": []
         }
       ]
@@ -272,28 +262,7 @@
           "checksum": "f2174221d412a79572817b5aa77125348f43266670b6329a9881cdccf7bbc4b1",
           "id": "org.apache.maven:maven-artifact:3.9.2",
           "parent": "org.apache.maven:maven-compat:3.9.2",
-          "children": [
-            {
-              "groupId": "org.apache.commons",
-              "artifactId": "commons-lang3",
-              "version": "3.12.0",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "d919d904486c037f8d193412da0c92e22a9fa24230b9d67a57855c5c31c7e94e",
-              "id": "org.apache.commons:commons-lang3:3.12.0",
-              "parent": "org.apache.maven:maven-artifact:3.9.2",
-              "children": []
-            },
-            {
-              "groupId": "org.codehaus.plexus",
-              "artifactId": "plexus-utils",
-              "version": "3.5.1",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-              "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-              "parent": "org.apache.maven:maven-artifact:3.9.2",
-              "children": []
-            }
-          ]
+          "children": []
         },
         {
           "groupId": "org.apache.maven",
@@ -303,1234 +272,7 @@
           "checksum": "5d544e975d9ca300f779f42b476d32032410c5a1c5e968b9b2140a702fa9e6f7",
           "id": "org.apache.maven:maven-core:3.9.2",
           "parent": "org.apache.maven:maven-compat:3.9.2",
-          "children": [
-            {
-              "groupId": "com.google.guava",
-              "artifactId": "failureaccess",
-              "version": "1.0.1",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "a171ee4c734dd2da837e4b16be9df4661afab72a41adaf31eb84dfdaf936ca26",
-              "id": "com.google.guava:failureaccess:1.0.1",
-              "parent": "org.apache.maven:maven-core:3.9.2",
-              "children": []
-            },
-            {
-              "groupId": "com.google.guava",
-              "artifactId": "guava",
-              "version": "31.1-jre",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "a42edc9cab792e39fe39bb94f3fca655ed157ff87a8af78e1d6ba5b07c4a00ab",
-              "id": "com.google.guava:guava:31.1-jre",
-              "parent": "org.apache.maven:maven-core:3.9.2",
-              "children": [
-                {
-                  "groupId": "com.google.code.findbugs",
-                  "artifactId": "jsr305",
-                  "version": "3.0.2",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
-                  "id": "com.google.code.findbugs:jsr305:3.0.2",
-                  "parent": "com.google.guava:guava:31.1-jre",
-                  "children": []
-                },
-                {
-                  "groupId": "com.google.errorprone",
-                  "artifactId": "error_prone_annotations",
-                  "version": "2.11.0",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "721cb91842b46fa056847d104d5225c8b8e1e8b62263b993051e1e5a0137b7ec",
-                  "id": "com.google.errorprone:error_prone_annotations:2.11.0",
-                  "parent": "com.google.guava:guava:31.1-jre",
-                  "children": []
-                },
-                {
-                  "groupId": "com.google.guava",
-                  "artifactId": "failureaccess",
-                  "version": "1.0.1",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "a171ee4c734dd2da837e4b16be9df4661afab72a41adaf31eb84dfdaf936ca26",
-                  "id": "com.google.guava:failureaccess:1.0.1",
-                  "parent": "com.google.guava:guava:31.1-jre",
-                  "children": []
-                },
-                {
-                  "groupId": "com.google.guava",
-                  "artifactId": "listenablefuture",
-                  "version": "9999.0-empty-to-avoid-conflict-with-guava",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "b372a037d4230aa57fbeffdef30fd6123f9c0c2db85d0aced00c91b974f33f99",
-                  "id": "com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava",
-                  "parent": "com.google.guava:guava:31.1-jre",
-                  "children": []
-                },
-                {
-                  "groupId": "com.google.j2objc",
-                  "artifactId": "j2objc-annotations",
-                  "version": "1.3",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "21af30c92267bd6122c0e0b4d20cccb6641a37eaf956c6540ec471d584e64a7b",
-                  "id": "com.google.j2objc:j2objc-annotations:1.3",
-                  "parent": "com.google.guava:guava:31.1-jre",
-                  "children": []
-                },
-                {
-                  "groupId": "org.checkerframework",
-                  "artifactId": "checker-qual",
-                  "version": "3.12.0",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "ff10785ac2a357ec5de9c293cb982a2cbb605c0309ea4cc1cb9b9bc6dbe7f3cb",
-                  "id": "org.checkerframework:checker-qual:3.12.0",
-                  "parent": "com.google.guava:guava:31.1-jre",
-                  "children": []
-                }
-              ]
-            },
-            {
-              "groupId": "com.google.inject",
-              "artifactId": "guice",
-              "version": "5.1.0",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "4130e50bfac48099c860f0d903b91860c81a249c90f38245f8fed58fc817bc26",
-              "id": "com.google.inject:guice:5.1.0",
-              "parent": "org.apache.maven:maven-core:3.9.2",
-              "children": [
-                {
-                  "groupId": "aopalliance",
-                  "artifactId": "aopalliance",
-                  "version": "1.0",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "addec670fedcd3f113c5c8091d783280d23f75e3acb841b61a9cdb079376a08",
-                  "id": "aopalliance:aopalliance:1.0",
-                  "parent": "com.google.inject:guice:5.1.0",
-                  "children": []
-                },
-                {
-                  "groupId": "javax.inject",
-                  "artifactId": "javax.inject",
-                  "version": "1",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
-                  "id": "javax.inject:javax.inject:1",
-                  "parent": "com.google.inject:guice:5.1.0",
-                  "children": []
-                }
-              ]
-            },
-            {
-              "groupId": "javax.inject",
-              "artifactId": "javax.inject",
-              "version": "1",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
-              "id": "javax.inject:javax.inject:1",
-              "parent": "org.apache.maven:maven-core:3.9.2",
-              "children": []
-            },
-            {
-              "groupId": "org.apache.commons",
-              "artifactId": "commons-lang3",
-              "version": "3.12.0",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "d919d904486c037f8d193412da0c92e22a9fa24230b9d67a57855c5c31c7e94e",
-              "id": "org.apache.commons:commons-lang3:3.12.0",
-              "parent": "org.apache.maven:maven-core:3.9.2",
-              "children": []
-            },
-            {
-              "groupId": "org.apache.maven",
-              "artifactId": "maven-artifact",
-              "version": "3.9.2",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "f2174221d412a79572817b5aa77125348f43266670b6329a9881cdccf7bbc4b1",
-              "id": "org.apache.maven:maven-artifact:3.9.2",
-              "parent": "org.apache.maven:maven-core:3.9.2",
-              "children": [
-                {
-                  "groupId": "org.apache.commons",
-                  "artifactId": "commons-lang3",
-                  "version": "3.12.0",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "d919d904486c037f8d193412da0c92e22a9fa24230b9d67a57855c5c31c7e94e",
-                  "id": "org.apache.commons:commons-lang3:3.12.0",
-                  "parent": "org.apache.maven:maven-artifact:3.9.2",
-                  "children": []
-                },
-                {
-                  "groupId": "org.codehaus.plexus",
-                  "artifactId": "plexus-utils",
-                  "version": "3.5.1",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-                  "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-                  "parent": "org.apache.maven:maven-artifact:3.9.2",
-                  "children": []
-                }
-              ]
-            },
-            {
-              "groupId": "org.apache.maven",
-              "artifactId": "maven-builder-support",
-              "version": "3.9.2",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "701d5793dcd28f09562744b4c3452f77ae94238424a07fb676cf76734deb13bf",
-              "id": "org.apache.maven:maven-builder-support:3.9.2",
-              "parent": "org.apache.maven:maven-core:3.9.2",
-              "children": []
-            },
-            {
-              "groupId": "org.apache.maven",
-              "artifactId": "maven-model",
-              "version": "3.9.2",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "c91583df8b399df87033dbb4c5efe55a0cf6f659da21714c3b0f6f5f9689e28",
-              "id": "org.apache.maven:maven-model:3.9.2",
-              "parent": "org.apache.maven:maven-core:3.9.2",
-              "children": [
-                {
-                  "groupId": "org.codehaus.plexus",
-                  "artifactId": "plexus-utils",
-                  "version": "3.5.1",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-                  "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-                  "parent": "org.apache.maven:maven-model:3.9.2",
-                  "children": []
-                }
-              ]
-            },
-            {
-              "groupId": "org.apache.maven",
-              "artifactId": "maven-model-builder",
-              "version": "3.9.2",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "1649e8b21eb17ceb528fa0830211482ee229bac177bff309824baaf25c2ad142",
-              "id": "org.apache.maven:maven-model-builder:3.9.2",
-              "parent": "org.apache.maven:maven-core:3.9.2",
-              "children": [
-                {
-                  "groupId": "javax.inject",
-                  "artifactId": "javax.inject",
-                  "version": "1",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
-                  "id": "javax.inject:javax.inject:1",
-                  "parent": "org.apache.maven:maven-model-builder:3.9.2",
-                  "children": []
-                },
-                {
-                  "groupId": "org.apache.maven",
-                  "artifactId": "maven-artifact",
-                  "version": "3.9.2",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "f2174221d412a79572817b5aa77125348f43266670b6329a9881cdccf7bbc4b1",
-                  "id": "org.apache.maven:maven-artifact:3.9.2",
-                  "parent": "org.apache.maven:maven-model-builder:3.9.2",
-                  "children": [
-                    {
-                      "groupId": "org.apache.commons",
-                      "artifactId": "commons-lang3",
-                      "version": "3.12.0",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "d919d904486c037f8d193412da0c92e22a9fa24230b9d67a57855c5c31c7e94e",
-                      "id": "org.apache.commons:commons-lang3:3.12.0",
-                      "parent": "org.apache.maven:maven-artifact:3.9.2",
-                      "children": []
-                    },
-                    {
-                      "groupId": "org.codehaus.plexus",
-                      "artifactId": "plexus-utils",
-                      "version": "3.5.1",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-                      "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-                      "parent": "org.apache.maven:maven-artifact:3.9.2",
-                      "children": []
-                    }
-                  ]
-                },
-                {
-                  "groupId": "org.apache.maven",
-                  "artifactId": "maven-builder-support",
-                  "version": "3.9.2",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "701d5793dcd28f09562744b4c3452f77ae94238424a07fb676cf76734deb13bf",
-                  "id": "org.apache.maven:maven-builder-support:3.9.2",
-                  "parent": "org.apache.maven:maven-model-builder:3.9.2",
-                  "children": []
-                },
-                {
-                  "groupId": "org.apache.maven",
-                  "artifactId": "maven-model",
-                  "version": "3.9.2",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "c91583df8b399df87033dbb4c5efe55a0cf6f659da21714c3b0f6f5f9689e28",
-                  "id": "org.apache.maven:maven-model:3.9.2",
-                  "parent": "org.apache.maven:maven-model-builder:3.9.2",
-                  "children": [
-                    {
-                      "groupId": "org.codehaus.plexus",
-                      "artifactId": "plexus-utils",
-                      "version": "3.5.1",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-                      "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-                      "parent": "org.apache.maven:maven-model:3.9.2",
-                      "children": []
-                    }
-                  ]
-                },
-                {
-                  "groupId": "org.codehaus.plexus",
-                  "artifactId": "plexus-interpolation",
-                  "version": "1.26",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "b3b5412ce17889103ea564bcdfcf9fb3dfa540344ffeac6b538a73c9d7182662",
-                  "id": "org.codehaus.plexus:plexus-interpolation:1.26",
-                  "parent": "org.apache.maven:maven-model-builder:3.9.2",
-                  "children": []
-                },
-                {
-                  "groupId": "org.codehaus.plexus",
-                  "artifactId": "plexus-utils",
-                  "version": "3.5.1",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-                  "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-                  "parent": "org.apache.maven:maven-model-builder:3.9.2",
-                  "children": []
-                },
-                {
-                  "groupId": "org.eclipse.sisu",
-                  "artifactId": "org.eclipse.sisu.inject",
-                  "version": "0.3.5",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "c5994010bcdce1d2bd603a4d50c47191ddbd7875d1157b23aaa26d33c82fda13",
-                  "id": "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.5",
-                  "parent": "org.apache.maven:maven-model-builder:3.9.2",
-                  "children": []
-                }
-              ]
-            },
-            {
-              "groupId": "org.apache.maven",
-              "artifactId": "maven-plugin-api",
-              "version": "3.9.2",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "27de347c74dd1d3eb984ae8611874116c486f9f0027f6a4e03f1b69d2ef4aabc",
-              "id": "org.apache.maven:maven-plugin-api:3.9.2",
-              "parent": "org.apache.maven:maven-core:3.9.2",
-              "children": [
-                {
-                  "groupId": "org.apache.maven",
-                  "artifactId": "maven-artifact",
-                  "version": "3.9.2",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "f2174221d412a79572817b5aa77125348f43266670b6329a9881cdccf7bbc4b1",
-                  "id": "org.apache.maven:maven-artifact:3.9.2",
-                  "parent": "org.apache.maven:maven-plugin-api:3.9.2",
-                  "children": [
-                    {
-                      "groupId": "org.apache.commons",
-                      "artifactId": "commons-lang3",
-                      "version": "3.12.0",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "d919d904486c037f8d193412da0c92e22a9fa24230b9d67a57855c5c31c7e94e",
-                      "id": "org.apache.commons:commons-lang3:3.12.0",
-                      "parent": "org.apache.maven:maven-artifact:3.9.2",
-                      "children": []
-                    },
-                    {
-                      "groupId": "org.codehaus.plexus",
-                      "artifactId": "plexus-utils",
-                      "version": "3.5.1",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-                      "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-                      "parent": "org.apache.maven:maven-artifact:3.9.2",
-                      "children": []
-                    }
-                  ]
-                },
-                {
-                  "groupId": "org.apache.maven",
-                  "artifactId": "maven-model",
-                  "version": "3.9.2",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "c91583df8b399df87033dbb4c5efe55a0cf6f659da21714c3b0f6f5f9689e28",
-                  "id": "org.apache.maven:maven-model:3.9.2",
-                  "parent": "org.apache.maven:maven-plugin-api:3.9.2",
-                  "children": [
-                    {
-                      "groupId": "org.codehaus.plexus",
-                      "artifactId": "plexus-utils",
-                      "version": "3.5.1",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-                      "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-                      "parent": "org.apache.maven:maven-model:3.9.2",
-                      "children": []
-                    }
-                  ]
-                },
-                {
-                  "groupId": "org.codehaus.plexus",
-                  "artifactId": "plexus-classworlds",
-                  "version": "2.7.0",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "c60ae538ba66adbc06aae205fbe2306211d3d213ab6df3239ec03cdde2458ad6",
-                  "id": "org.codehaus.plexus:plexus-classworlds:2.7.0",
-                  "parent": "org.apache.maven:maven-plugin-api:3.9.2",
-                  "children": []
-                },
-                {
-                  "groupId": "org.codehaus.plexus",
-                  "artifactId": "plexus-utils",
-                  "version": "3.5.1",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-                  "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-                  "parent": "org.apache.maven:maven-plugin-api:3.9.2",
-                  "children": []
-                },
-                {
-                  "groupId": "org.eclipse.sisu",
-                  "artifactId": "org.eclipse.sisu.plexus",
-                  "version": "0.3.5",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "7e4c61096d70826f20f7a7d55c59a5528e7aa5ad247ee2dfe544e4dd25f6a784",
-                  "id": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5",
-                  "parent": "org.apache.maven:maven-plugin-api:3.9.2",
-                  "children": [
-                    {
-                      "groupId": "javax.annotation",
-                      "artifactId": "javax.annotation-api",
-                      "version": "1.2",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "5909b396ca3a2be10d0eea32c74ef78d816e1b4ead21de1d78de1f890d033e04",
-                      "id": "javax.annotation:javax.annotation-api:1.2",
-                      "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5",
-                      "children": []
-                    },
-                    {
-                      "groupId": "org.codehaus.plexus",
-                      "artifactId": "plexus-classworlds",
-                      "version": "2.5.2",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "b2931d41740490a8d931cbe0cfe9ac20deb66cca606e679f52522f7f534c9fd7",
-                      "id": "org.codehaus.plexus:plexus-classworlds:2.5.2",
-                      "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5",
-                      "children": []
-                    },
-                    {
-                      "groupId": "org.codehaus.plexus",
-                      "artifactId": "plexus-component-annotations",
-                      "version": "1.5.5",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "4df7a6a7be64b35bbccf60b5c115697f9ea3421d22674ae67135dde375fcca1f",
-                      "id": "org.codehaus.plexus:plexus-component-annotations:1.5.5",
-                      "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5",
-                      "children": []
-                    },
-                    {
-                      "groupId": "org.codehaus.plexus",
-                      "artifactId": "plexus-utils",
-                      "version": "3.0.24",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "83ee748b12d06afb0ad4050a591132b3e8025fbb1990f1ed002e8b73293e69b4",
-                      "id": "org.codehaus.plexus:plexus-utils:3.0.24",
-                      "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5",
-                      "children": []
-                    },
-                    {
-                      "groupId": "org.eclipse.sisu",
-                      "artifactId": "org.eclipse.sisu.inject",
-                      "version": "0.3.5",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "c5994010bcdce1d2bd603a4d50c47191ddbd7875d1157b23aaa26d33c82fda13",
-                      "id": "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.5",
-                      "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5",
-                      "children": []
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "groupId": "org.apache.maven",
-              "artifactId": "maven-repository-metadata",
-              "version": "3.9.2",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "2ab4ad3dd4cf1052747344ebcfa89addfd75f1067d893f8721a22430fb360e8a",
-              "id": "org.apache.maven:maven-repository-metadata:3.9.2",
-              "parent": "org.apache.maven:maven-core:3.9.2",
-              "children": [
-                {
-                  "groupId": "org.codehaus.plexus",
-                  "artifactId": "plexus-utils",
-                  "version": "3.5.1",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-                  "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-                  "parent": "org.apache.maven:maven-repository-metadata:3.9.2",
-                  "children": []
-                }
-              ]
-            },
-            {
-              "groupId": "org.apache.maven",
-              "artifactId": "maven-resolver-provider",
-              "version": "3.9.2",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "cae807ff07bc3bfce26d2bb8f2a53b3f6b74600a5406b4c11a32d1fedaddf99",
-              "id": "org.apache.maven:maven-resolver-provider:3.9.2",
-              "parent": "org.apache.maven:maven-core:3.9.2",
-              "children": [
-                {
-                  "groupId": "javax.inject",
-                  "artifactId": "javax.inject",
-                  "version": "1",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
-                  "id": "javax.inject:javax.inject:1",
-                  "parent": "org.apache.maven:maven-resolver-provider:3.9.2",
-                  "children": []
-                },
-                {
-                  "groupId": "org.apache.maven",
-                  "artifactId": "maven-model",
-                  "version": "3.9.2",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "c91583df8b399df87033dbb4c5efe55a0cf6f659da21714c3b0f6f5f9689e28",
-                  "id": "org.apache.maven:maven-model:3.9.2",
-                  "parent": "org.apache.maven:maven-resolver-provider:3.9.2",
-                  "children": [
-                    {
-                      "groupId": "org.codehaus.plexus",
-                      "artifactId": "plexus-utils",
-                      "version": "3.5.1",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-                      "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-                      "parent": "org.apache.maven:maven-model:3.9.2",
-                      "children": []
-                    }
-                  ]
-                },
-                {
-                  "groupId": "org.apache.maven",
-                  "artifactId": "maven-model-builder",
-                  "version": "3.9.2",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "1649e8b21eb17ceb528fa0830211482ee229bac177bff309824baaf25c2ad142",
-                  "id": "org.apache.maven:maven-model-builder:3.9.2",
-                  "parent": "org.apache.maven:maven-resolver-provider:3.9.2",
-                  "children": [
-                    {
-                      "groupId": "javax.inject",
-                      "artifactId": "javax.inject",
-                      "version": "1",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
-                      "id": "javax.inject:javax.inject:1",
-                      "parent": "org.apache.maven:maven-model-builder:3.9.2",
-                      "children": []
-                    },
-                    {
-                      "groupId": "org.apache.maven",
-                      "artifactId": "maven-artifact",
-                      "version": "3.9.2",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "f2174221d412a79572817b5aa77125348f43266670b6329a9881cdccf7bbc4b1",
-                      "id": "org.apache.maven:maven-artifact:3.9.2",
-                      "parent": "org.apache.maven:maven-model-builder:3.9.2",
-                      "children": [
-                        {
-                          "groupId": "org.apache.commons",
-                          "artifactId": "commons-lang3",
-                          "version": "3.12.0",
-                          "checksumAlgorithm": "SHA-256",
-                          "checksum": "d919d904486c037f8d193412da0c92e22a9fa24230b9d67a57855c5c31c7e94e",
-                          "id": "org.apache.commons:commons-lang3:3.12.0",
-                          "parent": "org.apache.maven:maven-artifact:3.9.2",
-                          "children": []
-                        },
-                        {
-                          "groupId": "org.codehaus.plexus",
-                          "artifactId": "plexus-utils",
-                          "version": "3.5.1",
-                          "checksumAlgorithm": "SHA-256",
-                          "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-                          "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-                          "parent": "org.apache.maven:maven-artifact:3.9.2",
-                          "children": []
-                        }
-                      ]
-                    },
-                    {
-                      "groupId": "org.apache.maven",
-                      "artifactId": "maven-builder-support",
-                      "version": "3.9.2",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "701d5793dcd28f09562744b4c3452f77ae94238424a07fb676cf76734deb13bf",
-                      "id": "org.apache.maven:maven-builder-support:3.9.2",
-                      "parent": "org.apache.maven:maven-model-builder:3.9.2",
-                      "children": []
-                    },
-                    {
-                      "groupId": "org.apache.maven",
-                      "artifactId": "maven-model",
-                      "version": "3.9.2",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "c91583df8b399df87033dbb4c5efe55a0cf6f659da21714c3b0f6f5f9689e28",
-                      "id": "org.apache.maven:maven-model:3.9.2",
-                      "parent": "org.apache.maven:maven-model-builder:3.9.2",
-                      "children": [
-                        {
-                          "groupId": "org.codehaus.plexus",
-                          "artifactId": "plexus-utils",
-                          "version": "3.5.1",
-                          "checksumAlgorithm": "SHA-256",
-                          "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-                          "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-                          "parent": "org.apache.maven:maven-model:3.9.2",
-                          "children": []
-                        }
-                      ]
-                    },
-                    {
-                      "groupId": "org.codehaus.plexus",
-                      "artifactId": "plexus-interpolation",
-                      "version": "1.26",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "b3b5412ce17889103ea564bcdfcf9fb3dfa540344ffeac6b538a73c9d7182662",
-                      "id": "org.codehaus.plexus:plexus-interpolation:1.26",
-                      "parent": "org.apache.maven:maven-model-builder:3.9.2",
-                      "children": []
-                    },
-                    {
-                      "groupId": "org.codehaus.plexus",
-                      "artifactId": "plexus-utils",
-                      "version": "3.5.1",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-                      "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-                      "parent": "org.apache.maven:maven-model-builder:3.9.2",
-                      "children": []
-                    },
-                    {
-                      "groupId": "org.eclipse.sisu",
-                      "artifactId": "org.eclipse.sisu.inject",
-                      "version": "0.3.5",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "c5994010bcdce1d2bd603a4d50c47191ddbd7875d1157b23aaa26d33c82fda13",
-                      "id": "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.5",
-                      "parent": "org.apache.maven:maven-model-builder:3.9.2",
-                      "children": []
-                    }
-                  ]
-                },
-                {
-                  "groupId": "org.apache.maven",
-                  "artifactId": "maven-repository-metadata",
-                  "version": "3.9.2",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "2ab4ad3dd4cf1052747344ebcfa89addfd75f1067d893f8721a22430fb360e8a",
-                  "id": "org.apache.maven:maven-repository-metadata:3.9.2",
-                  "parent": "org.apache.maven:maven-resolver-provider:3.9.2",
-                  "children": [
-                    {
-                      "groupId": "org.codehaus.plexus",
-                      "artifactId": "plexus-utils",
-                      "version": "3.5.1",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-                      "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-                      "parent": "org.apache.maven:maven-repository-metadata:3.9.2",
-                      "children": []
-                    }
-                  ]
-                },
-                {
-                  "groupId": "org.apache.maven.resolver",
-                  "artifactId": "maven-resolver-api",
-                  "version": "1.9.10",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "5ee57c89259d0a41f56291864ca7db12349ce11eca8ef62be5680c7c244705d0",
-                  "id": "org.apache.maven.resolver:maven-resolver-api:1.9.10",
-                  "parent": "org.apache.maven:maven-resolver-provider:3.9.2",
-                  "children": []
-                },
-                {
-                  "groupId": "org.apache.maven.resolver",
-                  "artifactId": "maven-resolver-impl",
-                  "version": "1.9.10",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "6fc7cc06dd6364805e42b89dcaec2d0875ffb1fee8774938783918cb2020f2d8",
-                  "id": "org.apache.maven.resolver:maven-resolver-impl:1.9.10",
-                  "parent": "org.apache.maven:maven-resolver-provider:3.9.2",
-                  "children": [
-                    {
-                      "groupId": "org.apache.maven.resolver",
-                      "artifactId": "maven-resolver-api",
-                      "version": "1.9.10",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "5ee57c89259d0a41f56291864ca7db12349ce11eca8ef62be5680c7c244705d0",
-                      "id": "org.apache.maven.resolver:maven-resolver-api:1.9.10",
-                      "parent": "org.apache.maven.resolver:maven-resolver-impl:1.9.10",
-                      "children": []
-                    },
-                    {
-                      "groupId": "org.apache.maven.resolver",
-                      "artifactId": "maven-resolver-named-locks",
-                      "version": "1.9.10",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "f55d2e75468509a92fc841d818283168ea458ebcb34a3011531cac812e309155",
-                      "id": "org.apache.maven.resolver:maven-resolver-named-locks:1.9.10",
-                      "parent": "org.apache.maven.resolver:maven-resolver-impl:1.9.10",
-                      "children": [
-                        {
-                          "groupId": "org.slf4j",
-                          "artifactId": "slf4j-api",
-                          "version": "1.7.36",
-                          "checksumAlgorithm": "SHA-256",
-                          "checksum": "d3ef575e3e4979678dc01bf1dcce51021493b4d11fb7f1be8ad982877c16a1c0",
-                          "id": "org.slf4j:slf4j-api:1.7.36",
-                          "parent": "org.apache.maven.resolver:maven-resolver-named-locks:1.9.10",
-                          "children": []
-                        }
-                      ]
-                    },
-                    {
-                      "groupId": "org.apache.maven.resolver",
-                      "artifactId": "maven-resolver-spi",
-                      "version": "1.9.10",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "7554650b663fef31c594c75f600b2241bbed9306d1ee5637047da55e9a443df3",
-                      "id": "org.apache.maven.resolver:maven-resolver-spi:1.9.10",
-                      "parent": "org.apache.maven.resolver:maven-resolver-impl:1.9.10",
-                      "children": [
-                        {
-                          "groupId": "org.apache.maven.resolver",
-                          "artifactId": "maven-resolver-api",
-                          "version": "1.9.10",
-                          "checksumAlgorithm": "SHA-256",
-                          "checksum": "5ee57c89259d0a41f56291864ca7db12349ce11eca8ef62be5680c7c244705d0",
-                          "id": "org.apache.maven.resolver:maven-resolver-api:1.9.10",
-                          "parent": "org.apache.maven.resolver:maven-resolver-spi:1.9.10",
-                          "children": []
-                        }
-                      ]
-                    },
-                    {
-                      "groupId": "org.apache.maven.resolver",
-                      "artifactId": "maven-resolver-util",
-                      "version": "1.9.10",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "c6eda39bd4b7670e7314ffa006e4dc9da48617e2a6ff26e5af118f0be6a0cdd4",
-                      "id": "org.apache.maven.resolver:maven-resolver-util:1.9.10",
-                      "parent": "org.apache.maven.resolver:maven-resolver-impl:1.9.10",
-                      "children": [
-                        {
-                          "groupId": "org.apache.maven.resolver",
-                          "artifactId": "maven-resolver-api",
-                          "version": "1.9.10",
-                          "checksumAlgorithm": "SHA-256",
-                          "checksum": "5ee57c89259d0a41f56291864ca7db12349ce11eca8ef62be5680c7c244705d0",
-                          "id": "org.apache.maven.resolver:maven-resolver-api:1.9.10",
-                          "parent": "org.apache.maven.resolver:maven-resolver-util:1.9.10",
-                          "children": []
-                        }
-                      ]
-                    },
-                    {
-                      "groupId": "org.slf4j",
-                      "artifactId": "slf4j-api",
-                      "version": "1.7.36",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "d3ef575e3e4979678dc01bf1dcce51021493b4d11fb7f1be8ad982877c16a1c0",
-                      "id": "org.slf4j:slf4j-api:1.7.36",
-                      "parent": "org.apache.maven.resolver:maven-resolver-impl:1.9.10",
-                      "children": []
-                    }
-                  ]
-                },
-                {
-                  "groupId": "org.apache.maven.resolver",
-                  "artifactId": "maven-resolver-spi",
-                  "version": "1.9.10",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "7554650b663fef31c594c75f600b2241bbed9306d1ee5637047da55e9a443df3",
-                  "id": "org.apache.maven.resolver:maven-resolver-spi:1.9.10",
-                  "parent": "org.apache.maven:maven-resolver-provider:3.9.2",
-                  "children": [
-                    {
-                      "groupId": "org.apache.maven.resolver",
-                      "artifactId": "maven-resolver-api",
-                      "version": "1.9.10",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "5ee57c89259d0a41f56291864ca7db12349ce11eca8ef62be5680c7c244705d0",
-                      "id": "org.apache.maven.resolver:maven-resolver-api:1.9.10",
-                      "parent": "org.apache.maven.resolver:maven-resolver-spi:1.9.10",
-                      "children": []
-                    }
-                  ]
-                },
-                {
-                  "groupId": "org.apache.maven.resolver",
-                  "artifactId": "maven-resolver-util",
-                  "version": "1.9.10",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "c6eda39bd4b7670e7314ffa006e4dc9da48617e2a6ff26e5af118f0be6a0cdd4",
-                  "id": "org.apache.maven.resolver:maven-resolver-util:1.9.10",
-                  "parent": "org.apache.maven:maven-resolver-provider:3.9.2",
-                  "children": [
-                    {
-                      "groupId": "org.apache.maven.resolver",
-                      "artifactId": "maven-resolver-api",
-                      "version": "1.9.10",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "5ee57c89259d0a41f56291864ca7db12349ce11eca8ef62be5680c7c244705d0",
-                      "id": "org.apache.maven.resolver:maven-resolver-api:1.9.10",
-                      "parent": "org.apache.maven.resolver:maven-resolver-util:1.9.10",
-                      "children": []
-                    }
-                  ]
-                },
-                {
-                  "groupId": "org.codehaus.plexus",
-                  "artifactId": "plexus-utils",
-                  "version": "3.5.1",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-                  "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-                  "parent": "org.apache.maven:maven-resolver-provider:3.9.2",
-                  "children": []
-                }
-              ]
-            },
-            {
-              "groupId": "org.apache.maven",
-              "artifactId": "maven-settings",
-              "version": "3.9.2",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "ffd180b75ce1050465b2904f5e79db2fcb8628017433afe3b389e32e51360322",
-              "id": "org.apache.maven:maven-settings:3.9.2",
-              "parent": "org.apache.maven:maven-core:3.9.2",
-              "children": [
-                {
-                  "groupId": "org.codehaus.plexus",
-                  "artifactId": "plexus-utils",
-                  "version": "3.5.1",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-                  "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-                  "parent": "org.apache.maven:maven-settings:3.9.2",
-                  "children": []
-                }
-              ]
-            },
-            {
-              "groupId": "org.apache.maven",
-              "artifactId": "maven-settings-builder",
-              "version": "3.9.2",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "936ee7c856e72557d6280a7cf96c2f76eea570e29b11ee0d0057d89722513ed7",
-              "id": "org.apache.maven:maven-settings-builder:3.9.2",
-              "parent": "org.apache.maven:maven-core:3.9.2",
-              "children": [
-                {
-                  "groupId": "javax.inject",
-                  "artifactId": "javax.inject",
-                  "version": "1",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
-                  "id": "javax.inject:javax.inject:1",
-                  "parent": "org.apache.maven:maven-settings-builder:3.9.2",
-                  "children": []
-                },
-                {
-                  "groupId": "org.apache.maven",
-                  "artifactId": "maven-builder-support",
-                  "version": "3.9.2",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "701d5793dcd28f09562744b4c3452f77ae94238424a07fb676cf76734deb13bf",
-                  "id": "org.apache.maven:maven-builder-support:3.9.2",
-                  "parent": "org.apache.maven:maven-settings-builder:3.9.2",
-                  "children": []
-                },
-                {
-                  "groupId": "org.apache.maven",
-                  "artifactId": "maven-settings",
-                  "version": "3.9.2",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "ffd180b75ce1050465b2904f5e79db2fcb8628017433afe3b389e32e51360322",
-                  "id": "org.apache.maven:maven-settings:3.9.2",
-                  "parent": "org.apache.maven:maven-settings-builder:3.9.2",
-                  "children": [
-                    {
-                      "groupId": "org.codehaus.plexus",
-                      "artifactId": "plexus-utils",
-                      "version": "3.5.1",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-                      "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-                      "parent": "org.apache.maven:maven-settings:3.9.2",
-                      "children": []
-                    }
-                  ]
-                },
-                {
-                  "groupId": "org.codehaus.plexus",
-                  "artifactId": "plexus-interpolation",
-                  "version": "1.26",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "b3b5412ce17889103ea564bcdfcf9fb3dfa540344ffeac6b538a73c9d7182662",
-                  "id": "org.codehaus.plexus:plexus-interpolation:1.26",
-                  "parent": "org.apache.maven:maven-settings-builder:3.9.2",
-                  "children": []
-                },
-                {
-                  "groupId": "org.codehaus.plexus",
-                  "artifactId": "plexus-sec-dispatcher",
-                  "version": "2.0",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "873139960c4c780176dda580b003a2c4bf82188bdce5bb99234e224ef7acfceb",
-                  "id": "org.codehaus.plexus:plexus-sec-dispatcher:2.0",
-                  "parent": "org.apache.maven:maven-settings-builder:3.9.2",
-                  "children": [
-                    {
-                      "groupId": "javax.inject",
-                      "artifactId": "javax.inject",
-                      "version": "1",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
-                      "id": "javax.inject:javax.inject:1",
-                      "parent": "org.codehaus.plexus:plexus-sec-dispatcher:2.0",
-                      "children": []
-                    },
-                    {
-                      "groupId": "org.codehaus.plexus",
-                      "artifactId": "plexus-cipher",
-                      "version": "2.0",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "9a7f1b5c5a9effd61eadfd8731452a2f76a8e79111fac391ef75ea801bea203a",
-                      "id": "org.codehaus.plexus:plexus-cipher:2.0",
-                      "parent": "org.codehaus.plexus:plexus-sec-dispatcher:2.0",
-                      "children": [
-                        {
-                          "groupId": "javax.inject",
-                          "artifactId": "javax.inject",
-                          "version": "1",
-                          "checksumAlgorithm": "SHA-256",
-                          "checksum": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
-                          "id": "javax.inject:javax.inject:1",
-                          "parent": "org.codehaus.plexus:plexus-cipher:2.0",
-                          "children": []
-                        }
-                      ]
-                    },
-                    {
-                      "groupId": "org.codehaus.plexus",
-                      "artifactId": "plexus-utils",
-                      "version": "3.4.1",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "52d85e04b3918722af11d12855b4a8257df96a0e76c8f4e3852e6faa851f357b",
-                      "id": "org.codehaus.plexus:plexus-utils:3.4.1",
-                      "parent": "org.codehaus.plexus:plexus-sec-dispatcher:2.0",
-                      "children": []
-                    }
-                  ]
-                },
-                {
-                  "groupId": "org.codehaus.plexus",
-                  "artifactId": "plexus-utils",
-                  "version": "3.5.1",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-                  "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-                  "parent": "org.apache.maven:maven-settings-builder:3.9.2",
-                  "children": []
-                }
-              ]
-            },
-            {
-              "groupId": "org.apache.maven.resolver",
-              "artifactId": "maven-resolver-api",
-              "version": "1.9.10",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "5ee57c89259d0a41f56291864ca7db12349ce11eca8ef62be5680c7c244705d0",
-              "id": "org.apache.maven.resolver:maven-resolver-api:1.9.10",
-              "parent": "org.apache.maven:maven-core:3.9.2",
-              "children": []
-            },
-            {
-              "groupId": "org.apache.maven.resolver",
-              "artifactId": "maven-resolver-impl",
-              "version": "1.9.10",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "6fc7cc06dd6364805e42b89dcaec2d0875ffb1fee8774938783918cb2020f2d8",
-              "id": "org.apache.maven.resolver:maven-resolver-impl:1.9.10",
-              "parent": "org.apache.maven:maven-core:3.9.2",
-              "children": [
-                {
-                  "groupId": "org.apache.maven.resolver",
-                  "artifactId": "maven-resolver-api",
-                  "version": "1.9.10",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "5ee57c89259d0a41f56291864ca7db12349ce11eca8ef62be5680c7c244705d0",
-                  "id": "org.apache.maven.resolver:maven-resolver-api:1.9.10",
-                  "parent": "org.apache.maven.resolver:maven-resolver-impl:1.9.10",
-                  "children": []
-                },
-                {
-                  "groupId": "org.apache.maven.resolver",
-                  "artifactId": "maven-resolver-named-locks",
-                  "version": "1.9.10",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "f55d2e75468509a92fc841d818283168ea458ebcb34a3011531cac812e309155",
-                  "id": "org.apache.maven.resolver:maven-resolver-named-locks:1.9.10",
-                  "parent": "org.apache.maven.resolver:maven-resolver-impl:1.9.10",
-                  "children": [
-                    {
-                      "groupId": "org.slf4j",
-                      "artifactId": "slf4j-api",
-                      "version": "1.7.36",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "d3ef575e3e4979678dc01bf1dcce51021493b4d11fb7f1be8ad982877c16a1c0",
-                      "id": "org.slf4j:slf4j-api:1.7.36",
-                      "parent": "org.apache.maven.resolver:maven-resolver-named-locks:1.9.10",
-                      "children": []
-                    }
-                  ]
-                },
-                {
-                  "groupId": "org.apache.maven.resolver",
-                  "artifactId": "maven-resolver-spi",
-                  "version": "1.9.10",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "7554650b663fef31c594c75f600b2241bbed9306d1ee5637047da55e9a443df3",
-                  "id": "org.apache.maven.resolver:maven-resolver-spi:1.9.10",
-                  "parent": "org.apache.maven.resolver:maven-resolver-impl:1.9.10",
-                  "children": [
-                    {
-                      "groupId": "org.apache.maven.resolver",
-                      "artifactId": "maven-resolver-api",
-                      "version": "1.9.10",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "5ee57c89259d0a41f56291864ca7db12349ce11eca8ef62be5680c7c244705d0",
-                      "id": "org.apache.maven.resolver:maven-resolver-api:1.9.10",
-                      "parent": "org.apache.maven.resolver:maven-resolver-spi:1.9.10",
-                      "children": []
-                    }
-                  ]
-                },
-                {
-                  "groupId": "org.apache.maven.resolver",
-                  "artifactId": "maven-resolver-util",
-                  "version": "1.9.10",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "c6eda39bd4b7670e7314ffa006e4dc9da48617e2a6ff26e5af118f0be6a0cdd4",
-                  "id": "org.apache.maven.resolver:maven-resolver-util:1.9.10",
-                  "parent": "org.apache.maven.resolver:maven-resolver-impl:1.9.10",
-                  "children": [
-                    {
-                      "groupId": "org.apache.maven.resolver",
-                      "artifactId": "maven-resolver-api",
-                      "version": "1.9.10",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "5ee57c89259d0a41f56291864ca7db12349ce11eca8ef62be5680c7c244705d0",
-                      "id": "org.apache.maven.resolver:maven-resolver-api:1.9.10",
-                      "parent": "org.apache.maven.resolver:maven-resolver-util:1.9.10",
-                      "children": []
-                    }
-                  ]
-                },
-                {
-                  "groupId": "org.slf4j",
-                  "artifactId": "slf4j-api",
-                  "version": "1.7.36",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "d3ef575e3e4979678dc01bf1dcce51021493b4d11fb7f1be8ad982877c16a1c0",
-                  "id": "org.slf4j:slf4j-api:1.7.36",
-                  "parent": "org.apache.maven.resolver:maven-resolver-impl:1.9.10",
-                  "children": []
-                }
-              ]
-            },
-            {
-              "groupId": "org.apache.maven.resolver",
-              "artifactId": "maven-resolver-spi",
-              "version": "1.9.10",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "7554650b663fef31c594c75f600b2241bbed9306d1ee5637047da55e9a443df3",
-              "id": "org.apache.maven.resolver:maven-resolver-spi:1.9.10",
-              "parent": "org.apache.maven:maven-core:3.9.2",
-              "children": [
-                {
-                  "groupId": "org.apache.maven.resolver",
-                  "artifactId": "maven-resolver-api",
-                  "version": "1.9.10",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "5ee57c89259d0a41f56291864ca7db12349ce11eca8ef62be5680c7c244705d0",
-                  "id": "org.apache.maven.resolver:maven-resolver-api:1.9.10",
-                  "parent": "org.apache.maven.resolver:maven-resolver-spi:1.9.10",
-                  "children": []
-                }
-              ]
-            },
-            {
-              "groupId": "org.apache.maven.resolver",
-              "artifactId": "maven-resolver-util",
-              "version": "1.9.10",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "c6eda39bd4b7670e7314ffa006e4dc9da48617e2a6ff26e5af118f0be6a0cdd4",
-              "id": "org.apache.maven.resolver:maven-resolver-util:1.9.10",
-              "parent": "org.apache.maven:maven-core:3.9.2",
-              "children": [
-                {
-                  "groupId": "org.apache.maven.resolver",
-                  "artifactId": "maven-resolver-api",
-                  "version": "1.9.10",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "5ee57c89259d0a41f56291864ca7db12349ce11eca8ef62be5680c7c244705d0",
-                  "id": "org.apache.maven.resolver:maven-resolver-api:1.9.10",
-                  "parent": "org.apache.maven.resolver:maven-resolver-util:1.9.10",
-                  "children": []
-                }
-              ]
-            },
-            {
-              "groupId": "org.apache.maven.shared",
-              "artifactId": "maven-shared-utils",
-              "version": "3.3.4",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "7925d9c5a0e2040d24b8fae3f612eb399cbffe5838b33ba368777dc7bddf6dda",
-              "id": "org.apache.maven.shared:maven-shared-utils:3.3.4",
-              "parent": "org.apache.maven:maven-core:3.9.2",
-              "children": []
-            },
-            {
-              "groupId": "org.codehaus.plexus",
-              "artifactId": "plexus-classworlds",
-              "version": "2.7.0",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "c60ae538ba66adbc06aae205fbe2306211d3d213ab6df3239ec03cdde2458ad6",
-              "id": "org.codehaus.plexus:plexus-classworlds:2.7.0",
-              "parent": "org.apache.maven:maven-core:3.9.2",
-              "children": []
-            },
-            {
-              "groupId": "org.codehaus.plexus",
-              "artifactId": "plexus-component-annotations",
-              "version": "2.1.0",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "bde3617ce9b5bcf9584126046080043af6a4b3baea40a3b153f02e7bbc32acac",
-              "id": "org.codehaus.plexus:plexus-component-annotations:2.1.0",
-              "parent": "org.apache.maven:maven-core:3.9.2",
-              "children": []
-            },
-            {
-              "groupId": "org.codehaus.plexus",
-              "artifactId": "plexus-interpolation",
-              "version": "1.26",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "b3b5412ce17889103ea564bcdfcf9fb3dfa540344ffeac6b538a73c9d7182662",
-              "id": "org.codehaus.plexus:plexus-interpolation:1.26",
-              "parent": "org.apache.maven:maven-core:3.9.2",
-              "children": []
-            },
-            {
-              "groupId": "org.codehaus.plexus",
-              "artifactId": "plexus-utils",
-              "version": "3.5.1",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-              "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-              "parent": "org.apache.maven:maven-core:3.9.2",
-              "children": []
-            },
-            {
-              "groupId": "org.eclipse.sisu",
-              "artifactId": "org.eclipse.sisu.inject",
-              "version": "0.3.5",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "c5994010bcdce1d2bd603a4d50c47191ddbd7875d1157b23aaa26d33c82fda13",
-              "id": "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.5",
-              "parent": "org.apache.maven:maven-core:3.9.2",
-              "children": []
-            },
-            {
-              "groupId": "org.eclipse.sisu",
-              "artifactId": "org.eclipse.sisu.plexus",
-              "version": "0.3.5",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "7e4c61096d70826f20f7a7d55c59a5528e7aa5ad247ee2dfe544e4dd25f6a784",
-              "id": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5",
-              "parent": "org.apache.maven:maven-core:3.9.2",
-              "children": [
-                {
-                  "groupId": "javax.annotation",
-                  "artifactId": "javax.annotation-api",
-                  "version": "1.2",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "5909b396ca3a2be10d0eea32c74ef78d816e1b4ead21de1d78de1f890d033e04",
-                  "id": "javax.annotation:javax.annotation-api:1.2",
-                  "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5",
-                  "children": []
-                },
-                {
-                  "groupId": "org.codehaus.plexus",
-                  "artifactId": "plexus-classworlds",
-                  "version": "2.5.2",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "b2931d41740490a8d931cbe0cfe9ac20deb66cca606e679f52522f7f534c9fd7",
-                  "id": "org.codehaus.plexus:plexus-classworlds:2.5.2",
-                  "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5",
-                  "children": []
-                },
-                {
-                  "groupId": "org.codehaus.plexus",
-                  "artifactId": "plexus-component-annotations",
-                  "version": "1.5.5",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "4df7a6a7be64b35bbccf60b5c115697f9ea3421d22674ae67135dde375fcca1f",
-                  "id": "org.codehaus.plexus:plexus-component-annotations:1.5.5",
-                  "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5",
-                  "children": []
-                },
-                {
-                  "groupId": "org.codehaus.plexus",
-                  "artifactId": "plexus-utils",
-                  "version": "3.0.24",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "83ee748b12d06afb0ad4050a591132b3e8025fbb1990f1ed002e8b73293e69b4",
-                  "id": "org.codehaus.plexus:plexus-utils:3.0.24",
-                  "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5",
-                  "children": []
-                },
-                {
-                  "groupId": "org.eclipse.sisu",
-                  "artifactId": "org.eclipse.sisu.inject",
-                  "version": "0.3.5",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "c5994010bcdce1d2bd603a4d50c47191ddbd7875d1157b23aaa26d33c82fda13",
-                  "id": "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.5",
-                  "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5",
-                  "children": []
-                }
-              ]
-            },
-            {
-              "groupId": "org.slf4j",
-              "artifactId": "slf4j-api",
-              "version": "1.7.36",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "d3ef575e3e4979678dc01bf1dcce51021493b4d11fb7f1be8ad982877c16a1c0",
-              "id": "org.slf4j:slf4j-api:1.7.36",
-              "parent": "org.apache.maven:maven-core:3.9.2",
-              "children": []
-            }
-          ]
+          "children": []
         },
         {
           "groupId": "org.apache.maven",
@@ -1540,18 +282,7 @@
           "checksum": "c91583df8b399df87033dbb4c5efe55a0cf6f659da21714c3b0f6f5f9689e28",
           "id": "org.apache.maven:maven-model:3.9.2",
           "parent": "org.apache.maven:maven-compat:3.9.2",
-          "children": [
-            {
-              "groupId": "org.codehaus.plexus",
-              "artifactId": "plexus-utils",
-              "version": "3.5.1",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-              "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-              "parent": "org.apache.maven:maven-model:3.9.2",
-              "children": []
-            }
-          ]
+          "children": []
         },
         {
           "groupId": "org.apache.maven",
@@ -1561,110 +292,7 @@
           "checksum": "1649e8b21eb17ceb528fa0830211482ee229bac177bff309824baaf25c2ad142",
           "id": "org.apache.maven:maven-model-builder:3.9.2",
           "parent": "org.apache.maven:maven-compat:3.9.2",
-          "children": [
-            {
-              "groupId": "javax.inject",
-              "artifactId": "javax.inject",
-              "version": "1",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
-              "id": "javax.inject:javax.inject:1",
-              "parent": "org.apache.maven:maven-model-builder:3.9.2",
-              "children": []
-            },
-            {
-              "groupId": "org.apache.maven",
-              "artifactId": "maven-artifact",
-              "version": "3.9.2",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "f2174221d412a79572817b5aa77125348f43266670b6329a9881cdccf7bbc4b1",
-              "id": "org.apache.maven:maven-artifact:3.9.2",
-              "parent": "org.apache.maven:maven-model-builder:3.9.2",
-              "children": [
-                {
-                  "groupId": "org.apache.commons",
-                  "artifactId": "commons-lang3",
-                  "version": "3.12.0",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "d919d904486c037f8d193412da0c92e22a9fa24230b9d67a57855c5c31c7e94e",
-                  "id": "org.apache.commons:commons-lang3:3.12.0",
-                  "parent": "org.apache.maven:maven-artifact:3.9.2",
-                  "children": []
-                },
-                {
-                  "groupId": "org.codehaus.plexus",
-                  "artifactId": "plexus-utils",
-                  "version": "3.5.1",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-                  "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-                  "parent": "org.apache.maven:maven-artifact:3.9.2",
-                  "children": []
-                }
-              ]
-            },
-            {
-              "groupId": "org.apache.maven",
-              "artifactId": "maven-builder-support",
-              "version": "3.9.2",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "701d5793dcd28f09562744b4c3452f77ae94238424a07fb676cf76734deb13bf",
-              "id": "org.apache.maven:maven-builder-support:3.9.2",
-              "parent": "org.apache.maven:maven-model-builder:3.9.2",
-              "children": []
-            },
-            {
-              "groupId": "org.apache.maven",
-              "artifactId": "maven-model",
-              "version": "3.9.2",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "c91583df8b399df87033dbb4c5efe55a0cf6f659da21714c3b0f6f5f9689e28",
-              "id": "org.apache.maven:maven-model:3.9.2",
-              "parent": "org.apache.maven:maven-model-builder:3.9.2",
-              "children": [
-                {
-                  "groupId": "org.codehaus.plexus",
-                  "artifactId": "plexus-utils",
-                  "version": "3.5.1",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-                  "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-                  "parent": "org.apache.maven:maven-model:3.9.2",
-                  "children": []
-                }
-              ]
-            },
-            {
-              "groupId": "org.codehaus.plexus",
-              "artifactId": "plexus-interpolation",
-              "version": "1.26",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "b3b5412ce17889103ea564bcdfcf9fb3dfa540344ffeac6b538a73c9d7182662",
-              "id": "org.codehaus.plexus:plexus-interpolation:1.26",
-              "parent": "org.apache.maven:maven-model-builder:3.9.2",
-              "children": []
-            },
-            {
-              "groupId": "org.codehaus.plexus",
-              "artifactId": "plexus-utils",
-              "version": "3.5.1",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-              "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-              "parent": "org.apache.maven:maven-model-builder:3.9.2",
-              "children": []
-            },
-            {
-              "groupId": "org.eclipse.sisu",
-              "artifactId": "org.eclipse.sisu.inject",
-              "version": "0.3.5",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "c5994010bcdce1d2bd603a4d50c47191ddbd7875d1157b23aaa26d33c82fda13",
-              "id": "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.5",
-              "parent": "org.apache.maven:maven-model-builder:3.9.2",
-              "children": []
-            }
-          ]
+          "children": []
         },
         {
           "groupId": "org.apache.maven",
@@ -1674,18 +302,7 @@
           "checksum": "2ab4ad3dd4cf1052747344ebcfa89addfd75f1067d893f8721a22430fb360e8a",
           "id": "org.apache.maven:maven-repository-metadata:3.9.2",
           "parent": "org.apache.maven:maven-compat:3.9.2",
-          "children": [
-            {
-              "groupId": "org.codehaus.plexus",
-              "artifactId": "plexus-utils",
-              "version": "3.5.1",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-              "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-              "parent": "org.apache.maven:maven-repository-metadata:3.9.2",
-              "children": []
-            }
-          ]
+          "children": []
         },
         {
           "groupId": "org.apache.maven",
@@ -1714,18 +331,7 @@
               "checksum": "c91583df8b399df87033dbb4c5efe55a0cf6f659da21714c3b0f6f5f9689e28",
               "id": "org.apache.maven:maven-model:3.9.2",
               "parent": "org.apache.maven:maven-resolver-provider:3.9.2",
-              "children": [
-                {
-                  "groupId": "org.codehaus.plexus",
-                  "artifactId": "plexus-utils",
-                  "version": "3.5.1",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-                  "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-                  "parent": "org.apache.maven:maven-model:3.9.2",
-                  "children": []
-                }
-              ]
+              "children": []
             },
             {
               "groupId": "org.apache.maven",
@@ -1735,110 +341,7 @@
               "checksum": "1649e8b21eb17ceb528fa0830211482ee229bac177bff309824baaf25c2ad142",
               "id": "org.apache.maven:maven-model-builder:3.9.2",
               "parent": "org.apache.maven:maven-resolver-provider:3.9.2",
-              "children": [
-                {
-                  "groupId": "javax.inject",
-                  "artifactId": "javax.inject",
-                  "version": "1",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
-                  "id": "javax.inject:javax.inject:1",
-                  "parent": "org.apache.maven:maven-model-builder:3.9.2",
-                  "children": []
-                },
-                {
-                  "groupId": "org.apache.maven",
-                  "artifactId": "maven-artifact",
-                  "version": "3.9.2",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "f2174221d412a79572817b5aa77125348f43266670b6329a9881cdccf7bbc4b1",
-                  "id": "org.apache.maven:maven-artifact:3.9.2",
-                  "parent": "org.apache.maven:maven-model-builder:3.9.2",
-                  "children": [
-                    {
-                      "groupId": "org.apache.commons",
-                      "artifactId": "commons-lang3",
-                      "version": "3.12.0",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "d919d904486c037f8d193412da0c92e22a9fa24230b9d67a57855c5c31c7e94e",
-                      "id": "org.apache.commons:commons-lang3:3.12.0",
-                      "parent": "org.apache.maven:maven-artifact:3.9.2",
-                      "children": []
-                    },
-                    {
-                      "groupId": "org.codehaus.plexus",
-                      "artifactId": "plexus-utils",
-                      "version": "3.5.1",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-                      "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-                      "parent": "org.apache.maven:maven-artifact:3.9.2",
-                      "children": []
-                    }
-                  ]
-                },
-                {
-                  "groupId": "org.apache.maven",
-                  "artifactId": "maven-builder-support",
-                  "version": "3.9.2",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "701d5793dcd28f09562744b4c3452f77ae94238424a07fb676cf76734deb13bf",
-                  "id": "org.apache.maven:maven-builder-support:3.9.2",
-                  "parent": "org.apache.maven:maven-model-builder:3.9.2",
-                  "children": []
-                },
-                {
-                  "groupId": "org.apache.maven",
-                  "artifactId": "maven-model",
-                  "version": "3.9.2",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "c91583df8b399df87033dbb4c5efe55a0cf6f659da21714c3b0f6f5f9689e28",
-                  "id": "org.apache.maven:maven-model:3.9.2",
-                  "parent": "org.apache.maven:maven-model-builder:3.9.2",
-                  "children": [
-                    {
-                      "groupId": "org.codehaus.plexus",
-                      "artifactId": "plexus-utils",
-                      "version": "3.5.1",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-                      "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-                      "parent": "org.apache.maven:maven-model:3.9.2",
-                      "children": []
-                    }
-                  ]
-                },
-                {
-                  "groupId": "org.codehaus.plexus",
-                  "artifactId": "plexus-interpolation",
-                  "version": "1.26",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "b3b5412ce17889103ea564bcdfcf9fb3dfa540344ffeac6b538a73c9d7182662",
-                  "id": "org.codehaus.plexus:plexus-interpolation:1.26",
-                  "parent": "org.apache.maven:maven-model-builder:3.9.2",
-                  "children": []
-                },
-                {
-                  "groupId": "org.codehaus.plexus",
-                  "artifactId": "plexus-utils",
-                  "version": "3.5.1",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-                  "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-                  "parent": "org.apache.maven:maven-model-builder:3.9.2",
-                  "children": []
-                },
-                {
-                  "groupId": "org.eclipse.sisu",
-                  "artifactId": "org.eclipse.sisu.inject",
-                  "version": "0.3.5",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "c5994010bcdce1d2bd603a4d50c47191ddbd7875d1157b23aaa26d33c82fda13",
-                  "id": "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.5",
-                  "parent": "org.apache.maven:maven-model-builder:3.9.2",
-                  "children": []
-                }
-              ]
+              "children": []
             },
             {
               "groupId": "org.apache.maven",
@@ -1848,18 +351,7 @@
               "checksum": "2ab4ad3dd4cf1052747344ebcfa89addfd75f1067d893f8721a22430fb360e8a",
               "id": "org.apache.maven:maven-repository-metadata:3.9.2",
               "parent": "org.apache.maven:maven-resolver-provider:3.9.2",
-              "children": [
-                {
-                  "groupId": "org.codehaus.plexus",
-                  "artifactId": "plexus-utils",
-                  "version": "3.5.1",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-                  "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-                  "parent": "org.apache.maven:maven-repository-metadata:3.9.2",
-                  "children": []
-                }
-              ]
+              "children": []
             },
             {
               "groupId": "org.apache.maven.resolver",
@@ -2027,18 +519,7 @@
           "checksum": "ffd180b75ce1050465b2904f5e79db2fcb8628017433afe3b389e32e51360322",
           "id": "org.apache.maven:maven-settings:3.9.2",
           "parent": "org.apache.maven:maven-compat:3.9.2",
-          "children": [
-            {
-              "groupId": "org.codehaus.plexus",
-              "artifactId": "plexus-utils",
-              "version": "3.5.1",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-              "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-              "parent": "org.apache.maven:maven-settings:3.9.2",
-              "children": []
-            }
-          ]
+          "children": []
         },
         {
           "groupId": "org.apache.maven",
@@ -2048,121 +529,7 @@
           "checksum": "936ee7c856e72557d6280a7cf96c2f76eea570e29b11ee0d0057d89722513ed7",
           "id": "org.apache.maven:maven-settings-builder:3.9.2",
           "parent": "org.apache.maven:maven-compat:3.9.2",
-          "children": [
-            {
-              "groupId": "javax.inject",
-              "artifactId": "javax.inject",
-              "version": "1",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
-              "id": "javax.inject:javax.inject:1",
-              "parent": "org.apache.maven:maven-settings-builder:3.9.2",
-              "children": []
-            },
-            {
-              "groupId": "org.apache.maven",
-              "artifactId": "maven-builder-support",
-              "version": "3.9.2",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "701d5793dcd28f09562744b4c3452f77ae94238424a07fb676cf76734deb13bf",
-              "id": "org.apache.maven:maven-builder-support:3.9.2",
-              "parent": "org.apache.maven:maven-settings-builder:3.9.2",
-              "children": []
-            },
-            {
-              "groupId": "org.apache.maven",
-              "artifactId": "maven-settings",
-              "version": "3.9.2",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "ffd180b75ce1050465b2904f5e79db2fcb8628017433afe3b389e32e51360322",
-              "id": "org.apache.maven:maven-settings:3.9.2",
-              "parent": "org.apache.maven:maven-settings-builder:3.9.2",
-              "children": [
-                {
-                  "groupId": "org.codehaus.plexus",
-                  "artifactId": "plexus-utils",
-                  "version": "3.5.1",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-                  "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-                  "parent": "org.apache.maven:maven-settings:3.9.2",
-                  "children": []
-                }
-              ]
-            },
-            {
-              "groupId": "org.codehaus.plexus",
-              "artifactId": "plexus-interpolation",
-              "version": "1.26",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "b3b5412ce17889103ea564bcdfcf9fb3dfa540344ffeac6b538a73c9d7182662",
-              "id": "org.codehaus.plexus:plexus-interpolation:1.26",
-              "parent": "org.apache.maven:maven-settings-builder:3.9.2",
-              "children": []
-            },
-            {
-              "groupId": "org.codehaus.plexus",
-              "artifactId": "plexus-sec-dispatcher",
-              "version": "2.0",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "873139960c4c780176dda580b003a2c4bf82188bdce5bb99234e224ef7acfceb",
-              "id": "org.codehaus.plexus:plexus-sec-dispatcher:2.0",
-              "parent": "org.apache.maven:maven-settings-builder:3.9.2",
-              "children": [
-                {
-                  "groupId": "javax.inject",
-                  "artifactId": "javax.inject",
-                  "version": "1",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
-                  "id": "javax.inject:javax.inject:1",
-                  "parent": "org.codehaus.plexus:plexus-sec-dispatcher:2.0",
-                  "children": []
-                },
-                {
-                  "groupId": "org.codehaus.plexus",
-                  "artifactId": "plexus-cipher",
-                  "version": "2.0",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "9a7f1b5c5a9effd61eadfd8731452a2f76a8e79111fac391ef75ea801bea203a",
-                  "id": "org.codehaus.plexus:plexus-cipher:2.0",
-                  "parent": "org.codehaus.plexus:plexus-sec-dispatcher:2.0",
-                  "children": [
-                    {
-                      "groupId": "javax.inject",
-                      "artifactId": "javax.inject",
-                      "version": "1",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
-                      "id": "javax.inject:javax.inject:1",
-                      "parent": "org.codehaus.plexus:plexus-cipher:2.0",
-                      "children": []
-                    }
-                  ]
-                },
-                {
-                  "groupId": "org.codehaus.plexus",
-                  "artifactId": "plexus-utils",
-                  "version": "3.4.1",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "52d85e04b3918722af11d12855b4a8257df96a0e76c8f4e3852e6faa851f357b",
-                  "id": "org.codehaus.plexus:plexus-utils:3.4.1",
-                  "parent": "org.codehaus.plexus:plexus-sec-dispatcher:2.0",
-                  "children": []
-                }
-              ]
-            },
-            {
-              "groupId": "org.codehaus.plexus",
-              "artifactId": "plexus-utils",
-              "version": "3.5.1",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-              "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-              "parent": "org.apache.maven:maven-settings-builder:3.9.2",
-              "children": []
-            }
-          ]
+          "children": []
         },
         {
           "groupId": "org.apache.maven.resolver",
@@ -2348,26 +715,130 @@
           "checksum": "7e4c61096d70826f20f7a7d55c59a5528e7aa5ad247ee2dfe544e4dd25f6a784",
           "id": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5",
           "parent": "org.apache.maven:maven-compat:3.9.2",
+          "children": []
+        }
+      ]
+    },
+    {
+      "groupId": "org.apache.maven",
+      "artifactId": "maven-core",
+      "version": "3.2.5",
+      "checksumAlgorithm": "SHA-256",
+      "checksum": "4f1a0af8997e1daf778b91c5ae9e973f92df699439d909fdec7fc6055c09de12",
+      "id": "org.apache.maven:maven-core:3.2.5",
+      "children": [
+        {
+          "groupId": "org.apache.maven",
+          "artifactId": "maven-aether-provider",
+          "version": "3.2.5",
+          "checksumAlgorithm": "SHA-256",
+          "checksum": "703944b922d5351aad53b842f7dd38439b7213425f13c6c7f034b8b699b7d578",
+          "id": "org.apache.maven:maven-aether-provider:3.2.5",
+          "parent": "org.apache.maven:maven-core:3.2.5",
           "children": [
             {
-              "groupId": "javax.annotation",
-              "artifactId": "javax.annotation-api",
-              "version": "1.2",
+              "groupId": "org.apache.maven",
+              "artifactId": "maven-model",
+              "version": "3.2.5",
               "checksumAlgorithm": "SHA-256",
-              "checksum": "5909b396ca3a2be10d0eea32c74ef78d816e1b4ead21de1d78de1f890d033e04",
-              "id": "javax.annotation:javax.annotation-api:1.2",
-              "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5",
-              "children": []
+              "checksum": "8d439cc1661349dab1c69eed0f831336d187e162cc6d68aa4deefcff57ee0624",
+              "id": "org.apache.maven:maven-model:3.2.5",
+              "parent": "org.apache.maven:maven-aether-provider:3.2.5",
+              "children": [
+                {
+                  "groupId": "org.codehaus.plexus",
+                  "artifactId": "plexus-utils",
+                  "version": "3.0.20",
+                  "checksumAlgorithm": "SHA-256",
+                  "checksum": "8f3a655545fc5b4cbf12b5eb8a154fccb0c1144423a1450511f44005a3d574a2",
+                  "id": "org.codehaus.plexus:plexus-utils:3.0.20",
+                  "parent": "org.apache.maven:maven-model:3.2.5",
+                  "children": []
+                }
+              ]
             },
             {
-              "groupId": "org.codehaus.plexus",
-              "artifactId": "plexus-classworlds",
-              "version": "2.5.2",
+              "groupId": "org.apache.maven",
+              "artifactId": "maven-model-builder",
+              "version": "3.2.5",
               "checksumAlgorithm": "SHA-256",
-              "checksum": "b2931d41740490a8d931cbe0cfe9ac20deb66cca606e679f52522f7f534c9fd7",
-              "id": "org.codehaus.plexus:plexus-classworlds:2.5.2",
-              "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5",
-              "children": []
+              "checksum": "cc5321269d080ad6694458f53186be5391a21c488ab3a7d6dd73123c7681879d",
+              "id": "org.apache.maven:maven-model-builder:3.2.5",
+              "parent": "org.apache.maven:maven-aether-provider:3.2.5",
+              "children": [
+                {
+                  "groupId": "org.apache.maven",
+                  "artifactId": "maven-model",
+                  "version": "3.2.5",
+                  "checksumAlgorithm": "SHA-256",
+                  "checksum": "8d439cc1661349dab1c69eed0f831336d187e162cc6d68aa4deefcff57ee0624",
+                  "id": "org.apache.maven:maven-model:3.2.5",
+                  "parent": "org.apache.maven:maven-model-builder:3.2.5",
+                  "children": [
+                    {
+                      "groupId": "org.codehaus.plexus",
+                      "artifactId": "plexus-utils",
+                      "version": "3.0.20",
+                      "checksumAlgorithm": "SHA-256",
+                      "checksum": "8f3a655545fc5b4cbf12b5eb8a154fccb0c1144423a1450511f44005a3d574a2",
+                      "id": "org.codehaus.plexus:plexus-utils:3.0.20",
+                      "parent": "org.apache.maven:maven-model:3.2.5",
+                      "children": []
+                    }
+                  ]
+                },
+                {
+                  "groupId": "org.codehaus.plexus",
+                  "artifactId": "plexus-component-annotations",
+                  "version": "1.5.5",
+                  "checksumAlgorithm": "SHA-256",
+                  "checksum": "4df7a6a7be64b35bbccf60b5c115697f9ea3421d22674ae67135dde375fcca1f",
+                  "id": "org.codehaus.plexus:plexus-component-annotations:1.5.5",
+                  "parent": "org.apache.maven:maven-model-builder:3.2.5",
+                  "children": []
+                },
+                {
+                  "groupId": "org.codehaus.plexus",
+                  "artifactId": "plexus-interpolation",
+                  "version": "1.21",
+                  "checksumAlgorithm": "SHA-256",
+                  "checksum": "aba7980581027ad5fc74a27ee4d64aad74932fdb32694967242d03fc50290d1f",
+                  "id": "org.codehaus.plexus:plexus-interpolation:1.21",
+                  "parent": "org.apache.maven:maven-model-builder:3.2.5",
+                  "children": []
+                },
+                {
+                  "groupId": "org.codehaus.plexus",
+                  "artifactId": "plexus-utils",
+                  "version": "3.0.20",
+                  "checksumAlgorithm": "SHA-256",
+                  "checksum": "8f3a655545fc5b4cbf12b5eb8a154fccb0c1144423a1450511f44005a3d574a2",
+                  "id": "org.codehaus.plexus:plexus-utils:3.0.20",
+                  "parent": "org.apache.maven:maven-model-builder:3.2.5",
+                  "children": []
+                }
+              ]
+            },
+            {
+              "groupId": "org.apache.maven",
+              "artifactId": "maven-repository-metadata",
+              "version": "3.2.5",
+              "checksumAlgorithm": "SHA-256",
+              "checksum": "62b517b77f24edebdee0e382ecddb44bb6632b7c08c528d625aed7d2980df12b",
+              "id": "org.apache.maven:maven-repository-metadata:3.2.5",
+              "parent": "org.apache.maven:maven-aether-provider:3.2.5",
+              "children": [
+                {
+                  "groupId": "org.codehaus.plexus",
+                  "artifactId": "plexus-utils",
+                  "version": "3.0.20",
+                  "checksumAlgorithm": "SHA-256",
+                  "checksum": "8f3a655545fc5b4cbf12b5eb8a154fccb0c1144423a1450511f44005a3d574a2",
+                  "id": "org.codehaus.plexus:plexus-utils:3.0.20",
+                  "parent": "org.apache.maven:maven-repository-metadata:3.2.5",
+                  "children": []
+                }
+              ]
             },
             {
               "groupId": "org.codehaus.plexus",
@@ -2376,231 +847,174 @@
               "checksumAlgorithm": "SHA-256",
               "checksum": "4df7a6a7be64b35bbccf60b5c115697f9ea3421d22674ae67135dde375fcca1f",
               "id": "org.codehaus.plexus:plexus-component-annotations:1.5.5",
-              "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5",
+              "parent": "org.apache.maven:maven-aether-provider:3.2.5",
               "children": []
             },
             {
               "groupId": "org.codehaus.plexus",
               "artifactId": "plexus-utils",
-              "version": "3.0.24",
+              "version": "3.0.20",
               "checksumAlgorithm": "SHA-256",
-              "checksum": "83ee748b12d06afb0ad4050a591132b3e8025fbb1990f1ed002e8b73293e69b4",
-              "id": "org.codehaus.plexus:plexus-utils:3.0.24",
-              "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5",
+              "checksum": "8f3a655545fc5b4cbf12b5eb8a154fccb0c1144423a1450511f44005a3d574a2",
+              "id": "org.codehaus.plexus:plexus-utils:3.0.20",
+              "parent": "org.apache.maven:maven-aether-provider:3.2.5",
               "children": []
             },
             {
-              "groupId": "org.eclipse.sisu",
-              "artifactId": "org.eclipse.sisu.inject",
-              "version": "0.3.5",
+              "groupId": "org.eclipse.aether",
+              "artifactId": "aether-api",
+              "version": "1.0.0.v20140518",
               "checksumAlgorithm": "SHA-256",
-              "checksum": "c5994010bcdce1d2bd603a4d50c47191ddbd7875d1157b23aaa26d33c82fda13",
-              "id": "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.5",
-              "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5",
-              "children": []
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "groupId": "org.apache.maven",
-      "artifactId": "maven-core",
-      "version": "3.9.2",
-      "checksumAlgorithm": "SHA-256",
-      "checksum": "5d544e975d9ca300f779f42b476d32032410c5a1c5e968b9b2140a702fa9e6f7",
-      "id": "org.apache.maven:maven-core:3.9.2",
-      "children": [
-        {
-          "groupId": "com.google.guava",
-          "artifactId": "failureaccess",
-          "version": "1.0.1",
-          "checksumAlgorithm": "SHA-256",
-          "checksum": "a171ee4c734dd2da837e4b16be9df4661afab72a41adaf31eb84dfdaf936ca26",
-          "id": "com.google.guava:failureaccess:1.0.1",
-          "parent": "org.apache.maven:maven-core:3.9.2",
-          "children": []
-        },
-        {
-          "groupId": "com.google.guava",
-          "artifactId": "guava",
-          "version": "31.1-jre",
-          "checksumAlgorithm": "SHA-256",
-          "checksum": "a42edc9cab792e39fe39bb94f3fca655ed157ff87a8af78e1d6ba5b07c4a00ab",
-          "id": "com.google.guava:guava:31.1-jre",
-          "parent": "org.apache.maven:maven-core:3.9.2",
-          "children": [
-            {
-              "groupId": "com.google.code.findbugs",
-              "artifactId": "jsr305",
-              "version": "3.0.2",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
-              "id": "com.google.code.findbugs:jsr305:3.0.2",
-              "parent": "com.google.guava:guava:31.1-jre",
+              "checksum": "84b98521684ab22f9528470fa6d8ab68a230e1b211623c989ba7016c306eb773",
+              "id": "org.eclipse.aether:aether-api:1.0.0.v20140518",
+              "parent": "org.apache.maven:maven-aether-provider:3.2.5",
               "children": []
             },
             {
-              "groupId": "com.google.errorprone",
-              "artifactId": "error_prone_annotations",
-              "version": "2.11.0",
+              "groupId": "org.eclipse.aether",
+              "artifactId": "aether-impl",
+              "version": "1.0.0.v20140518",
               "checksumAlgorithm": "SHA-256",
-              "checksum": "721cb91842b46fa056847d104d5225c8b8e1e8b62263b993051e1e5a0137b7ec",
-              "id": "com.google.errorprone:error_prone_annotations:2.11.0",
-              "parent": "com.google.guava:guava:31.1-jre",
-              "children": []
+              "checksum": "9a9b60e685385225f08e662cb9f60d96610b0987f0f47bbf3f0c92df8a897d00",
+              "id": "org.eclipse.aether:aether-impl:1.0.0.v20140518",
+              "parent": "org.apache.maven:maven-aether-provider:3.2.5",
+              "children": [
+                {
+                  "groupId": "org.eclipse.aether",
+                  "artifactId": "aether-api",
+                  "version": "1.0.0.v20140518",
+                  "checksumAlgorithm": "SHA-256",
+                  "checksum": "84b98521684ab22f9528470fa6d8ab68a230e1b211623c989ba7016c306eb773",
+                  "id": "org.eclipse.aether:aether-api:1.0.0.v20140518",
+                  "parent": "org.eclipse.aether:aether-impl:1.0.0.v20140518",
+                  "children": []
+                },
+                {
+                  "groupId": "org.eclipse.aether",
+                  "artifactId": "aether-spi",
+                  "version": "1.0.0.v20140518",
+                  "checksumAlgorithm": "SHA-256",
+                  "checksum": "a3266d127a4e9f4aa9c4fa0986e31eec784e866f79112e1840d1667e17c10fb2",
+                  "id": "org.eclipse.aether:aether-spi:1.0.0.v20140518",
+                  "parent": "org.eclipse.aether:aether-impl:1.0.0.v20140518",
+                  "children": [
+                    {
+                      "groupId": "org.eclipse.aether",
+                      "artifactId": "aether-api",
+                      "version": "1.0.0.v20140518",
+                      "checksumAlgorithm": "SHA-256",
+                      "checksum": "84b98521684ab22f9528470fa6d8ab68a230e1b211623c989ba7016c306eb773",
+                      "id": "org.eclipse.aether:aether-api:1.0.0.v20140518",
+                      "parent": "org.eclipse.aether:aether-spi:1.0.0.v20140518",
+                      "children": []
+                    }
+                  ]
+                },
+                {
+                  "groupId": "org.eclipse.aether",
+                  "artifactId": "aether-util",
+                  "version": "1.0.0.v20140518",
+                  "checksumAlgorithm": "SHA-256",
+                  "checksum": "aff0951639837c4e3a4699a421fa79f410032f603f5c6a5bba435e98531f3984",
+                  "id": "org.eclipse.aether:aether-util:1.0.0.v20140518",
+                  "parent": "org.eclipse.aether:aether-impl:1.0.0.v20140518",
+                  "children": [
+                    {
+                      "groupId": "org.eclipse.aether",
+                      "artifactId": "aether-api",
+                      "version": "1.0.0.v20140518",
+                      "checksumAlgorithm": "SHA-256",
+                      "checksum": "84b98521684ab22f9528470fa6d8ab68a230e1b211623c989ba7016c306eb773",
+                      "id": "org.eclipse.aether:aether-api:1.0.0.v20140518",
+                      "parent": "org.eclipse.aether:aether-util:1.0.0.v20140518",
+                      "children": []
+                    }
+                  ]
+                }
+              ]
             },
             {
-              "groupId": "com.google.guava",
-              "artifactId": "failureaccess",
-              "version": "1.0.1",
+              "groupId": "org.eclipse.aether",
+              "artifactId": "aether-spi",
+              "version": "1.0.0.v20140518",
               "checksumAlgorithm": "SHA-256",
-              "checksum": "a171ee4c734dd2da837e4b16be9df4661afab72a41adaf31eb84dfdaf936ca26",
-              "id": "com.google.guava:failureaccess:1.0.1",
-              "parent": "com.google.guava:guava:31.1-jre",
-              "children": []
+              "checksum": "a3266d127a4e9f4aa9c4fa0986e31eec784e866f79112e1840d1667e17c10fb2",
+              "id": "org.eclipse.aether:aether-spi:1.0.0.v20140518",
+              "parent": "org.apache.maven:maven-aether-provider:3.2.5",
+              "children": [
+                {
+                  "groupId": "org.eclipse.aether",
+                  "artifactId": "aether-api",
+                  "version": "1.0.0.v20140518",
+                  "checksumAlgorithm": "SHA-256",
+                  "checksum": "84b98521684ab22f9528470fa6d8ab68a230e1b211623c989ba7016c306eb773",
+                  "id": "org.eclipse.aether:aether-api:1.0.0.v20140518",
+                  "parent": "org.eclipse.aether:aether-spi:1.0.0.v20140518",
+                  "children": []
+                }
+              ]
             },
             {
-              "groupId": "com.google.guava",
-              "artifactId": "listenablefuture",
-              "version": "9999.0-empty-to-avoid-conflict-with-guava",
+              "groupId": "org.eclipse.aether",
+              "artifactId": "aether-util",
+              "version": "1.0.0.v20140518",
               "checksumAlgorithm": "SHA-256",
-              "checksum": "b372a037d4230aa57fbeffdef30fd6123f9c0c2db85d0aced00c91b974f33f99",
-              "id": "com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava",
-              "parent": "com.google.guava:guava:31.1-jre",
-              "children": []
-            },
-            {
-              "groupId": "com.google.j2objc",
-              "artifactId": "j2objc-annotations",
-              "version": "1.3",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "21af30c92267bd6122c0e0b4d20cccb6641a37eaf956c6540ec471d584e64a7b",
-              "id": "com.google.j2objc:j2objc-annotations:1.3",
-              "parent": "com.google.guava:guava:31.1-jre",
-              "children": []
-            },
-            {
-              "groupId": "org.checkerframework",
-              "artifactId": "checker-qual",
-              "version": "3.12.0",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "ff10785ac2a357ec5de9c293cb982a2cbb605c0309ea4cc1cb9b9bc6dbe7f3cb",
-              "id": "org.checkerframework:checker-qual:3.12.0",
-              "parent": "com.google.guava:guava:31.1-jre",
-              "children": []
-            }
-          ]
-        },
-        {
-          "groupId": "com.google.inject",
-          "artifactId": "guice",
-          "version": "5.1.0",
-          "checksumAlgorithm": "SHA-256",
-          "checksum": "4130e50bfac48099c860f0d903b91860c81a249c90f38245f8fed58fc817bc26",
-          "id": "com.google.inject:guice:5.1.0",
-          "parent": "org.apache.maven:maven-core:3.9.2",
-          "children": [
-            {
-              "groupId": "aopalliance",
-              "artifactId": "aopalliance",
-              "version": "1.0",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "addec670fedcd3f113c5c8091d783280d23f75e3acb841b61a9cdb079376a08",
-              "id": "aopalliance:aopalliance:1.0",
-              "parent": "com.google.inject:guice:5.1.0",
-              "children": []
-            },
-            {
-              "groupId": "javax.inject",
-              "artifactId": "javax.inject",
-              "version": "1",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
-              "id": "javax.inject:javax.inject:1",
-              "parent": "com.google.inject:guice:5.1.0",
-              "children": []
-            }
-          ]
-        },
-        {
-          "groupId": "javax.inject",
-          "artifactId": "javax.inject",
-          "version": "1",
-          "checksumAlgorithm": "SHA-256",
-          "checksum": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
-          "id": "javax.inject:javax.inject:1",
-          "parent": "org.apache.maven:maven-core:3.9.2",
-          "children": []
-        },
-        {
-          "groupId": "org.apache.commons",
-          "artifactId": "commons-lang3",
-          "version": "3.12.0",
-          "checksumAlgorithm": "SHA-256",
-          "checksum": "d919d904486c037f8d193412da0c92e22a9fa24230b9d67a57855c5c31c7e94e",
-          "id": "org.apache.commons:commons-lang3:3.12.0",
-          "parent": "org.apache.maven:maven-core:3.9.2",
-          "children": []
-        },
-        {
-          "groupId": "org.apache.maven",
-          "artifactId": "maven-artifact",
-          "version": "3.9.2",
-          "checksumAlgorithm": "SHA-256",
-          "checksum": "f2174221d412a79572817b5aa77125348f43266670b6329a9881cdccf7bbc4b1",
-          "id": "org.apache.maven:maven-artifact:3.9.2",
-          "parent": "org.apache.maven:maven-core:3.9.2",
-          "children": [
-            {
-              "groupId": "org.apache.commons",
-              "artifactId": "commons-lang3",
-              "version": "3.12.0",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "d919d904486c037f8d193412da0c92e22a9fa24230b9d67a57855c5c31c7e94e",
-              "id": "org.apache.commons:commons-lang3:3.12.0",
-              "parent": "org.apache.maven:maven-artifact:3.9.2",
-              "children": []
-            },
-            {
-              "groupId": "org.codehaus.plexus",
-              "artifactId": "plexus-utils",
-              "version": "3.5.1",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-              "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-              "parent": "org.apache.maven:maven-artifact:3.9.2",
-              "children": []
+              "checksum": "aff0951639837c4e3a4699a421fa79f410032f603f5c6a5bba435e98531f3984",
+              "id": "org.eclipse.aether:aether-util:1.0.0.v20140518",
+              "parent": "org.apache.maven:maven-aether-provider:3.2.5",
+              "children": [
+                {
+                  "groupId": "org.eclipse.aether",
+                  "artifactId": "aether-api",
+                  "version": "1.0.0.v20140518",
+                  "checksumAlgorithm": "SHA-256",
+                  "checksum": "84b98521684ab22f9528470fa6d8ab68a230e1b211623c989ba7016c306eb773",
+                  "id": "org.eclipse.aether:aether-api:1.0.0.v20140518",
+                  "parent": "org.eclipse.aether:aether-util:1.0.0.v20140518",
+                  "children": []
+                }
+              ]
             }
           ]
         },
         {
           "groupId": "org.apache.maven",
-          "artifactId": "maven-builder-support",
-          "version": "3.9.2",
+          "artifactId": "maven-artifact",
+          "version": "3.2.5",
           "checksumAlgorithm": "SHA-256",
-          "checksum": "701d5793dcd28f09562744b4c3452f77ae94238424a07fb676cf76734deb13bf",
-          "id": "org.apache.maven:maven-builder-support:3.9.2",
-          "parent": "org.apache.maven:maven-core:3.9.2",
-          "children": []
+          "checksum": "270385907ecfbcb256fe5afb883869fd57a5c021b5242693743ef787605c6335",
+          "id": "org.apache.maven:maven-artifact:3.2.5",
+          "parent": "org.apache.maven:maven-core:3.2.5",
+          "children": [
+            {
+              "groupId": "org.codehaus.plexus",
+              "artifactId": "plexus-utils",
+              "version": "3.0.20",
+              "checksumAlgorithm": "SHA-256",
+              "checksum": "8f3a655545fc5b4cbf12b5eb8a154fccb0c1144423a1450511f44005a3d574a2",
+              "id": "org.codehaus.plexus:plexus-utils:3.0.20",
+              "parent": "org.apache.maven:maven-artifact:3.2.5",
+              "children": []
+            }
+          ]
         },
         {
           "groupId": "org.apache.maven",
           "artifactId": "maven-model",
-          "version": "3.9.2",
+          "version": "3.2.5",
           "checksumAlgorithm": "SHA-256",
-          "checksum": "c91583df8b399df87033dbb4c5efe55a0cf6f659da21714c3b0f6f5f9689e28",
-          "id": "org.apache.maven:maven-model:3.9.2",
-          "parent": "org.apache.maven:maven-core:3.9.2",
+          "checksum": "8d439cc1661349dab1c69eed0f831336d187e162cc6d68aa4deefcff57ee0624",
+          "id": "org.apache.maven:maven-model:3.2.5",
+          "parent": "org.apache.maven:maven-core:3.2.5",
           "children": [
             {
               "groupId": "org.codehaus.plexus",
               "artifactId": "plexus-utils",
-              "version": "3.5.1",
+              "version": "3.0.20",
               "checksumAlgorithm": "SHA-256",
-              "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-              "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-              "parent": "org.apache.maven:maven-model:3.9.2",
+              "checksum": "8f3a655545fc5b4cbf12b5eb8a154fccb0c1144423a1450511f44005a3d574a2",
+              "id": "org.codehaus.plexus:plexus-utils:3.0.20",
+              "parent": "org.apache.maven:maven-model:3.2.5",
               "children": []
             }
           ]
@@ -2608,112 +1022,61 @@
         {
           "groupId": "org.apache.maven",
           "artifactId": "maven-model-builder",
-          "version": "3.9.2",
+          "version": "3.2.5",
           "checksumAlgorithm": "SHA-256",
-          "checksum": "1649e8b21eb17ceb528fa0830211482ee229bac177bff309824baaf25c2ad142",
-          "id": "org.apache.maven:maven-model-builder:3.9.2",
-          "parent": "org.apache.maven:maven-core:3.9.2",
+          "checksum": "cc5321269d080ad6694458f53186be5391a21c488ab3a7d6dd73123c7681879d",
+          "id": "org.apache.maven:maven-model-builder:3.2.5",
+          "parent": "org.apache.maven:maven-core:3.2.5",
           "children": [
-            {
-              "groupId": "javax.inject",
-              "artifactId": "javax.inject",
-              "version": "1",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
-              "id": "javax.inject:javax.inject:1",
-              "parent": "org.apache.maven:maven-model-builder:3.9.2",
-              "children": []
-            },
-            {
-              "groupId": "org.apache.maven",
-              "artifactId": "maven-artifact",
-              "version": "3.9.2",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "f2174221d412a79572817b5aa77125348f43266670b6329a9881cdccf7bbc4b1",
-              "id": "org.apache.maven:maven-artifact:3.9.2",
-              "parent": "org.apache.maven:maven-model-builder:3.9.2",
-              "children": [
-                {
-                  "groupId": "org.apache.commons",
-                  "artifactId": "commons-lang3",
-                  "version": "3.12.0",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "d919d904486c037f8d193412da0c92e22a9fa24230b9d67a57855c5c31c7e94e",
-                  "id": "org.apache.commons:commons-lang3:3.12.0",
-                  "parent": "org.apache.maven:maven-artifact:3.9.2",
-                  "children": []
-                },
-                {
-                  "groupId": "org.codehaus.plexus",
-                  "artifactId": "plexus-utils",
-                  "version": "3.5.1",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-                  "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-                  "parent": "org.apache.maven:maven-artifact:3.9.2",
-                  "children": []
-                }
-              ]
-            },
-            {
-              "groupId": "org.apache.maven",
-              "artifactId": "maven-builder-support",
-              "version": "3.9.2",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "701d5793dcd28f09562744b4c3452f77ae94238424a07fb676cf76734deb13bf",
-              "id": "org.apache.maven:maven-builder-support:3.9.2",
-              "parent": "org.apache.maven:maven-model-builder:3.9.2",
-              "children": []
-            },
             {
               "groupId": "org.apache.maven",
               "artifactId": "maven-model",
-              "version": "3.9.2",
+              "version": "3.2.5",
               "checksumAlgorithm": "SHA-256",
-              "checksum": "c91583df8b399df87033dbb4c5efe55a0cf6f659da21714c3b0f6f5f9689e28",
-              "id": "org.apache.maven:maven-model:3.9.2",
-              "parent": "org.apache.maven:maven-model-builder:3.9.2",
+              "checksum": "8d439cc1661349dab1c69eed0f831336d187e162cc6d68aa4deefcff57ee0624",
+              "id": "org.apache.maven:maven-model:3.2.5",
+              "parent": "org.apache.maven:maven-model-builder:3.2.5",
               "children": [
                 {
                   "groupId": "org.codehaus.plexus",
                   "artifactId": "plexus-utils",
-                  "version": "3.5.1",
+                  "version": "3.0.20",
                   "checksumAlgorithm": "SHA-256",
-                  "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-                  "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-                  "parent": "org.apache.maven:maven-model:3.9.2",
+                  "checksum": "8f3a655545fc5b4cbf12b5eb8a154fccb0c1144423a1450511f44005a3d574a2",
+                  "id": "org.codehaus.plexus:plexus-utils:3.0.20",
+                  "parent": "org.apache.maven:maven-model:3.2.5",
                   "children": []
                 }
               ]
             },
             {
               "groupId": "org.codehaus.plexus",
-              "artifactId": "plexus-interpolation",
-              "version": "1.26",
+              "artifactId": "plexus-component-annotations",
+              "version": "1.5.5",
               "checksumAlgorithm": "SHA-256",
-              "checksum": "b3b5412ce17889103ea564bcdfcf9fb3dfa540344ffeac6b538a73c9d7182662",
-              "id": "org.codehaus.plexus:plexus-interpolation:1.26",
-              "parent": "org.apache.maven:maven-model-builder:3.9.2",
+              "checksum": "4df7a6a7be64b35bbccf60b5c115697f9ea3421d22674ae67135dde375fcca1f",
+              "id": "org.codehaus.plexus:plexus-component-annotations:1.5.5",
+              "parent": "org.apache.maven:maven-model-builder:3.2.5",
+              "children": []
+            },
+            {
+              "groupId": "org.codehaus.plexus",
+              "artifactId": "plexus-interpolation",
+              "version": "1.21",
+              "checksumAlgorithm": "SHA-256",
+              "checksum": "aba7980581027ad5fc74a27ee4d64aad74932fdb32694967242d03fc50290d1f",
+              "id": "org.codehaus.plexus:plexus-interpolation:1.21",
+              "parent": "org.apache.maven:maven-model-builder:3.2.5",
               "children": []
             },
             {
               "groupId": "org.codehaus.plexus",
               "artifactId": "plexus-utils",
-              "version": "3.5.1",
+              "version": "3.0.20",
               "checksumAlgorithm": "SHA-256",
-              "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-              "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-              "parent": "org.apache.maven:maven-model-builder:3.9.2",
-              "children": []
-            },
-            {
-              "groupId": "org.eclipse.sisu",
-              "artifactId": "org.eclipse.sisu.inject",
-              "version": "0.3.5",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "c5994010bcdce1d2bd603a4d50c47191ddbd7875d1157b23aaa26d33c82fda13",
-              "id": "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.5",
-              "parent": "org.apache.maven:maven-model-builder:3.9.2",
+              "checksum": "8f3a655545fc5b4cbf12b5eb8a154fccb0c1144423a1450511f44005a3d574a2",
+              "id": "org.codehaus.plexus:plexus-utils:3.0.20",
+              "parent": "org.apache.maven:maven-model-builder:3.2.5",
               "children": []
             }
           ]
@@ -2721,39 +1084,29 @@
         {
           "groupId": "org.apache.maven",
           "artifactId": "maven-plugin-api",
-          "version": "3.9.2",
+          "version": "3.2.5",
           "checksumAlgorithm": "SHA-256",
-          "checksum": "27de347c74dd1d3eb984ae8611874116c486f9f0027f6a4e03f1b69d2ef4aabc",
-          "id": "org.apache.maven:maven-plugin-api:3.9.2",
-          "parent": "org.apache.maven:maven-core:3.9.2",
+          "checksum": "194a6f0ce889ed3b0d8a9bc4d3c79541e878098b7e303e4ac76c1031850772c3",
+          "id": "org.apache.maven:maven-plugin-api:3.2.5",
+          "parent": "org.apache.maven:maven-core:3.2.5",
           "children": [
             {
               "groupId": "org.apache.maven",
               "artifactId": "maven-artifact",
-              "version": "3.9.2",
+              "version": "3.2.5",
               "checksumAlgorithm": "SHA-256",
-              "checksum": "f2174221d412a79572817b5aa77125348f43266670b6329a9881cdccf7bbc4b1",
-              "id": "org.apache.maven:maven-artifact:3.9.2",
-              "parent": "org.apache.maven:maven-plugin-api:3.9.2",
+              "checksum": "270385907ecfbcb256fe5afb883869fd57a5c021b5242693743ef787605c6335",
+              "id": "org.apache.maven:maven-artifact:3.2.5",
+              "parent": "org.apache.maven:maven-plugin-api:3.2.5",
               "children": [
-                {
-                  "groupId": "org.apache.commons",
-                  "artifactId": "commons-lang3",
-                  "version": "3.12.0",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "d919d904486c037f8d193412da0c92e22a9fa24230b9d67a57855c5c31c7e94e",
-                  "id": "org.apache.commons:commons-lang3:3.12.0",
-                  "parent": "org.apache.maven:maven-artifact:3.9.2",
-                  "children": []
-                },
                 {
                   "groupId": "org.codehaus.plexus",
                   "artifactId": "plexus-utils",
-                  "version": "3.5.1",
+                  "version": "3.0.20",
                   "checksumAlgorithm": "SHA-256",
-                  "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-                  "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-                  "parent": "org.apache.maven:maven-artifact:3.9.2",
+                  "checksum": "8f3a655545fc5b4cbf12b5eb8a154fccb0c1144423a1450511f44005a3d574a2",
+                  "id": "org.codehaus.plexus:plexus-utils:3.0.20",
+                  "parent": "org.apache.maven:maven-artifact:3.2.5",
                   "children": []
                 }
               ]
@@ -2761,71 +1114,72 @@
             {
               "groupId": "org.apache.maven",
               "artifactId": "maven-model",
-              "version": "3.9.2",
+              "version": "3.2.5",
               "checksumAlgorithm": "SHA-256",
-              "checksum": "c91583df8b399df87033dbb4c5efe55a0cf6f659da21714c3b0f6f5f9689e28",
-              "id": "org.apache.maven:maven-model:3.9.2",
-              "parent": "org.apache.maven:maven-plugin-api:3.9.2",
+              "checksum": "8d439cc1661349dab1c69eed0f831336d187e162cc6d68aa4deefcff57ee0624",
+              "id": "org.apache.maven:maven-model:3.2.5",
+              "parent": "org.apache.maven:maven-plugin-api:3.2.5",
               "children": [
                 {
                   "groupId": "org.codehaus.plexus",
                   "artifactId": "plexus-utils",
-                  "version": "3.5.1",
+                  "version": "3.0.20",
                   "checksumAlgorithm": "SHA-256",
-                  "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-                  "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-                  "parent": "org.apache.maven:maven-model:3.9.2",
+                  "checksum": "8f3a655545fc5b4cbf12b5eb8a154fccb0c1144423a1450511f44005a3d574a2",
+                  "id": "org.codehaus.plexus:plexus-utils:3.0.20",
+                  "parent": "org.apache.maven:maven-model:3.2.5",
                   "children": []
                 }
               ]
             },
             {
-              "groupId": "org.codehaus.plexus",
-              "artifactId": "plexus-classworlds",
-              "version": "2.7.0",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "c60ae538ba66adbc06aae205fbe2306211d3d213ab6df3239ec03cdde2458ad6",
-              "id": "org.codehaus.plexus:plexus-classworlds:2.7.0",
-              "parent": "org.apache.maven:maven-plugin-api:3.9.2",
-              "children": []
-            },
-            {
-              "groupId": "org.codehaus.plexus",
-              "artifactId": "plexus-utils",
-              "version": "3.5.1",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-              "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-              "parent": "org.apache.maven:maven-plugin-api:3.9.2",
-              "children": []
-            },
-            {
               "groupId": "org.eclipse.sisu",
               "artifactId": "org.eclipse.sisu.plexus",
-              "version": "0.3.5",
+              "version": "0.3.0.M1",
               "checksumAlgorithm": "SHA-256",
-              "checksum": "7e4c61096d70826f20f7a7d55c59a5528e7aa5ad247ee2dfe544e4dd25f6a784",
-              "id": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5",
-              "parent": "org.apache.maven:maven-plugin-api:3.9.2",
+              "checksum": "35b545ead7e5513ec8c4974a984659ec68738e6761bb7c08a9876a2e901d38ae",
+              "id": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.0.M1",
+              "parent": "org.apache.maven:maven-plugin-api:3.2.5",
               "children": [
                 {
-                  "groupId": "javax.annotation",
-                  "artifactId": "javax.annotation-api",
-                  "version": "1.2",
+                  "groupId": "javax.enterprise",
+                  "artifactId": "cdi-api",
+                  "version": "1.0",
                   "checksumAlgorithm": "SHA-256",
-                  "checksum": "5909b396ca3a2be10d0eea32c74ef78d816e1b4ead21de1d78de1f890d033e04",
-                  "id": "javax.annotation:javax.annotation-api:1.2",
-                  "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5",
-                  "children": []
+                  "checksum": "1f10b2204cc77c919301f20ff90461c3df1b6e6cb148be1c2d22107f4851d423",
+                  "id": "javax.enterprise:cdi-api:1.0",
+                  "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.0.M1",
+                  "children": [
+                    {
+                      "groupId": "javax.annotation",
+                      "artifactId": "jsr250-api",
+                      "version": "1.0",
+                      "checksumAlgorithm": "SHA-256",
+                      "checksum": "a1a922d0d9b6d183ed3800dfac01d1e1eb159f0e8c6f94736931c1def54a941f",
+                      "id": "javax.annotation:jsr250-api:1.0",
+                      "parent": "javax.enterprise:cdi-api:1.0",
+                      "children": []
+                    },
+                    {
+                      "groupId": "javax.inject",
+                      "artifactId": "javax.inject",
+                      "version": "1",
+                      "checksumAlgorithm": "SHA-256",
+                      "checksum": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
+                      "id": "javax.inject:javax.inject:1",
+                      "parent": "javax.enterprise:cdi-api:1.0",
+                      "children": []
+                    }
+                  ]
                 },
                 {
                   "groupId": "org.codehaus.plexus",
                   "artifactId": "plexus-classworlds",
-                  "version": "2.5.2",
+                  "version": "2.5.1",
                   "checksumAlgorithm": "SHA-256",
-                  "checksum": "b2931d41740490a8d931cbe0cfe9ac20deb66cca606e679f52522f7f534c9fd7",
-                  "id": "org.codehaus.plexus:plexus-classworlds:2.5.2",
-                  "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5",
+                  "checksum": "de9ce33b29088c2db7c3f55ddc061c2a7a72f9c93c28faad62cc15aee26b6888",
+                  "id": "org.codehaus.plexus:plexus-classworlds:2.5.1",
+                  "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.0.M1",
                   "children": []
                 },
                 {
@@ -2835,27 +1189,27 @@
                   "checksumAlgorithm": "SHA-256",
                   "checksum": "4df7a6a7be64b35bbccf60b5c115697f9ea3421d22674ae67135dde375fcca1f",
                   "id": "org.codehaus.plexus:plexus-component-annotations:1.5.5",
-                  "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5",
+                  "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.0.M1",
                   "children": []
                 },
                 {
                   "groupId": "org.codehaus.plexus",
                   "artifactId": "plexus-utils",
-                  "version": "3.0.24",
+                  "version": "2.1",
                   "checksumAlgorithm": "SHA-256",
-                  "checksum": "83ee748b12d06afb0ad4050a591132b3e8025fbb1990f1ed002e8b73293e69b4",
-                  "id": "org.codehaus.plexus:plexus-utils:3.0.24",
-                  "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5",
+                  "checksum": "35608df55aa672a195d6b01573a5630a315998b3bbd06310b20eb169113923aa",
+                  "id": "org.codehaus.plexus:plexus-utils:2.1",
+                  "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.0.M1",
                   "children": []
                 },
                 {
                   "groupId": "org.eclipse.sisu",
                   "artifactId": "org.eclipse.sisu.inject",
-                  "version": "0.3.5",
+                  "version": "0.3.0.M1",
                   "checksumAlgorithm": "SHA-256",
-                  "checksum": "c5994010bcdce1d2bd603a4d50c47191ddbd7875d1157b23aaa26d33c82fda13",
-                  "id": "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.5",
-                  "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5",
+                  "checksum": "3a878482877e66337ab8461e7f55ab9d701f8090f889ad8938cceefa33193fe4",
+                  "id": "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.0.M1",
+                  "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.0.M1",
                   "children": []
                 }
               ]
@@ -2865,352 +1219,20 @@
         {
           "groupId": "org.apache.maven",
           "artifactId": "maven-repository-metadata",
-          "version": "3.9.2",
+          "version": "3.2.5",
           "checksumAlgorithm": "SHA-256",
-          "checksum": "2ab4ad3dd4cf1052747344ebcfa89addfd75f1067d893f8721a22430fb360e8a",
-          "id": "org.apache.maven:maven-repository-metadata:3.9.2",
-          "parent": "org.apache.maven:maven-core:3.9.2",
+          "checksum": "62b517b77f24edebdee0e382ecddb44bb6632b7c08c528d625aed7d2980df12b",
+          "id": "org.apache.maven:maven-repository-metadata:3.2.5",
+          "parent": "org.apache.maven:maven-core:3.2.5",
           "children": [
             {
               "groupId": "org.codehaus.plexus",
               "artifactId": "plexus-utils",
-              "version": "3.5.1",
+              "version": "3.0.20",
               "checksumAlgorithm": "SHA-256",
-              "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-              "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-              "parent": "org.apache.maven:maven-repository-metadata:3.9.2",
-              "children": []
-            }
-          ]
-        },
-        {
-          "groupId": "org.apache.maven",
-          "artifactId": "maven-resolver-provider",
-          "version": "3.9.2",
-          "checksumAlgorithm": "SHA-256",
-          "checksum": "cae807ff07bc3bfce26d2bb8f2a53b3f6b74600a5406b4c11a32d1fedaddf99",
-          "id": "org.apache.maven:maven-resolver-provider:3.9.2",
-          "parent": "org.apache.maven:maven-core:3.9.2",
-          "children": [
-            {
-              "groupId": "javax.inject",
-              "artifactId": "javax.inject",
-              "version": "1",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
-              "id": "javax.inject:javax.inject:1",
-              "parent": "org.apache.maven:maven-resolver-provider:3.9.2",
-              "children": []
-            },
-            {
-              "groupId": "org.apache.maven",
-              "artifactId": "maven-model",
-              "version": "3.9.2",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "c91583df8b399df87033dbb4c5efe55a0cf6f659da21714c3b0f6f5f9689e28",
-              "id": "org.apache.maven:maven-model:3.9.2",
-              "parent": "org.apache.maven:maven-resolver-provider:3.9.2",
-              "children": [
-                {
-                  "groupId": "org.codehaus.plexus",
-                  "artifactId": "plexus-utils",
-                  "version": "3.5.1",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-                  "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-                  "parent": "org.apache.maven:maven-model:3.9.2",
-                  "children": []
-                }
-              ]
-            },
-            {
-              "groupId": "org.apache.maven",
-              "artifactId": "maven-model-builder",
-              "version": "3.9.2",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "1649e8b21eb17ceb528fa0830211482ee229bac177bff309824baaf25c2ad142",
-              "id": "org.apache.maven:maven-model-builder:3.9.2",
-              "parent": "org.apache.maven:maven-resolver-provider:3.9.2",
-              "children": [
-                {
-                  "groupId": "javax.inject",
-                  "artifactId": "javax.inject",
-                  "version": "1",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
-                  "id": "javax.inject:javax.inject:1",
-                  "parent": "org.apache.maven:maven-model-builder:3.9.2",
-                  "children": []
-                },
-                {
-                  "groupId": "org.apache.maven",
-                  "artifactId": "maven-artifact",
-                  "version": "3.9.2",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "f2174221d412a79572817b5aa77125348f43266670b6329a9881cdccf7bbc4b1",
-                  "id": "org.apache.maven:maven-artifact:3.9.2",
-                  "parent": "org.apache.maven:maven-model-builder:3.9.2",
-                  "children": [
-                    {
-                      "groupId": "org.apache.commons",
-                      "artifactId": "commons-lang3",
-                      "version": "3.12.0",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "d919d904486c037f8d193412da0c92e22a9fa24230b9d67a57855c5c31c7e94e",
-                      "id": "org.apache.commons:commons-lang3:3.12.0",
-                      "parent": "org.apache.maven:maven-artifact:3.9.2",
-                      "children": []
-                    },
-                    {
-                      "groupId": "org.codehaus.plexus",
-                      "artifactId": "plexus-utils",
-                      "version": "3.5.1",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-                      "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-                      "parent": "org.apache.maven:maven-artifact:3.9.2",
-                      "children": []
-                    }
-                  ]
-                },
-                {
-                  "groupId": "org.apache.maven",
-                  "artifactId": "maven-builder-support",
-                  "version": "3.9.2",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "701d5793dcd28f09562744b4c3452f77ae94238424a07fb676cf76734deb13bf",
-                  "id": "org.apache.maven:maven-builder-support:3.9.2",
-                  "parent": "org.apache.maven:maven-model-builder:3.9.2",
-                  "children": []
-                },
-                {
-                  "groupId": "org.apache.maven",
-                  "artifactId": "maven-model",
-                  "version": "3.9.2",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "c91583df8b399df87033dbb4c5efe55a0cf6f659da21714c3b0f6f5f9689e28",
-                  "id": "org.apache.maven:maven-model:3.9.2",
-                  "parent": "org.apache.maven:maven-model-builder:3.9.2",
-                  "children": [
-                    {
-                      "groupId": "org.codehaus.plexus",
-                      "artifactId": "plexus-utils",
-                      "version": "3.5.1",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-                      "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-                      "parent": "org.apache.maven:maven-model:3.9.2",
-                      "children": []
-                    }
-                  ]
-                },
-                {
-                  "groupId": "org.codehaus.plexus",
-                  "artifactId": "plexus-interpolation",
-                  "version": "1.26",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "b3b5412ce17889103ea564bcdfcf9fb3dfa540344ffeac6b538a73c9d7182662",
-                  "id": "org.codehaus.plexus:plexus-interpolation:1.26",
-                  "parent": "org.apache.maven:maven-model-builder:3.9.2",
-                  "children": []
-                },
-                {
-                  "groupId": "org.codehaus.plexus",
-                  "artifactId": "plexus-utils",
-                  "version": "3.5.1",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-                  "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-                  "parent": "org.apache.maven:maven-model-builder:3.9.2",
-                  "children": []
-                },
-                {
-                  "groupId": "org.eclipse.sisu",
-                  "artifactId": "org.eclipse.sisu.inject",
-                  "version": "0.3.5",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "c5994010bcdce1d2bd603a4d50c47191ddbd7875d1157b23aaa26d33c82fda13",
-                  "id": "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.5",
-                  "parent": "org.apache.maven:maven-model-builder:3.9.2",
-                  "children": []
-                }
-              ]
-            },
-            {
-              "groupId": "org.apache.maven",
-              "artifactId": "maven-repository-metadata",
-              "version": "3.9.2",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "2ab4ad3dd4cf1052747344ebcfa89addfd75f1067d893f8721a22430fb360e8a",
-              "id": "org.apache.maven:maven-repository-metadata:3.9.2",
-              "parent": "org.apache.maven:maven-resolver-provider:3.9.2",
-              "children": [
-                {
-                  "groupId": "org.codehaus.plexus",
-                  "artifactId": "plexus-utils",
-                  "version": "3.5.1",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-                  "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-                  "parent": "org.apache.maven:maven-repository-metadata:3.9.2",
-                  "children": []
-                }
-              ]
-            },
-            {
-              "groupId": "org.apache.maven.resolver",
-              "artifactId": "maven-resolver-api",
-              "version": "1.9.10",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "5ee57c89259d0a41f56291864ca7db12349ce11eca8ef62be5680c7c244705d0",
-              "id": "org.apache.maven.resolver:maven-resolver-api:1.9.10",
-              "parent": "org.apache.maven:maven-resolver-provider:3.9.2",
-              "children": []
-            },
-            {
-              "groupId": "org.apache.maven.resolver",
-              "artifactId": "maven-resolver-impl",
-              "version": "1.9.10",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "6fc7cc06dd6364805e42b89dcaec2d0875ffb1fee8774938783918cb2020f2d8",
-              "id": "org.apache.maven.resolver:maven-resolver-impl:1.9.10",
-              "parent": "org.apache.maven:maven-resolver-provider:3.9.2",
-              "children": [
-                {
-                  "groupId": "org.apache.maven.resolver",
-                  "artifactId": "maven-resolver-api",
-                  "version": "1.9.10",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "5ee57c89259d0a41f56291864ca7db12349ce11eca8ef62be5680c7c244705d0",
-                  "id": "org.apache.maven.resolver:maven-resolver-api:1.9.10",
-                  "parent": "org.apache.maven.resolver:maven-resolver-impl:1.9.10",
-                  "children": []
-                },
-                {
-                  "groupId": "org.apache.maven.resolver",
-                  "artifactId": "maven-resolver-named-locks",
-                  "version": "1.9.10",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "f55d2e75468509a92fc841d818283168ea458ebcb34a3011531cac812e309155",
-                  "id": "org.apache.maven.resolver:maven-resolver-named-locks:1.9.10",
-                  "parent": "org.apache.maven.resolver:maven-resolver-impl:1.9.10",
-                  "children": [
-                    {
-                      "groupId": "org.slf4j",
-                      "artifactId": "slf4j-api",
-                      "version": "1.7.36",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "d3ef575e3e4979678dc01bf1dcce51021493b4d11fb7f1be8ad982877c16a1c0",
-                      "id": "org.slf4j:slf4j-api:1.7.36",
-                      "parent": "org.apache.maven.resolver:maven-resolver-named-locks:1.9.10",
-                      "children": []
-                    }
-                  ]
-                },
-                {
-                  "groupId": "org.apache.maven.resolver",
-                  "artifactId": "maven-resolver-spi",
-                  "version": "1.9.10",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "7554650b663fef31c594c75f600b2241bbed9306d1ee5637047da55e9a443df3",
-                  "id": "org.apache.maven.resolver:maven-resolver-spi:1.9.10",
-                  "parent": "org.apache.maven.resolver:maven-resolver-impl:1.9.10",
-                  "children": [
-                    {
-                      "groupId": "org.apache.maven.resolver",
-                      "artifactId": "maven-resolver-api",
-                      "version": "1.9.10",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "5ee57c89259d0a41f56291864ca7db12349ce11eca8ef62be5680c7c244705d0",
-                      "id": "org.apache.maven.resolver:maven-resolver-api:1.9.10",
-                      "parent": "org.apache.maven.resolver:maven-resolver-spi:1.9.10",
-                      "children": []
-                    }
-                  ]
-                },
-                {
-                  "groupId": "org.apache.maven.resolver",
-                  "artifactId": "maven-resolver-util",
-                  "version": "1.9.10",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "c6eda39bd4b7670e7314ffa006e4dc9da48617e2a6ff26e5af118f0be6a0cdd4",
-                  "id": "org.apache.maven.resolver:maven-resolver-util:1.9.10",
-                  "parent": "org.apache.maven.resolver:maven-resolver-impl:1.9.10",
-                  "children": [
-                    {
-                      "groupId": "org.apache.maven.resolver",
-                      "artifactId": "maven-resolver-api",
-                      "version": "1.9.10",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "5ee57c89259d0a41f56291864ca7db12349ce11eca8ef62be5680c7c244705d0",
-                      "id": "org.apache.maven.resolver:maven-resolver-api:1.9.10",
-                      "parent": "org.apache.maven.resolver:maven-resolver-util:1.9.10",
-                      "children": []
-                    }
-                  ]
-                },
-                {
-                  "groupId": "org.slf4j",
-                  "artifactId": "slf4j-api",
-                  "version": "1.7.36",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "d3ef575e3e4979678dc01bf1dcce51021493b4d11fb7f1be8ad982877c16a1c0",
-                  "id": "org.slf4j:slf4j-api:1.7.36",
-                  "parent": "org.apache.maven.resolver:maven-resolver-impl:1.9.10",
-                  "children": []
-                }
-              ]
-            },
-            {
-              "groupId": "org.apache.maven.resolver",
-              "artifactId": "maven-resolver-spi",
-              "version": "1.9.10",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "7554650b663fef31c594c75f600b2241bbed9306d1ee5637047da55e9a443df3",
-              "id": "org.apache.maven.resolver:maven-resolver-spi:1.9.10",
-              "parent": "org.apache.maven:maven-resolver-provider:3.9.2",
-              "children": [
-                {
-                  "groupId": "org.apache.maven.resolver",
-                  "artifactId": "maven-resolver-api",
-                  "version": "1.9.10",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "5ee57c89259d0a41f56291864ca7db12349ce11eca8ef62be5680c7c244705d0",
-                  "id": "org.apache.maven.resolver:maven-resolver-api:1.9.10",
-                  "parent": "org.apache.maven.resolver:maven-resolver-spi:1.9.10",
-                  "children": []
-                }
-              ]
-            },
-            {
-              "groupId": "org.apache.maven.resolver",
-              "artifactId": "maven-resolver-util",
-              "version": "1.9.10",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "c6eda39bd4b7670e7314ffa006e4dc9da48617e2a6ff26e5af118f0be6a0cdd4",
-              "id": "org.apache.maven.resolver:maven-resolver-util:1.9.10",
-              "parent": "org.apache.maven:maven-resolver-provider:3.9.2",
-              "children": [
-                {
-                  "groupId": "org.apache.maven.resolver",
-                  "artifactId": "maven-resolver-api",
-                  "version": "1.9.10",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "5ee57c89259d0a41f56291864ca7db12349ce11eca8ef62be5680c7c244705d0",
-                  "id": "org.apache.maven.resolver:maven-resolver-api:1.9.10",
-                  "parent": "org.apache.maven.resolver:maven-resolver-util:1.9.10",
-                  "children": []
-                }
-              ]
-            },
-            {
-              "groupId": "org.codehaus.plexus",
-              "artifactId": "plexus-utils",
-              "version": "3.5.1",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-              "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-              "parent": "org.apache.maven:maven-resolver-provider:3.9.2",
+              "checksum": "8f3a655545fc5b4cbf12b5eb8a154fccb0c1144423a1450511f44005a3d574a2",
+              "id": "org.codehaus.plexus:plexus-utils:3.0.20",
+              "parent": "org.apache.maven:maven-repository-metadata:3.2.5",
               "children": []
             }
           ]
@@ -3218,20 +1240,20 @@
         {
           "groupId": "org.apache.maven",
           "artifactId": "maven-settings",
-          "version": "3.9.2",
+          "version": "3.2.5",
           "checksumAlgorithm": "SHA-256",
-          "checksum": "ffd180b75ce1050465b2904f5e79db2fcb8628017433afe3b389e32e51360322",
-          "id": "org.apache.maven:maven-settings:3.9.2",
-          "parent": "org.apache.maven:maven-core:3.9.2",
+          "checksum": "1874d4ee660b935675a60bdb2ef63e0ff5a81769f4fc04a035fa9d4c4e238224",
+          "id": "org.apache.maven:maven-settings:3.2.5",
+          "parent": "org.apache.maven:maven-core:3.2.5",
           "children": [
             {
               "groupId": "org.codehaus.plexus",
               "artifactId": "plexus-utils",
-              "version": "3.5.1",
+              "version": "3.0.20",
               "checksumAlgorithm": "SHA-256",
-              "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-              "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-              "parent": "org.apache.maven:maven-settings:3.9.2",
+              "checksum": "8f3a655545fc5b4cbf12b5eb8a154fccb0c1144423a1450511f44005a3d574a2",
+              "id": "org.codehaus.plexus:plexus-utils:3.0.20",
+              "parent": "org.apache.maven:maven-settings:3.2.5",
               "children": []
             }
           ]
@@ -3239,72 +1261,258 @@
         {
           "groupId": "org.apache.maven",
           "artifactId": "maven-settings-builder",
-          "version": "3.9.2",
+          "version": "3.2.5",
           "checksumAlgorithm": "SHA-256",
-          "checksum": "936ee7c856e72557d6280a7cf96c2f76eea570e29b11ee0d0057d89722513ed7",
-          "id": "org.apache.maven:maven-settings-builder:3.9.2",
-          "parent": "org.apache.maven:maven-core:3.9.2",
+          "checksum": "9c5a014ceb8abb55e997dcc41d17bbe0ae145db574be6b7186e75950c241269f",
+          "id": "org.apache.maven:maven-settings-builder:3.2.5",
+          "parent": "org.apache.maven:maven-core:3.2.5",
           "children": [
-            {
-              "groupId": "javax.inject",
-              "artifactId": "javax.inject",
-              "version": "1",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
-              "id": "javax.inject:javax.inject:1",
-              "parent": "org.apache.maven:maven-settings-builder:3.9.2",
-              "children": []
-            },
-            {
-              "groupId": "org.apache.maven",
-              "artifactId": "maven-builder-support",
-              "version": "3.9.2",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "701d5793dcd28f09562744b4c3452f77ae94238424a07fb676cf76734deb13bf",
-              "id": "org.apache.maven:maven-builder-support:3.9.2",
-              "parent": "org.apache.maven:maven-settings-builder:3.9.2",
-              "children": []
-            },
             {
               "groupId": "org.apache.maven",
               "artifactId": "maven-settings",
-              "version": "3.9.2",
+              "version": "3.2.5",
               "checksumAlgorithm": "SHA-256",
-              "checksum": "ffd180b75ce1050465b2904f5e79db2fcb8628017433afe3b389e32e51360322",
-              "id": "org.apache.maven:maven-settings:3.9.2",
-              "parent": "org.apache.maven:maven-settings-builder:3.9.2",
+              "checksum": "1874d4ee660b935675a60bdb2ef63e0ff5a81769f4fc04a035fa9d4c4e238224",
+              "id": "org.apache.maven:maven-settings:3.2.5",
+              "parent": "org.apache.maven:maven-settings-builder:3.2.5",
               "children": [
                 {
                   "groupId": "org.codehaus.plexus",
                   "artifactId": "plexus-utils",
-                  "version": "3.5.1",
+                  "version": "3.0.20",
                   "checksumAlgorithm": "SHA-256",
-                  "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-                  "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-                  "parent": "org.apache.maven:maven-settings:3.9.2",
+                  "checksum": "8f3a655545fc5b4cbf12b5eb8a154fccb0c1144423a1450511f44005a3d574a2",
+                  "id": "org.codehaus.plexus:plexus-utils:3.0.20",
+                  "parent": "org.apache.maven:maven-settings:3.2.5",
                   "children": []
                 }
               ]
             },
             {
               "groupId": "org.codehaus.plexus",
-              "artifactId": "plexus-interpolation",
-              "version": "1.26",
+              "artifactId": "plexus-component-annotations",
+              "version": "1.5.5",
               "checksumAlgorithm": "SHA-256",
-              "checksum": "b3b5412ce17889103ea564bcdfcf9fb3dfa540344ffeac6b538a73c9d7182662",
-              "id": "org.codehaus.plexus:plexus-interpolation:1.26",
-              "parent": "org.apache.maven:maven-settings-builder:3.9.2",
+              "checksum": "4df7a6a7be64b35bbccf60b5c115697f9ea3421d22674ae67135dde375fcca1f",
+              "id": "org.codehaus.plexus:plexus-component-annotations:1.5.5",
+              "parent": "org.apache.maven:maven-settings-builder:3.2.5",
               "children": []
             },
             {
               "groupId": "org.codehaus.plexus",
-              "artifactId": "plexus-sec-dispatcher",
-              "version": "2.0",
+              "artifactId": "plexus-interpolation",
+              "version": "1.21",
               "checksumAlgorithm": "SHA-256",
-              "checksum": "873139960c4c780176dda580b003a2c4bf82188bdce5bb99234e224ef7acfceb",
-              "id": "org.codehaus.plexus:plexus-sec-dispatcher:2.0",
-              "parent": "org.apache.maven:maven-settings-builder:3.9.2",
+              "checksum": "aba7980581027ad5fc74a27ee4d64aad74932fdb32694967242d03fc50290d1f",
+              "id": "org.codehaus.plexus:plexus-interpolation:1.21",
+              "parent": "org.apache.maven:maven-settings-builder:3.2.5",
+              "children": []
+            },
+            {
+              "groupId": "org.codehaus.plexus",
+              "artifactId": "plexus-utils",
+              "version": "3.0.20",
+              "checksumAlgorithm": "SHA-256",
+              "checksum": "8f3a655545fc5b4cbf12b5eb8a154fccb0c1144423a1450511f44005a3d574a2",
+              "id": "org.codehaus.plexus:plexus-utils:3.0.20",
+              "parent": "org.apache.maven:maven-settings-builder:3.2.5",
+              "children": []
+            },
+            {
+              "groupId": "org.sonatype.plexus",
+              "artifactId": "plexus-sec-dispatcher",
+              "version": "1.3",
+              "checksumAlgorithm": "SHA-256",
+              "checksum": "3b0559bb8432f28937efe6ca193ef54a8506d0075d73fd7406b9b116c6a11063",
+              "id": "org.sonatype.plexus:plexus-sec-dispatcher:1.3",
+              "parent": "org.apache.maven:maven-settings-builder:3.2.5",
               "children": [
+                {
+                  "groupId": "org.codehaus.plexus",
+                  "artifactId": "plexus-utils",
+                  "version": "1.5.5",
+                  "checksumAlgorithm": "SHA-256",
+                  "checksum": "92f38b0af28629847e461060eae84bcd7441995a5ecba785400754164fbbd1dc",
+                  "id": "org.codehaus.plexus:plexus-utils:1.5.5",
+                  "parent": "org.sonatype.plexus:plexus-sec-dispatcher:1.3",
+                  "children": []
+                },
+                {
+                  "groupId": "org.sonatype.plexus",
+                  "artifactId": "plexus-cipher",
+                  "version": "1.4",
+                  "checksumAlgorithm": "SHA-256",
+                  "checksum": "5a15fdba22669e0fdd06e10dcce6320879e1f7398fbc910cd0677b50672a78c4",
+                  "id": "org.sonatype.plexus:plexus-cipher:1.4",
+                  "parent": "org.sonatype.plexus:plexus-sec-dispatcher:1.3",
+                  "children": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "groupId": "org.codehaus.plexus",
+          "artifactId": "plexus-classworlds",
+          "version": "2.5.2",
+          "checksumAlgorithm": "SHA-256",
+          "checksum": "b2931d41740490a8d931cbe0cfe9ac20deb66cca606e679f52522f7f534c9fd7",
+          "id": "org.codehaus.plexus:plexus-classworlds:2.5.2",
+          "parent": "org.apache.maven:maven-core:3.2.5",
+          "children": []
+        },
+        {
+          "groupId": "org.codehaus.plexus",
+          "artifactId": "plexus-component-annotations",
+          "version": "1.5.5",
+          "checksumAlgorithm": "SHA-256",
+          "checksum": "4df7a6a7be64b35bbccf60b5c115697f9ea3421d22674ae67135dde375fcca1f",
+          "id": "org.codehaus.plexus:plexus-component-annotations:1.5.5",
+          "parent": "org.apache.maven:maven-core:3.2.5",
+          "children": []
+        },
+        {
+          "groupId": "org.codehaus.plexus",
+          "artifactId": "plexus-interpolation",
+          "version": "1.21",
+          "checksumAlgorithm": "SHA-256",
+          "checksum": "aba7980581027ad5fc74a27ee4d64aad74932fdb32694967242d03fc50290d1f",
+          "id": "org.codehaus.plexus:plexus-interpolation:1.21",
+          "parent": "org.apache.maven:maven-core:3.2.5",
+          "children": []
+        },
+        {
+          "groupId": "org.codehaus.plexus",
+          "artifactId": "plexus-utils",
+          "version": "3.0.20",
+          "checksumAlgorithm": "SHA-256",
+          "checksum": "8f3a655545fc5b4cbf12b5eb8a154fccb0c1144423a1450511f44005a3d574a2",
+          "id": "org.codehaus.plexus:plexus-utils:3.0.20",
+          "parent": "org.apache.maven:maven-core:3.2.5",
+          "children": []
+        },
+        {
+          "groupId": "org.eclipse.aether",
+          "artifactId": "aether-api",
+          "version": "1.0.0.v20140518",
+          "checksumAlgorithm": "SHA-256",
+          "checksum": "84b98521684ab22f9528470fa6d8ab68a230e1b211623c989ba7016c306eb773",
+          "id": "org.eclipse.aether:aether-api:1.0.0.v20140518",
+          "parent": "org.apache.maven:maven-core:3.2.5",
+          "children": []
+        },
+        {
+          "groupId": "org.eclipse.aether",
+          "artifactId": "aether-impl",
+          "version": "1.0.0.v20140518",
+          "checksumAlgorithm": "SHA-256",
+          "checksum": "9a9b60e685385225f08e662cb9f60d96610b0987f0f47bbf3f0c92df8a897d00",
+          "id": "org.eclipse.aether:aether-impl:1.0.0.v20140518",
+          "parent": "org.apache.maven:maven-core:3.2.5",
+          "children": [
+            {
+              "groupId": "org.eclipse.aether",
+              "artifactId": "aether-api",
+              "version": "1.0.0.v20140518",
+              "checksumAlgorithm": "SHA-256",
+              "checksum": "84b98521684ab22f9528470fa6d8ab68a230e1b211623c989ba7016c306eb773",
+              "id": "org.eclipse.aether:aether-api:1.0.0.v20140518",
+              "parent": "org.eclipse.aether:aether-impl:1.0.0.v20140518",
+              "children": []
+            },
+            {
+              "groupId": "org.eclipse.aether",
+              "artifactId": "aether-spi",
+              "version": "1.0.0.v20140518",
+              "checksumAlgorithm": "SHA-256",
+              "checksum": "a3266d127a4e9f4aa9c4fa0986e31eec784e866f79112e1840d1667e17c10fb2",
+              "id": "org.eclipse.aether:aether-spi:1.0.0.v20140518",
+              "parent": "org.eclipse.aether:aether-impl:1.0.0.v20140518",
+              "children": [
+                {
+                  "groupId": "org.eclipse.aether",
+                  "artifactId": "aether-api",
+                  "version": "1.0.0.v20140518",
+                  "checksumAlgorithm": "SHA-256",
+                  "checksum": "84b98521684ab22f9528470fa6d8ab68a230e1b211623c989ba7016c306eb773",
+                  "id": "org.eclipse.aether:aether-api:1.0.0.v20140518",
+                  "parent": "org.eclipse.aether:aether-spi:1.0.0.v20140518",
+                  "children": []
+                }
+              ]
+            },
+            {
+              "groupId": "org.eclipse.aether",
+              "artifactId": "aether-util",
+              "version": "1.0.0.v20140518",
+              "checksumAlgorithm": "SHA-256",
+              "checksum": "aff0951639837c4e3a4699a421fa79f410032f603f5c6a5bba435e98531f3984",
+              "id": "org.eclipse.aether:aether-util:1.0.0.v20140518",
+              "parent": "org.eclipse.aether:aether-impl:1.0.0.v20140518",
+              "children": [
+                {
+                  "groupId": "org.eclipse.aether",
+                  "artifactId": "aether-api",
+                  "version": "1.0.0.v20140518",
+                  "checksumAlgorithm": "SHA-256",
+                  "checksum": "84b98521684ab22f9528470fa6d8ab68a230e1b211623c989ba7016c306eb773",
+                  "id": "org.eclipse.aether:aether-api:1.0.0.v20140518",
+                  "parent": "org.eclipse.aether:aether-util:1.0.0.v20140518",
+                  "children": []
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "groupId": "org.eclipse.aether",
+          "artifactId": "aether-util",
+          "version": "1.0.0.v20140518",
+          "checksumAlgorithm": "SHA-256",
+          "checksum": "aff0951639837c4e3a4699a421fa79f410032f603f5c6a5bba435e98531f3984",
+          "id": "org.eclipse.aether:aether-util:1.0.0.v20140518",
+          "parent": "org.apache.maven:maven-core:3.2.5",
+          "children": [
+            {
+              "groupId": "org.eclipse.aether",
+              "artifactId": "aether-api",
+              "version": "1.0.0.v20140518",
+              "checksumAlgorithm": "SHA-256",
+              "checksum": "84b98521684ab22f9528470fa6d8ab68a230e1b211623c989ba7016c306eb773",
+              "id": "org.eclipse.aether:aether-api:1.0.0.v20140518",
+              "parent": "org.eclipse.aether:aether-util:1.0.0.v20140518",
+              "children": []
+            }
+          ]
+        },
+        {
+          "groupId": "org.eclipse.sisu",
+          "artifactId": "org.eclipse.sisu.plexus",
+          "version": "0.3.0.M1",
+          "checksumAlgorithm": "SHA-256",
+          "checksum": "35b545ead7e5513ec8c4974a984659ec68738e6761bb7c08a9876a2e901d38ae",
+          "id": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.0.M1",
+          "parent": "org.apache.maven:maven-core:3.2.5",
+          "children": [
+            {
+              "groupId": "javax.enterprise",
+              "artifactId": "cdi-api",
+              "version": "1.0",
+              "checksumAlgorithm": "SHA-256",
+              "checksum": "1f10b2204cc77c919301f20ff90461c3df1b6e6cb148be1c2d22107f4851d423",
+              "id": "javax.enterprise:cdi-api:1.0",
+              "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.0.M1",
+              "children": [
+                {
+                  "groupId": "javax.annotation",
+                  "artifactId": "jsr250-api",
+                  "version": "1.0",
+                  "checksumAlgorithm": "SHA-256",
+                  "checksum": "a1a922d0d9b6d183ed3800dfac01d1e1eb159f0e8c6f94736931c1def54a941f",
+                  "id": "javax.annotation:jsr250-api:1.0",
+                  "parent": "javax.enterprise:cdi-api:1.0",
+                  "children": []
+                },
                 {
                   "groupId": "javax.inject",
                   "artifactId": "javax.inject",
@@ -3312,287 +1520,19 @@
                   "checksumAlgorithm": "SHA-256",
                   "checksum": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
                   "id": "javax.inject:javax.inject:1",
-                  "parent": "org.codehaus.plexus:plexus-sec-dispatcher:2.0",
-                  "children": []
-                },
-                {
-                  "groupId": "org.codehaus.plexus",
-                  "artifactId": "plexus-cipher",
-                  "version": "2.0",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "9a7f1b5c5a9effd61eadfd8731452a2f76a8e79111fac391ef75ea801bea203a",
-                  "id": "org.codehaus.plexus:plexus-cipher:2.0",
-                  "parent": "org.codehaus.plexus:plexus-sec-dispatcher:2.0",
-                  "children": [
-                    {
-                      "groupId": "javax.inject",
-                      "artifactId": "javax.inject",
-                      "version": "1",
-                      "checksumAlgorithm": "SHA-256",
-                      "checksum": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
-                      "id": "javax.inject:javax.inject:1",
-                      "parent": "org.codehaus.plexus:plexus-cipher:2.0",
-                      "children": []
-                    }
-                  ]
-                },
-                {
-                  "groupId": "org.codehaus.plexus",
-                  "artifactId": "plexus-utils",
-                  "version": "3.4.1",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "52d85e04b3918722af11d12855b4a8257df96a0e76c8f4e3852e6faa851f357b",
-                  "id": "org.codehaus.plexus:plexus-utils:3.4.1",
-                  "parent": "org.codehaus.plexus:plexus-sec-dispatcher:2.0",
+                  "parent": "javax.enterprise:cdi-api:1.0",
                   "children": []
                 }
               ]
-            },
-            {
-              "groupId": "org.codehaus.plexus",
-              "artifactId": "plexus-utils",
-              "version": "3.5.1",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-              "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-              "parent": "org.apache.maven:maven-settings-builder:3.9.2",
-              "children": []
-            }
-          ]
-        },
-        {
-          "groupId": "org.apache.maven.resolver",
-          "artifactId": "maven-resolver-api",
-          "version": "1.9.10",
-          "checksumAlgorithm": "SHA-256",
-          "checksum": "5ee57c89259d0a41f56291864ca7db12349ce11eca8ef62be5680c7c244705d0",
-          "id": "org.apache.maven.resolver:maven-resolver-api:1.9.10",
-          "parent": "org.apache.maven:maven-core:3.9.2",
-          "children": []
-        },
-        {
-          "groupId": "org.apache.maven.resolver",
-          "artifactId": "maven-resolver-impl",
-          "version": "1.9.10",
-          "checksumAlgorithm": "SHA-256",
-          "checksum": "6fc7cc06dd6364805e42b89dcaec2d0875ffb1fee8774938783918cb2020f2d8",
-          "id": "org.apache.maven.resolver:maven-resolver-impl:1.9.10",
-          "parent": "org.apache.maven:maven-core:3.9.2",
-          "children": [
-            {
-              "groupId": "org.apache.maven.resolver",
-              "artifactId": "maven-resolver-api",
-              "version": "1.9.10",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "5ee57c89259d0a41f56291864ca7db12349ce11eca8ef62be5680c7c244705d0",
-              "id": "org.apache.maven.resolver:maven-resolver-api:1.9.10",
-              "parent": "org.apache.maven.resolver:maven-resolver-impl:1.9.10",
-              "children": []
-            },
-            {
-              "groupId": "org.apache.maven.resolver",
-              "artifactId": "maven-resolver-named-locks",
-              "version": "1.9.10",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "f55d2e75468509a92fc841d818283168ea458ebcb34a3011531cac812e309155",
-              "id": "org.apache.maven.resolver:maven-resolver-named-locks:1.9.10",
-              "parent": "org.apache.maven.resolver:maven-resolver-impl:1.9.10",
-              "children": [
-                {
-                  "groupId": "org.slf4j",
-                  "artifactId": "slf4j-api",
-                  "version": "1.7.36",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "d3ef575e3e4979678dc01bf1dcce51021493b4d11fb7f1be8ad982877c16a1c0",
-                  "id": "org.slf4j:slf4j-api:1.7.36",
-                  "parent": "org.apache.maven.resolver:maven-resolver-named-locks:1.9.10",
-                  "children": []
-                }
-              ]
-            },
-            {
-              "groupId": "org.apache.maven.resolver",
-              "artifactId": "maven-resolver-spi",
-              "version": "1.9.10",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "7554650b663fef31c594c75f600b2241bbed9306d1ee5637047da55e9a443df3",
-              "id": "org.apache.maven.resolver:maven-resolver-spi:1.9.10",
-              "parent": "org.apache.maven.resolver:maven-resolver-impl:1.9.10",
-              "children": [
-                {
-                  "groupId": "org.apache.maven.resolver",
-                  "artifactId": "maven-resolver-api",
-                  "version": "1.9.10",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "5ee57c89259d0a41f56291864ca7db12349ce11eca8ef62be5680c7c244705d0",
-                  "id": "org.apache.maven.resolver:maven-resolver-api:1.9.10",
-                  "parent": "org.apache.maven.resolver:maven-resolver-spi:1.9.10",
-                  "children": []
-                }
-              ]
-            },
-            {
-              "groupId": "org.apache.maven.resolver",
-              "artifactId": "maven-resolver-util",
-              "version": "1.9.10",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "c6eda39bd4b7670e7314ffa006e4dc9da48617e2a6ff26e5af118f0be6a0cdd4",
-              "id": "org.apache.maven.resolver:maven-resolver-util:1.9.10",
-              "parent": "org.apache.maven.resolver:maven-resolver-impl:1.9.10",
-              "children": [
-                {
-                  "groupId": "org.apache.maven.resolver",
-                  "artifactId": "maven-resolver-api",
-                  "version": "1.9.10",
-                  "checksumAlgorithm": "SHA-256",
-                  "checksum": "5ee57c89259d0a41f56291864ca7db12349ce11eca8ef62be5680c7c244705d0",
-                  "id": "org.apache.maven.resolver:maven-resolver-api:1.9.10",
-                  "parent": "org.apache.maven.resolver:maven-resolver-util:1.9.10",
-                  "children": []
-                }
-              ]
-            },
-            {
-              "groupId": "org.slf4j",
-              "artifactId": "slf4j-api",
-              "version": "1.7.36",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "d3ef575e3e4979678dc01bf1dcce51021493b4d11fb7f1be8ad982877c16a1c0",
-              "id": "org.slf4j:slf4j-api:1.7.36",
-              "parent": "org.apache.maven.resolver:maven-resolver-impl:1.9.10",
-              "children": []
-            }
-          ]
-        },
-        {
-          "groupId": "org.apache.maven.resolver",
-          "artifactId": "maven-resolver-spi",
-          "version": "1.9.10",
-          "checksumAlgorithm": "SHA-256",
-          "checksum": "7554650b663fef31c594c75f600b2241bbed9306d1ee5637047da55e9a443df3",
-          "id": "org.apache.maven.resolver:maven-resolver-spi:1.9.10",
-          "parent": "org.apache.maven:maven-core:3.9.2",
-          "children": [
-            {
-              "groupId": "org.apache.maven.resolver",
-              "artifactId": "maven-resolver-api",
-              "version": "1.9.10",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "5ee57c89259d0a41f56291864ca7db12349ce11eca8ef62be5680c7c244705d0",
-              "id": "org.apache.maven.resolver:maven-resolver-api:1.9.10",
-              "parent": "org.apache.maven.resolver:maven-resolver-spi:1.9.10",
-              "children": []
-            }
-          ]
-        },
-        {
-          "groupId": "org.apache.maven.resolver",
-          "artifactId": "maven-resolver-util",
-          "version": "1.9.10",
-          "checksumAlgorithm": "SHA-256",
-          "checksum": "c6eda39bd4b7670e7314ffa006e4dc9da48617e2a6ff26e5af118f0be6a0cdd4",
-          "id": "org.apache.maven.resolver:maven-resolver-util:1.9.10",
-          "parent": "org.apache.maven:maven-core:3.9.2",
-          "children": [
-            {
-              "groupId": "org.apache.maven.resolver",
-              "artifactId": "maven-resolver-api",
-              "version": "1.9.10",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "5ee57c89259d0a41f56291864ca7db12349ce11eca8ef62be5680c7c244705d0",
-              "id": "org.apache.maven.resolver:maven-resolver-api:1.9.10",
-              "parent": "org.apache.maven.resolver:maven-resolver-util:1.9.10",
-              "children": []
-            }
-          ]
-        },
-        {
-          "groupId": "org.apache.maven.shared",
-          "artifactId": "maven-shared-utils",
-          "version": "3.3.4",
-          "checksumAlgorithm": "SHA-256",
-          "checksum": "7925d9c5a0e2040d24b8fae3f612eb399cbffe5838b33ba368777dc7bddf6dda",
-          "id": "org.apache.maven.shared:maven-shared-utils:3.3.4",
-          "parent": "org.apache.maven:maven-core:3.9.2",
-          "children": []
-        },
-        {
-          "groupId": "org.codehaus.plexus",
-          "artifactId": "plexus-classworlds",
-          "version": "2.7.0",
-          "checksumAlgorithm": "SHA-256",
-          "checksum": "c60ae538ba66adbc06aae205fbe2306211d3d213ab6df3239ec03cdde2458ad6",
-          "id": "org.codehaus.plexus:plexus-classworlds:2.7.0",
-          "parent": "org.apache.maven:maven-core:3.9.2",
-          "children": []
-        },
-        {
-          "groupId": "org.codehaus.plexus",
-          "artifactId": "plexus-component-annotations",
-          "version": "2.1.0",
-          "checksumAlgorithm": "SHA-256",
-          "checksum": "bde3617ce9b5bcf9584126046080043af6a4b3baea40a3b153f02e7bbc32acac",
-          "id": "org.codehaus.plexus:plexus-component-annotations:2.1.0",
-          "parent": "org.apache.maven:maven-core:3.9.2",
-          "children": []
-        },
-        {
-          "groupId": "org.codehaus.plexus",
-          "artifactId": "plexus-interpolation",
-          "version": "1.26",
-          "checksumAlgorithm": "SHA-256",
-          "checksum": "b3b5412ce17889103ea564bcdfcf9fb3dfa540344ffeac6b538a73c9d7182662",
-          "id": "org.codehaus.plexus:plexus-interpolation:1.26",
-          "parent": "org.apache.maven:maven-core:3.9.2",
-          "children": []
-        },
-        {
-          "groupId": "org.codehaus.plexus",
-          "artifactId": "plexus-utils",
-          "version": "3.5.1",
-          "checksumAlgorithm": "SHA-256",
-          "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-          "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-          "parent": "org.apache.maven:maven-core:3.9.2",
-          "children": []
-        },
-        {
-          "groupId": "org.eclipse.sisu",
-          "artifactId": "org.eclipse.sisu.inject",
-          "version": "0.3.5",
-          "checksumAlgorithm": "SHA-256",
-          "checksum": "c5994010bcdce1d2bd603a4d50c47191ddbd7875d1157b23aaa26d33c82fda13",
-          "id": "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.5",
-          "parent": "org.apache.maven:maven-core:3.9.2",
-          "children": []
-        },
-        {
-          "groupId": "org.eclipse.sisu",
-          "artifactId": "org.eclipse.sisu.plexus",
-          "version": "0.3.5",
-          "checksumAlgorithm": "SHA-256",
-          "checksum": "7e4c61096d70826f20f7a7d55c59a5528e7aa5ad247ee2dfe544e4dd25f6a784",
-          "id": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5",
-          "parent": "org.apache.maven:maven-core:3.9.2",
-          "children": [
-            {
-              "groupId": "javax.annotation",
-              "artifactId": "javax.annotation-api",
-              "version": "1.2",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "5909b396ca3a2be10d0eea32c74ef78d816e1b4ead21de1d78de1f890d033e04",
-              "id": "javax.annotation:javax.annotation-api:1.2",
-              "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5",
-              "children": []
             },
             {
               "groupId": "org.codehaus.plexus",
               "artifactId": "plexus-classworlds",
-              "version": "2.5.2",
+              "version": "2.5.1",
               "checksumAlgorithm": "SHA-256",
-              "checksum": "b2931d41740490a8d931cbe0cfe9ac20deb66cca606e679f52522f7f534c9fd7",
-              "id": "org.codehaus.plexus:plexus-classworlds:2.5.2",
-              "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5",
+              "checksum": "de9ce33b29088c2db7c3f55ddc061c2a7a72f9c93c28faad62cc15aee26b6888",
+              "id": "org.codehaus.plexus:plexus-classworlds:2.5.1",
+              "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.0.M1",
               "children": []
             },
             {
@@ -3602,59 +1542,121 @@
               "checksumAlgorithm": "SHA-256",
               "checksum": "4df7a6a7be64b35bbccf60b5c115697f9ea3421d22674ae67135dde375fcca1f",
               "id": "org.codehaus.plexus:plexus-component-annotations:1.5.5",
-              "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5",
+              "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.0.M1",
               "children": []
             },
             {
               "groupId": "org.codehaus.plexus",
               "artifactId": "plexus-utils",
-              "version": "3.0.24",
+              "version": "2.1",
               "checksumAlgorithm": "SHA-256",
-              "checksum": "83ee748b12d06afb0ad4050a591132b3e8025fbb1990f1ed002e8b73293e69b4",
-              "id": "org.codehaus.plexus:plexus-utils:3.0.24",
-              "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5",
+              "checksum": "35608df55aa672a195d6b01573a5630a315998b3bbd06310b20eb169113923aa",
+              "id": "org.codehaus.plexus:plexus-utils:2.1",
+              "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.0.M1",
               "children": []
             },
             {
               "groupId": "org.eclipse.sisu",
               "artifactId": "org.eclipse.sisu.inject",
-              "version": "0.3.5",
+              "version": "0.3.0.M1",
               "checksumAlgorithm": "SHA-256",
-              "checksum": "c5994010bcdce1d2bd603a4d50c47191ddbd7875d1157b23aaa26d33c82fda13",
-              "id": "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.5",
-              "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5",
+              "checksum": "3a878482877e66337ab8461e7f55ab9d701f8090f889ad8938cceefa33193fe4",
+              "id": "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.0.M1",
+              "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.0.M1",
               "children": []
             }
           ]
         },
         {
-          "groupId": "org.slf4j",
-          "artifactId": "slf4j-api",
-          "version": "1.7.36",
+          "groupId": "org.sonatype.plexus",
+          "artifactId": "plexus-sec-dispatcher",
+          "version": "1.3",
           "checksumAlgorithm": "SHA-256",
-          "checksum": "d3ef575e3e4979678dc01bf1dcce51021493b4d11fb7f1be8ad982877c16a1c0",
-          "id": "org.slf4j:slf4j-api:1.7.36",
-          "parent": "org.apache.maven:maven-core:3.9.2",
-          "children": []
+          "checksum": "3b0559bb8432f28937efe6ca193ef54a8506d0075d73fd7406b9b116c6a11063",
+          "id": "org.sonatype.plexus:plexus-sec-dispatcher:1.3",
+          "parent": "org.apache.maven:maven-core:3.2.5",
+          "children": [
+            {
+              "groupId": "org.codehaus.plexus",
+              "artifactId": "plexus-utils",
+              "version": "1.5.5",
+              "checksumAlgorithm": "SHA-256",
+              "checksum": "92f38b0af28629847e461060eae84bcd7441995a5ecba785400754164fbbd1dc",
+              "id": "org.codehaus.plexus:plexus-utils:1.5.5",
+              "parent": "org.sonatype.plexus:plexus-sec-dispatcher:1.3",
+              "children": []
+            },
+            {
+              "groupId": "org.sonatype.plexus",
+              "artifactId": "plexus-cipher",
+              "version": "1.4",
+              "checksumAlgorithm": "SHA-256",
+              "checksum": "5a15fdba22669e0fdd06e10dcce6320879e1f7398fbc910cd0677b50672a78c4",
+              "id": "org.sonatype.plexus:plexus-cipher:1.4",
+              "parent": "org.sonatype.plexus:plexus-sec-dispatcher:1.3",
+              "children": []
+            }
+          ]
+        },
+        {
+          "groupId": "org.sonatype.sisu",
+          "artifactId": "sisu-guice",
+          "version": "3.2.3",
+          "checksumAlgorithm": "SHA-256",
+          "checksum": "4af7012b6d11ab585ae841130ff091dcad6531d7bf13db4d7deac91589eef4",
+          "id": "org.sonatype.sisu:sisu-guice:3.2.3",
+          "parent": "org.apache.maven:maven-core:3.2.5",
+          "children": [
+            {
+              "groupId": "aopalliance",
+              "artifactId": "aopalliance",
+              "version": "1.0",
+              "checksumAlgorithm": "SHA-256",
+              "checksum": "addec670fedcd3f113c5c8091d783280d23f75e3acb841b61a9cdb079376a08",
+              "id": "aopalliance:aopalliance:1.0",
+              "parent": "org.sonatype.sisu:sisu-guice:3.2.3",
+              "children": []
+            },
+            {
+              "groupId": "com.google.guava",
+              "artifactId": "guava",
+              "version": "16.0.1",
+              "checksumAlgorithm": "SHA-256",
+              "checksum": "a896857d07845d38c7dc5bbc0457b6d9b0f62ecffda010e5e9ec12d561f676d3",
+              "id": "com.google.guava:guava:16.0.1",
+              "parent": "org.sonatype.sisu:sisu-guice:3.2.3",
+              "children": []
+            },
+            {
+              "groupId": "javax.inject",
+              "artifactId": "javax.inject",
+              "version": "1",
+              "checksumAlgorithm": "SHA-256",
+              "checksum": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
+              "id": "javax.inject:javax.inject:1",
+              "parent": "org.sonatype.sisu:sisu-guice:3.2.3",
+              "children": []
+            }
+          ]
         }
       ]
     },
     {
       "groupId": "org.apache.maven",
       "artifactId": "maven-model",
-      "version": "3.9.2",
+      "version": "3.2.5",
       "checksumAlgorithm": "SHA-256",
-      "checksum": "c91583df8b399df87033dbb4c5efe55a0cf6f659da21714c3b0f6f5f9689e28",
-      "id": "org.apache.maven:maven-model:3.9.2",
+      "checksum": "8d439cc1661349dab1c69eed0f831336d187e162cc6d68aa4deefcff57ee0624",
+      "id": "org.apache.maven:maven-model:3.2.5",
       "children": [
         {
           "groupId": "org.codehaus.plexus",
           "artifactId": "plexus-utils",
-          "version": "3.5.1",
+          "version": "3.0.20",
           "checksumAlgorithm": "SHA-256",
-          "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-          "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-          "parent": "org.apache.maven:maven-model:3.9.2",
+          "checksum": "8f3a655545fc5b4cbf12b5eb8a154fccb0c1144423a1450511f44005a3d574a2",
+          "id": "org.codehaus.plexus:plexus-utils:3.0.20",
+          "parent": "org.apache.maven:maven-model:3.2.5",
           "children": []
         }
       ]
@@ -3662,38 +1664,28 @@
     {
       "groupId": "org.apache.maven",
       "artifactId": "maven-plugin-api",
-      "version": "3.9.2",
+      "version": "3.2.5",
       "checksumAlgorithm": "SHA-256",
-      "checksum": "27de347c74dd1d3eb984ae8611874116c486f9f0027f6a4e03f1b69d2ef4aabc",
-      "id": "org.apache.maven:maven-plugin-api:3.9.2",
+      "checksum": "194a6f0ce889ed3b0d8a9bc4d3c79541e878098b7e303e4ac76c1031850772c3",
+      "id": "org.apache.maven:maven-plugin-api:3.2.5",
       "children": [
         {
           "groupId": "org.apache.maven",
           "artifactId": "maven-artifact",
-          "version": "3.9.2",
+          "version": "3.2.5",
           "checksumAlgorithm": "SHA-256",
-          "checksum": "f2174221d412a79572817b5aa77125348f43266670b6329a9881cdccf7bbc4b1",
-          "id": "org.apache.maven:maven-artifact:3.9.2",
-          "parent": "org.apache.maven:maven-plugin-api:3.9.2",
+          "checksum": "270385907ecfbcb256fe5afb883869fd57a5c021b5242693743ef787605c6335",
+          "id": "org.apache.maven:maven-artifact:3.2.5",
+          "parent": "org.apache.maven:maven-plugin-api:3.2.5",
           "children": [
-            {
-              "groupId": "org.apache.commons",
-              "artifactId": "commons-lang3",
-              "version": "3.12.0",
-              "checksumAlgorithm": "SHA-256",
-              "checksum": "d919d904486c037f8d193412da0c92e22a9fa24230b9d67a57855c5c31c7e94e",
-              "id": "org.apache.commons:commons-lang3:3.12.0",
-              "parent": "org.apache.maven:maven-artifact:3.9.2",
-              "children": []
-            },
             {
               "groupId": "org.codehaus.plexus",
               "artifactId": "plexus-utils",
-              "version": "3.5.1",
+              "version": "3.0.20",
               "checksumAlgorithm": "SHA-256",
-              "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-              "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-              "parent": "org.apache.maven:maven-artifact:3.9.2",
+              "checksum": "8f3a655545fc5b4cbf12b5eb8a154fccb0c1144423a1450511f44005a3d574a2",
+              "id": "org.codehaus.plexus:plexus-utils:3.0.20",
+              "parent": "org.apache.maven:maven-artifact:3.2.5",
               "children": []
             }
           ]
@@ -3701,71 +1693,72 @@
         {
           "groupId": "org.apache.maven",
           "artifactId": "maven-model",
-          "version": "3.9.2",
+          "version": "3.2.5",
           "checksumAlgorithm": "SHA-256",
-          "checksum": "c91583df8b399df87033dbb4c5efe55a0cf6f659da21714c3b0f6f5f9689e28",
-          "id": "org.apache.maven:maven-model:3.9.2",
-          "parent": "org.apache.maven:maven-plugin-api:3.9.2",
+          "checksum": "8d439cc1661349dab1c69eed0f831336d187e162cc6d68aa4deefcff57ee0624",
+          "id": "org.apache.maven:maven-model:3.2.5",
+          "parent": "org.apache.maven:maven-plugin-api:3.2.5",
           "children": [
             {
               "groupId": "org.codehaus.plexus",
               "artifactId": "plexus-utils",
-              "version": "3.5.1",
+              "version": "3.0.20",
               "checksumAlgorithm": "SHA-256",
-              "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-              "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-              "parent": "org.apache.maven:maven-model:3.9.2",
+              "checksum": "8f3a655545fc5b4cbf12b5eb8a154fccb0c1144423a1450511f44005a3d574a2",
+              "id": "org.codehaus.plexus:plexus-utils:3.0.20",
+              "parent": "org.apache.maven:maven-model:3.2.5",
               "children": []
             }
           ]
         },
         {
-          "groupId": "org.codehaus.plexus",
-          "artifactId": "plexus-classworlds",
-          "version": "2.7.0",
-          "checksumAlgorithm": "SHA-256",
-          "checksum": "c60ae538ba66adbc06aae205fbe2306211d3d213ab6df3239ec03cdde2458ad6",
-          "id": "org.codehaus.plexus:plexus-classworlds:2.7.0",
-          "parent": "org.apache.maven:maven-plugin-api:3.9.2",
-          "children": []
-        },
-        {
-          "groupId": "org.codehaus.plexus",
-          "artifactId": "plexus-utils",
-          "version": "3.5.1",
-          "checksumAlgorithm": "SHA-256",
-          "checksum": "86e0255d4c879c61b4833ed7f13124e8bb679df47debb127326e7db7dd49a07b",
-          "id": "org.codehaus.plexus:plexus-utils:3.5.1",
-          "parent": "org.apache.maven:maven-plugin-api:3.9.2",
-          "children": []
-        },
-        {
           "groupId": "org.eclipse.sisu",
           "artifactId": "org.eclipse.sisu.plexus",
-          "version": "0.3.5",
+          "version": "0.3.0.M1",
           "checksumAlgorithm": "SHA-256",
-          "checksum": "7e4c61096d70826f20f7a7d55c59a5528e7aa5ad247ee2dfe544e4dd25f6a784",
-          "id": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5",
-          "parent": "org.apache.maven:maven-plugin-api:3.9.2",
+          "checksum": "35b545ead7e5513ec8c4974a984659ec68738e6761bb7c08a9876a2e901d38ae",
+          "id": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.0.M1",
+          "parent": "org.apache.maven:maven-plugin-api:3.2.5",
           "children": [
             {
-              "groupId": "javax.annotation",
-              "artifactId": "javax.annotation-api",
-              "version": "1.2",
+              "groupId": "javax.enterprise",
+              "artifactId": "cdi-api",
+              "version": "1.0",
               "checksumAlgorithm": "SHA-256",
-              "checksum": "5909b396ca3a2be10d0eea32c74ef78d816e1b4ead21de1d78de1f890d033e04",
-              "id": "javax.annotation:javax.annotation-api:1.2",
-              "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5",
-              "children": []
+              "checksum": "1f10b2204cc77c919301f20ff90461c3df1b6e6cb148be1c2d22107f4851d423",
+              "id": "javax.enterprise:cdi-api:1.0",
+              "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.0.M1",
+              "children": [
+                {
+                  "groupId": "javax.annotation",
+                  "artifactId": "jsr250-api",
+                  "version": "1.0",
+                  "checksumAlgorithm": "SHA-256",
+                  "checksum": "a1a922d0d9b6d183ed3800dfac01d1e1eb159f0e8c6f94736931c1def54a941f",
+                  "id": "javax.annotation:jsr250-api:1.0",
+                  "parent": "javax.enterprise:cdi-api:1.0",
+                  "children": []
+                },
+                {
+                  "groupId": "javax.inject",
+                  "artifactId": "javax.inject",
+                  "version": "1",
+                  "checksumAlgorithm": "SHA-256",
+                  "checksum": "91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff",
+                  "id": "javax.inject:javax.inject:1",
+                  "parent": "javax.enterprise:cdi-api:1.0",
+                  "children": []
+                }
+              ]
             },
             {
               "groupId": "org.codehaus.plexus",
               "artifactId": "plexus-classworlds",
-              "version": "2.5.2",
+              "version": "2.5.1",
               "checksumAlgorithm": "SHA-256",
-              "checksum": "b2931d41740490a8d931cbe0cfe9ac20deb66cca606e679f52522f7f534c9fd7",
-              "id": "org.codehaus.plexus:plexus-classworlds:2.5.2",
-              "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5",
+              "checksum": "de9ce33b29088c2db7c3f55ddc061c2a7a72f9c93c28faad62cc15aee26b6888",
+              "id": "org.codehaus.plexus:plexus-classworlds:2.5.1",
+              "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.0.M1",
               "children": []
             },
             {
@@ -3775,27 +1768,27 @@
               "checksumAlgorithm": "SHA-256",
               "checksum": "4df7a6a7be64b35bbccf60b5c115697f9ea3421d22674ae67135dde375fcca1f",
               "id": "org.codehaus.plexus:plexus-component-annotations:1.5.5",
-              "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5",
+              "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.0.M1",
               "children": []
             },
             {
               "groupId": "org.codehaus.plexus",
               "artifactId": "plexus-utils",
-              "version": "3.0.24",
+              "version": "2.1",
               "checksumAlgorithm": "SHA-256",
-              "checksum": "83ee748b12d06afb0ad4050a591132b3e8025fbb1990f1ed002e8b73293e69b4",
-              "id": "org.codehaus.plexus:plexus-utils:3.0.24",
-              "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5",
+              "checksum": "35608df55aa672a195d6b01573a5630a315998b3bbd06310b20eb169113923aa",
+              "id": "org.codehaus.plexus:plexus-utils:2.1",
+              "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.0.M1",
               "children": []
             },
             {
               "groupId": "org.eclipse.sisu",
               "artifactId": "org.eclipse.sisu.inject",
-              "version": "0.3.5",
+              "version": "0.3.0.M1",
               "checksumAlgorithm": "SHA-256",
-              "checksum": "c5994010bcdce1d2bd603a4d50c47191ddbd7875d1157b23aaa26d33c82fda13",
-              "id": "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.5",
-              "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.5",
+              "checksum": "3a878482877e66337ab8461e7f55ab9d701f8090f889ad8938cceefa33193fe4",
+              "id": "org.eclipse.sisu:org.eclipse.sisu.inject:0.3.0.M1",
+              "parent": "org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.0.M1",
               "children": []
             }
           ]
@@ -4008,7 +2001,18 @@
               "checksum": "88e5334c4c29a6e81c74a1d814c54a9a3b1e4fc6560a95da196fe16928095471",
               "id": "org.apache.maven.shared:maven-shared-utils:3.1.0",
               "parent": "org.apache.maven.shared:maven-common-artifact-filters:3.1.0",
-              "children": []
+              "children": [
+                {
+                  "groupId": "commons-io",
+                  "artifactId": "commons-io",
+                  "version": "2.5",
+                  "checksumAlgorithm": "SHA-256",
+                  "checksum": "a10418348d234968600ccb1d988efcbbd08716e1d96936ccc1880e7d22513474",
+                  "id": "commons-io:commons-io:2.5",
+                  "parent": "org.apache.maven.shared:maven-shared-utils:3.1.0",
+                  "children": []
+                }
+              ]
             },
             {
               "groupId": "org.sonatype.sisu",

--- a/maven_plugin/pom.xml
+++ b/maven_plugin/pom.xml
@@ -18,7 +18,7 @@
   </prerequisites>
 
   <properties>
-    <mavenVersion>3.9.2</mavenVersion>
+    <mavenVersion>3.2.5</mavenVersion>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/GenerateLockFileMojo.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/GenerateLockFileMojo.java
@@ -1,6 +1,7 @@
 package io.github.chains_project.maven_lockfile;
 
 import io.github.chains_project.maven_lockfile.data.LockFile;
+import io.github.chains_project.maven_lockfile.data.Metadata;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -48,19 +49,28 @@ public class GenerateLockFileMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "false", property = "includeMavenPlugins")
     private String includeMavenPlugins;
+
+    @Parameter(defaultValue = "${maven.version}")
+    private String mavenVersion;
+
+    @Parameter(defaultValue = "${java.version}")
+    private String javaVersion;
+
     /**
      * Generate a lock file for the dependencies of the current project.
      * @throws MojoExecutionException if the lock file could not be written or the generation failed.
      */
     public void execute() throws MojoExecutionException {
         try {
-
+            String osName = System.getProperty("os.name");
+            Metadata metadata = new Metadata(osName, mavenVersion, javaVersion);
             LockFile lockFile = LockFileFacade.generateLockFileFromProject(
                     session,
                     project,
                     dependencyCollectorBuilder,
                     dependencyResolver,
-                    Boolean.parseBoolean(includeMavenPlugins));
+                    Boolean.parseBoolean(includeMavenPlugins),
+                    metadata);
 
             Path lockFilePath = LockFileFacade.getLockFilePath(project);
             Files.writeString(lockFilePath, JsonUtils.toJson(lockFile));

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/LockFileFacade.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/LockFileFacade.java
@@ -6,6 +6,7 @@ import io.github.chains_project.maven_lockfile.data.ArtifactId;
 import io.github.chains_project.maven_lockfile.data.GroupId;
 import io.github.chains_project.maven_lockfile.data.LockFile;
 import io.github.chains_project.maven_lockfile.data.MavenPlugin;
+import io.github.chains_project.maven_lockfile.data.Metadata;
 import io.github.chains_project.maven_lockfile.data.VersionNumber;
 import io.github.chains_project.maven_lockfile.graph.DependencyGraph;
 import java.nio.file.Path;
@@ -113,6 +114,7 @@ public class LockFileFacade {
      * @param dependencyCollectorBuilder  The dependency collector builder to use for generating the dependency graph.
      * @param resolver  The dependency resolver to use for resolving the dependencies.
      * @param includeMavenPlugins  Whether to include maven plugins in the lock file.
+     * @param metadata The metadata to include in the lock file.
      * @return  A lock file for the project.
      */
     public static LockFile generateLockFileFromProject(
@@ -120,7 +122,8 @@ public class LockFileFacade {
             MavenProject project,
             DependencyCollectorBuilder dependencyCollectorBuilder,
             DependencyResolver resolver,
-            boolean includeMavenPlugins) {
+            boolean includeMavenPlugins,
+            Metadata metadata) {
         LOGGER.info("Generating lock file for project " + project.getArtifactId());
         List<MavenPlugin> plugins = new ArrayList<>();
         if (includeMavenPlugins) {
@@ -134,7 +137,8 @@ public class LockFileFacade {
                 ArtifactId.of(project.getArtifactId()),
                 VersionNumber.of(project.getVersion()),
                 roots,
-                plugins);
+                plugins,
+                metadata);
     }
 
     private static List<MavenPlugin> getAllPlugins(MavenProject project) {

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/ValidateChecksumMojo.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/ValidateChecksumMojo.java
@@ -6,6 +6,7 @@ import io.github.chains_project.maven_lockfile.data.LockFile;
 import io.github.chains_project.maven_lockfile.data.Metadata;
 import io.github.chains_project.maven_lockfile.reporting.LockFileDifference;
 import java.io.IOException;
+import java.util.Objects;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -73,7 +74,7 @@ public class ValidateChecksumMojo extends AbstractMojo {
                     dependencyResolver,
                     Boolean.parseBoolean(includeMavenPlugins),
                     metadata);
-            if (!lockFileFromFile.getMetadata().equals(lockFileFromProject.getMetadata())) {
+            if (!Objects.equals(lockFileFromFile.getMetadata(), lockFileFromProject.getMetadata())) {
                 getLog().warn(
                                 "Lock file metadata does not match project metadata. This could be due to a change in the environment.");
             }

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/LockFile.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/LockFile.java
@@ -29,21 +29,25 @@ public class LockFile {
     @SerializedName("lockFileVersion")
     private int lockfileVersion = 1; // TODO: we normally should create an enum with Name -> Numbers
 
-    private List<DependencyNode> dependencies;
+    private final List<DependencyNode> dependencies;
 
-    private List<MavenPlugin> mavenPlugins;
+    private final List<MavenPlugin> mavenPlugins;
+
+    private final Metadata metadata;
 
     public LockFile(
             GroupId groupId,
             ArtifactId name,
             VersionNumber versionNumber,
             List<DependencyNode> dependencies,
-            List<MavenPlugin> mavenPlugins) {
+            List<MavenPlugin> mavenPlugins,
+            Metadata metadata) {
         this.dependencies = dependencies == null ? Collections.emptyList() : dependencies;
         this.name = name;
         this.version = versionNumber;
         this.groupId = groupId;
         this.mavenPlugins = mavenPlugins == null ? Collections.emptyList() : mavenPlugins;
+        this.metadata = metadata;
     }
     /**
      * Create a lock file object from a serialized JSON string.
@@ -68,6 +72,12 @@ public class LockFile {
      */
     public List<MavenPlugin> getMavenPlugins() {
         return nullToEmpty(mavenPlugins);
+    }
+    /**
+     * @return the metadata about the environment in which the lock file was generated
+     */
+    public Metadata getMetadata() {
+        return metadata;
     }
 
     @Override

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/Metadata.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/Metadata.java
@@ -1,0 +1,62 @@
+package io.github.chains_project.maven_lockfile.data;
+
+import java.util.Objects;
+
+/**
+ * Metadata about the environment in which the lock file was generated. This includes the OS name, the Maven version and the Java version.
+ */
+public class Metadata {
+
+    private final String osName;
+    private final String mavenVersion;
+    private final String javaVersion;
+
+    public Metadata(String osName, String mavenVersion, String javaVersion) {
+        this.osName = osName;
+        this.mavenVersion = mavenVersion;
+        this.javaVersion = javaVersion;
+    }
+
+    /**
+     * @return the java version of the environment in which the lock file was generated
+     */
+    public String getJavaVersion() {
+        return javaVersion;
+    }
+    /**
+     * @return the mavenVersion of the environment in which the lock file was generated
+     */
+    public String getMavenVersion() {
+        return mavenVersion;
+    }
+    /**
+     * @return the osName of the environment in which the lock file was generated
+     */
+    public String getOsName() {
+        return osName;
+    }
+
+    @Override
+    public String toString() {
+        return "Metadata [osName=" + osName + ", mavenVersion=" + mavenVersion + ", javaVersion=" + javaVersion + "]";
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(osName, mavenVersion, javaVersion);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof Metadata)) {
+            return false;
+        }
+        Metadata other = (Metadata) obj;
+        return Objects.equals(osName, other.osName)
+                && Objects.equals(mavenVersion, other.mavenVersion)
+                && Objects.equals(javaVersion, other.javaVersion);
+    }
+}


### PR DESCRIPTION
In every lockfile we now record the maven, java and os version of the environment. Also we print a warning if this does not match the original one.
Integration tests for this feature are missing.

fixes #203

 