### PR TITLE
✨ Regenerate lockfile if workflow file is changed

### DIFF
--- a/template/action.yml
+++ b/template/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: 'Include Maven plugins in the lockfile'
     required: false
     default: 'false'
+  workflow-filename:
+    description: 'Name of the workflow file'
+    required: false
+    default: 'Lockfile.yml'
 runs:
   using: "composite"
   steps:
@@ -53,6 +57,7 @@ runs:
       with:
         files: |
               **/pom.xml
+              **/${{ inputs.workflow-filename}}
     - name: print all changed files
       run: echo all changed files are ${{ steps.changed-files.outputs.all_changed_files }}
       shell: bash


### PR DESCRIPTION
Add support for specifying a custom name for the workflow file in the input. This enables users to use any name they want for the file, rather than being restricted to using the default name.

This commit also updates the step for changed files to include the workflow file, when specified in the input.