### PR TITLE
⬇️ Downgrade maven version

### DIFF
--- a/maven_plugin/pom.xml
+++ b/maven_plugin/pom.xml
@@ -24,7 +24,7 @@
     <maven>${mavenVersion}</maven>
   </prerequisites>
   <properties>
-    <mavenVersion>3.9.6</mavenVersion>
+    <mavenVersion>3.2.5</mavenVersion>
     <maven.compiler.target>11</maven.compiler.target>
     <maven.compiler.source>11</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/renovate.json
+++ b/renovate.json
@@ -50,10 +50,12 @@
       "semanticCommitType": ":bookmark:",
       "automerge": true,
       "automergeType": "pr"
+    },
+    {
+      "matchPackagePatterns": [
+        "org.apache.maven:"
+      ],
+      "enabled": false
     }
-  ],
-  "ignoreDeps": [
-    "maven-core",
-    "mavenVersion"
   ]
 }


### PR DESCRIPTION
Maven packages are supposed to be ignored by renovate, but the previous renovate configs do not seem to be working. The maven version was updated by renovate, and that causes the workflows to fail. 
AFAIK, there are not any other functionality issues with updating the maven version, so we can update the workflows to use the updated version. But until it is confirmed that there are not any other issues, I'm downgrading maven to the original version before the renovate update. 