### PR TITLE
fix: 🐛 Include leading zeros in checksums

### DIFF
--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/ValidateChecksumMojo.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/ValidateChecksumMojo.java
@@ -55,8 +55,8 @@ public class ValidateChecksumMojo extends AbstractLockfileMojo {
                 sb.append("Lock file validation failed. Differences:");
                 sb.append("\n");
                 sb.append("Your lockfile from file is for:"
-                        + lockFileFromFile.getGroupId().getValue() + ":"
-                        + lockFileFromFile.getName().getValue() + ":"
+                        + lockFileFromFile.getGroupId().getValue()
+                        + ":" + lockFileFromFile.getName().getValue() + ":"
                         + lockFileFromFile.getVersion().getValue() + "\n");
                 sb.append("Your generated lockfile is for:"
                         + lockFileFromProject.getGroupId().getValue() + ":"

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/checksum/FileSystemChecksumCalculator.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/checksum/FileSystemChecksumCalculator.java
@@ -1,6 +1,6 @@
 package io.github.chains_project.maven_lockfile.checksum;
 
-import java.math.BigInteger;
+import com.google.common.io.BaseEncoding;
 import java.nio.file.Files;
 import java.security.MessageDigest;
 import java.util.List;
@@ -63,7 +63,8 @@ public class FileSystemChecksumCalculator extends AbstractChecksumCalculator {
             MessageDigest messageDigest = MessageDigest.getInstance(checksumAlgorithm);
             byte[] fileBuffer = Files.readAllBytes(artifact.getFile().toPath());
             byte[] artifactHash = messageDigest.digest(fileBuffer);
-            return Optional.of(new BigInteger(1, artifactHash).toString(16));
+            BaseEncoding baseEncoding = BaseEncoding.base16();
+            return Optional.of(baseEncoding.encode(artifactHash));
         } catch (Exception e) {
             LOGGER.warn("Could not calculate checksum for artifact " + artifact, e);
             return Optional.empty();


### PR DESCRIPTION
Add support for leading zeros in checksums.
Thanks to @SirYwell and @I-Al-Istannen for pointing this out.

Co-authored-by: i-al-istannen <i-al-istannen@users.noreply.github.com>
Co-authored-by: SirYwell <hannesgreule@outlook.de>