### PR TITLE
📝 Update lockfile versions & add metadata

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -69,7 +69,7 @@ runs:
       shell: bash
 
     - id: action
-      run: ~/.jbang/bin/jbang --repos 'mavencentral' io.github.chains-project:maven-lockfile-github-action:3.3.1-SNAPSHOT
+      run: ~/.jbang/bin/jbang --repos 'mavencentral' io.github.chains-project:maven-lockfile-github-action:3.4.1-SNAPSHOT
       shell: bash
       env:
         JSON_INPUTS: ${{ toJSON(inputs) }}

--- a/github_action/pom.xml
+++ b/github_action/pom.xml
@@ -4,13 +4,15 @@
   <parent>
     <groupId>io.github.chains-project</groupId>
     <artifactId>maven-lockfile-parent</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.4.1-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
   <groupId>io.github.chains-project</groupId>
   <artifactId>maven-lockfile-github-action</artifactId>
-  <version>3.3.1-SNAPSHOT</version>
-  <name>maven-lockfile-github-action-</name>
+  <version>3.4.1-SNAPSHOT</version>
+  <name>maven-lockfile-github-action</name>
+  <description>This is a github action for maven-lockfile. It allows the integration of maven-lockfile in your github development workflow.</description>
+  <url>https://github.com/chains-project/maven-lockfile</url>
   <distributionManagement>
     <repository>
       <id>github</id>

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -32,7 +32,7 @@ files:
   active: ALWAYS
   globs:
     - pattern: target/*.buildinfo
-    - pattern: target/**/*cyclonedx.json
+    - pattern: target/staging-deploy/**/*cyclonedx.json
 signing:
   active: ALWAYS
   armored: true
@@ -42,6 +42,7 @@ deploy:
       maven-central:
         active: ALWAYS
         url: https://s01.oss.sonatype.org/service/local
+        snapshotUrl: https://s01.oss.sonatype.org/content/repositories/snapshots/
         closeRepository: true
         releaseRepository: true
         stagingRepositories:

--- a/lockfile.json
+++ b/lockfile.json
@@ -1,7 +1,7 @@
 {
   "artifactID": "maven-lockfile-parent",
   "groupID": "io.github.chains-project",
-  "version": "3.3.1-SNAPSHOT",
+  "version": "3.4.1-SNAPSHOT",
   "lockFileVersion": 1,
   "dependencies": [],
   "mavenPlugins": [

--- a/maven_plugin/lockfile.json
+++ b/maven_plugin/lockfile.json
@@ -1,7 +1,7 @@
 {
   "artifactID": "maven-lockfile",
   "groupID": "io.github.chains-project",
-  "version": "3.3.1-SNAPSHOT",
+  "version": "3.4.1-SNAPSHOT",
   "lockFileVersion": 1,
   "dependencies": [
     {

--- a/maven_plugin/pom.xml
+++ b/maven_plugin/pom.xml
@@ -4,14 +4,21 @@
   <parent>
     <groupId>io.github.chains-project</groupId>
     <artifactId>maven-lockfile-parent</artifactId>
-    <version>3.3.1-SNAPSHOT</version>
+    <version>3.4.1-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
   <groupId>io.github.chains-project</groupId>
   <artifactId>maven-lockfile</artifactId>
-  <version>3.3.1-SNAPSHOT</version>
+  <version>3.4.1-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
   <name>maven-lockfile-plugin</name>
+  <description>This plugin is a state-of-the-art solution that can be used to validate the integrity
+    of a maven repository.
+    It does this by generating a lock file that contains the checksums of all the artifacts in the
+    repository.
+    The lock file can then be used to validate the integrity of the repository.
+    This guards the supply chain against malicious actors that might tamper with the artifacts in
+    the repository.</description>
   <url>https://github.com/chains-project/maven-lockfile</url>
   <prerequisites>
     <maven>${mavenVersion}</maven>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.chains-project</groupId>
   <artifactId>maven-lockfile-parent</artifactId>
-  <version>3.3.1-SNAPSHOT</version>
+  <version>3.4.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>maven-lockfile-parent</name>
   <description>This plugin is a state-of-the-art solution that can be used to validate the integrity
@@ -38,7 +38,7 @@
     <url>https://github.com/chains-project/maven-lockfile.git</url>
   </scm>
   <properties>
-    <project.build.outputTimestamp>2023-06-14T21:46:29Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2023-06-19T10:59:10Z</project.build.outputTimestamp>
   </properties>
   <build>
     <plugins>
@@ -46,6 +46,7 @@
         <groupId>org.cyclonedx</groupId>
         <artifactId>cyclonedx-maven-plugin</artifactId>
         <version>2.7.9</version>
+        <inherited>true</inherited>
         <configuration>
           <includeTestScope>true</includeTestScope>
           <outputDirectory>${project.build.directory}/staging-deploy/io/github/chains-project/${project.artifactId}/</outputDirectory>


### PR DESCRIPTION
The version of `maven-lockfile-parent`, `maven-lockfile-github-action`, `maven-lockfile`, and the root pom are changed from `3.3.1-SNAPSHOT` to `3.4.1-SNAPSHOT`. Additionally, metadata such as the `description` and `url` are added to `maven-lockfile-github-action` and `maven-lockfile`. Finally, `maven-lockfile` is further improved with a new `description` that explains how it guards against malicious actors.