### PR TITLE
🔍 Add dependency license checker to Qodana

### DIFF
--- a/qodana.yml
+++ b/qodana.yml
@@ -18,6 +18,7 @@ groups:
       - UseOfClone
       - UnstableApiUsage
 inspections:
+  - name: CheckDependencyLicenses
   - group: ExcludedInspections
     enabled: false
   - group: IncludedPaths


### PR DESCRIPTION
Included dependency license checker and enabled an inspection group for selected paths while disabling an excluded inspection group.