### PR TITLE
✨ Removed redundant Maven plugin from pom.xml

### DIFF
--- a/maven_plugin/pom.xml
+++ b/maven_plugin/pom.xml
@@ -276,21 +276,6 @@
             <artifactId>maven-deploy-plugin</artifactId>
             <version>3.1.1</version>
           </plugin>
-          <plugin>
-            <groupId>io.github.chains-project</groupId>
-            <artifactId>maven-lockfile</artifactId>
-            <version>3.3.0</version>
-            <configuration>
-              <includeMavenPlugins>true</includeMavenPlugins>
-            </configuration>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>validate</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
         </plugins>
       </build>
     </profile>


### PR DESCRIPTION
The <io.github.chains-project.maven-lockfile> plugin was removed from the Maven build process as it was deemed redundant. It no longer participated in the plugin's execution stages.