### PR TITLE
🐛 Update lockfile validation error message

### DIFF
--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/ValidateChecksumMojo.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/ValidateChecksumMojo.java
@@ -105,6 +105,15 @@ public class ValidateChecksumMojo extends AbstractMojo {
                 var diff = LockFileDifference.diff(lockFileFromFile, lockFileFromProject);
                 StringBuilder sb = new StringBuilder();
                 sb.append("Lock file validation failed. Differences:");
+                sb.append("\n");
+                sb.append("Your lockfile from file is for:"
+                        + lockFileFromFile.getGroupId().getValue() + ":"
+                        + lockFileFromFile.getName().getValue() + ":"
+                        + lockFileFromFile.getVersion().getValue() + "\n");
+                sb.append("Your generated lockfile is for:"
+                        + lockFileFromProject.getGroupId().getValue() + ":"
+                        + lockFileFromProject.getName().getValue() + ":"
+                        + lockFileFromProject.getVersion().getValue() + "\n");
                 sb.append("Missing dependencies in lock file:\n ");
                 sb.append(JsonUtils.toJson(diff.getMissingDependenciesInFile()));
                 sb.append("\n");

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/LockFile.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/LockFile.java
@@ -66,7 +66,24 @@ public class LockFile {
     public List<DependencyNode> getDependencies() {
         return nullToEmpty(dependencies);
     }
-
+    /**
+     * @return the groupId
+     */
+    public GroupId getGroupId() {
+        return groupId;
+    }
+    /**
+     * @return the name
+     */
+    public ArtifactId getName() {
+        return name;
+    }
+    /**
+     * @return the version
+     */
+    public VersionNumber getVersion() {
+        return version;
+    }
     /**
      * @return the mavenPlugins
      */


### PR DESCRIPTION
The lock file validation failed due to differences found. The error message now displays the missing dependencies and details about the lock-files version differences.