### PR TITLE
✨ Added maven-lockfile plugin for better dependency management

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -1,7 +1,7 @@
 {
   "artifactID": "maven-lockfile-parent",
   "groupID": "io.github.chains-project",
-  "version": "3.3.0-SNAPSHOT",
+  "version": "3.3.1-SNAPSHOT",
   "lockFileVersion": 1,
   "dependencies": [],
   "mavenPlugins": [

--- a/maven_plugin/lockfile.json
+++ b/maven_plugin/lockfile.json
@@ -1,7 +1,7 @@
 {
   "artifactID": "maven-lockfile",
   "groupID": "io.github.chains-project",
-  "version": "3.3.0-SNAPSHOT",
+  "version": "3.3.1-SNAPSHOT",
   "lockFileVersion": 1,
   "dependencies": [
     {

--- a/maven_plugin/pom.xml
+++ b/maven_plugin/pom.xml
@@ -276,6 +276,21 @@
             <artifactId>maven-deploy-plugin</artifactId>
             <version>3.1.1</version>
           </plugin>
+          <plugin>
+            <groupId>io.github.chains-project</groupId>
+            <artifactId>maven-lockfile</artifactId>
+            <version>3.3.0</version>
+            <configuration>
+              <includeMavenPlugins>true</includeMavenPlugins>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>validate</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
       </build>
     </profile>


### PR DESCRIPTION
A new Maven plugin is included in pom.xml to validate dependencies and prevent conflicts. The maven-lockfile plugin is configured to include all Maven plugins and performs a validation goal during the build process.