### PR TITLE
🐛 Update the dependency resolution mechanism and fix duplicates in freeze

### DIFF
--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/FreezeDependencyMojo.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/FreezeDependencyMojo.java
@@ -61,12 +61,12 @@ public class FreezeDependencyMojo extends AbstractMojo {
             List<Dependency> pomDeps = pom.getDependencies();
             Map<String, Dependency> pomDepMap = new HashMap<>();
             for (var pomDep : pomDeps) {
-                String key = pomDep.getGroupId() + ":" + pomDep.getArtifactId() + ":" + pomDep.getScope();
+                String key = pomDep.getGroupId() + ":" + pomDep.getArtifactId();
                 pomDepMap.put(key, pomDep);
             }
 
             for (Dependency dep : filteredDeps) {
-                String key = dep.getGroupId() + ":" + dep.getArtifactId() + ":" + dep.getScope();
+                String key = dep.getGroupId() + ":" + dep.getArtifactId();
                 var pomDep = pomDepMap.get(key);
                 if (pomDep != null) {
                     pomDep.setVersion(dep.getVersion());

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/FreezeDependencyMojo.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/FreezeDependencyMojo.java
@@ -2,16 +2,6 @@ package io.github.chains_project.maven_lockfile;
 
 import io.github.chains_project.maven_lockfile.data.LockFile;
 import io.github.chains_project.maven_lockfile.graph.DependencyNode;
-import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Queue;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
@@ -25,6 +15,12 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.*;
 
 /**
  * Freeze the dependencies of a project. Every dependency will be locked to a specific version.
@@ -48,13 +44,14 @@ public class FreezeDependencyMojo extends AbstractMojo {
 
     /**
      * Freezes the dependencies of the project. Every dependency will be locked to a specific version.
+     *
      * @throws MojoExecutionException if the lock file is invalid or could not be read.
      */
     public void execute() throws MojoExecutionException {
         File pomFile = project.getFile();
         try {
             LockFile lockFileFromFile = LockFile.readLockFile(LockFileFacade.getLockFilePath(project));
-            List<Dependency> filteredDeps = getHighestVersionDependency(lockFileFromFile);
+            List<Dependency> filteredDeps = getNearestVersionDependency(lockFileFromFile);
             // read the pom with a pomfile reader:
             MavenXpp3Reader reader = new MavenXpp3Reader();
             Model pom = reader.read(new FileReader(pomFile));
@@ -78,41 +75,32 @@ public class FreezeDependencyMojo extends AbstractMojo {
             // write the pom back to the pom file:
             MavenXpp3Writer writer = new MavenXpp3Writer();
             writer.write(new FileWriter(pomFile), pom);
-        } catch (IOException e) {
-            throw new MojoExecutionException("Could not freeze versions", e);
-        } catch (XmlPullParserException e) {
+        } catch (IOException | XmlPullParserException e) {
             throw new MojoExecutionException("Could not freeze versions", e);
         }
     }
 
-    private List<Dependency> getHighestVersionDependency(LockFile lockFileFromFile) {
+    private List<Dependency> getNearestVersionDependency(LockFile lockFileFromFile) {
         var deps = lockFileFromFile.getDependencies();
-        List<Dependency> filteredDeps = new ArrayList<>();
+        Map<String, Dependency> nearestVersionMap = new HashMap<>();
         Queue<DependencyNode> depQueue = new ArrayDeque<>(deps);
         while (!depQueue.isEmpty()) {
-            var dep = depQueue.poll();
-            filteredDeps.add(toMavenDependency(dep));
-            depQueue.addAll(dep.getChildren());
-        }
-        // Create a map to store the highest version of each dependency
-        Map<String, Dependency> highestVersionMap = new HashMap<>();
-        // Iterate over the filtered dependencies and update the highest version map
-        for (Dependency dep : filteredDeps) {
+            var depNode = depQueue.poll();
+            Dependency dep = toMavenDependency(depNode);
             String key = dep.getGroupId() + ":" + dep.getArtifactId();
-            Dependency highestVersionDep = highestVersionMap.get(key);
-            if (highestVersionDep == null || dep.getVersion().compareTo(highestVersionDep.getVersion()) > 0) {
-                highestVersionMap.put(key, dep);
+            if (depNode.isIncluded()) {
+                nearestVersionMap.put(key, dep);
             }
+            depQueue.addAll(depNode.getChildren());
         }
-
-        // Replace the filtered dependencies list with the values from the highest version map
-        filteredDeps = new ArrayList<>(highestVersionMap.values());
-        return filteredDeps;
+        return new ArrayList<>(nearestVersionMap.values());
     }
+
     /**
      * Converts a DependencyNode to a Maven Model Dependency.
-     * @param dep  the DependencyNode to convert
-     * @return  the converted Dependency
+     *
+     * @param dep the DependencyNode to convert
+     * @return the converted Dependency
      */
     private Dependency toMavenDependency(DependencyNode dep) {
         Dependency mavenDep = new Dependency();

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/FreezeDependencyMojo.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/FreezeDependencyMojo.java
@@ -2,6 +2,11 @@ package io.github.chains_project.maven_lockfile;
 
 import io.github.chains_project.maven_lockfile.data.LockFile;
 import io.github.chains_project.maven_lockfile.graph.DependencyNode;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.*;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
@@ -15,12 +20,6 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
-
-import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.util.*;
 
 /**
  * Freeze the dependencies of a project. Every dependency will be locked to a specific version.

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/graph/DependencyGraph.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/graph/DependencyGraph.java
@@ -7,13 +7,12 @@ import io.github.chains_project.maven_lockfile.data.ArtifactId;
 import io.github.chains_project.maven_lockfile.data.GroupId;
 import io.github.chains_project.maven_lockfile.data.MavenScope;
 import io.github.chains_project.maven_lockfile.data.VersionNumber;
-import org.apache.maven.shared.dependency.graph.internal.SpyingDependencyNodeUtils;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import org.apache.maven.shared.dependency.graph.internal.SpyingDependencyNodeUtils;
 
 public class DependencyGraph {
 

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/graph/DependencyNode.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/graph/DependencyNode.java
@@ -5,11 +5,12 @@ import io.github.chains_project.maven_lockfile.data.ArtifactId;
 import io.github.chains_project.maven_lockfile.data.GroupId;
 import io.github.chains_project.maven_lockfile.data.MavenScope;
 import io.github.chains_project.maven_lockfile.data.VersionNumber;
+
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import javax.annotation.Nullable;
 
 /**
  * This class represents a node in the dependency graph. It contains the artifactId, groupId and version  of the dependency.
@@ -26,6 +27,9 @@ public class DependencyNode implements Comparable<DependencyNode> {
 
     @Nullable
     private String selectedVersion;
+
+    @Nullable
+    private boolean included;
 
     NodeId id;
 
@@ -124,6 +128,20 @@ public class DependencyNode implements Comparable<DependencyNode> {
      */
     public String getSelectedVersion() {
         return selectedVersion;
+    }
+
+    /**
+     * @param included the state of inclusion
+     */
+    public void setIncluded(boolean included) {
+        this.included = included;
+    }
+
+    /**
+     * @return the state of inclusion
+     */
+    public boolean isIncluded() {
+        return included;
     }
 
     @Override

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/graph/DependencyNode.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/graph/DependencyNode.java
@@ -5,12 +5,11 @@ import io.github.chains_project.maven_lockfile.data.ArtifactId;
 import io.github.chains_project.maven_lockfile.data.GroupId;
 import io.github.chains_project.maven_lockfile.data.MavenScope;
 import io.github.chains_project.maven_lockfile.data.VersionNumber;
-
-import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import javax.annotation.Nullable;
 
 /**
  * This class represents a node in the dependency graph. It contains the artifactId, groupId and version  of the dependency.


### PR DESCRIPTION
Fixes 

- https://github.com/chains-project/maven-lockfile/issues/687
- https://github.com/chains-project/maven-lockfile/issues/686
- https://github.com/chains-project/maven-lockfile/issues/683
 - Adds a new field "included" to the lockfile to track the dependency conflict resolution.  