### PR TITLE
:construction_worker: feat: trigger github action on changed lockfile.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ jobs:
             include-maven-plugins: true
 
 ```
-If a pom.xml file is changed, this action will add a commit with the updated lockfile to the pull request.
+If a pom.xml or lockfile.json file is changed, this action will add a commit with the updated lockfile to the pull request.
 Otherwise, it will validate the lockfile and fail if the lockfile is incorrect.
 A lockfile is incorrect if any dependency has changed since the lockfile was generated. This includes versions and checksums.
 

--- a/action.yml
+++ b/action.yml
@@ -52,12 +52,13 @@ runs:
       shell: bash
 
 
-    - name: Get all changed pom.xml file(s)
+    - name: Get all changed pom.xml and lockfile.json file(s)
       id: changed-files
       uses: tj-actions/changed-files@48d8f15b2aaa3d255ca5af3eba4870f807ce6b3c # v45
       with:
         files: |
               **/pom.xml
+              **/lockfile.json
               **/${{ inputs.workflow-filename}}
     - name: print all changed files
       run: echo all changed files are ${{ steps.changed-files.outputs.all_changed_files }}

--- a/action.yml
+++ b/action.yml
@@ -52,13 +52,12 @@ runs:
       shell: bash
 
 
-    - name: Get all changed pom.xml and lockfile.json file(s)
+    - name: Get all changed pom.xml file(s)
       id: changed-files
       uses: tj-actions/changed-files@48d8f15b2aaa3d255ca5af3eba4870f807ce6b3c # v45
       with:
         files: |
               **/pom.xml
-              **/lockfile.json
               **/${{ inputs.workflow-filename}}
     - name: print all changed files
       run: echo all changed files are ${{ steps.changed-files.outputs.all_changed_files }}

--- a/template/action.yml
+++ b/template/action.yml
@@ -52,12 +52,13 @@ runs:
       shell: bash
 
 
-    - name: Get all changed pom.xml file(s)
+    - name: Get all changed pom.xml and lockfile.json file(s)
       id: changed-files
       uses: tj-actions/changed-files@48d8f15b2aaa3d255ca5af3eba4870f807ce6b3c # v45
       with:
         files: |
               **/pom.xml
+              **/lockfile.json
               **/${{ inputs.workflow-filename}}
     - name: print all changed files
       run: echo all changed files are ${{ steps.changed-files.outputs.all_changed_files }}


### PR DESCRIPTION
The github action would only trigger when the pom.xml was changed. If someone makes a PR where the lockfile.json is changed but the pom stays the same. The maven-lockfile github action would not trigger and a faulty lockfile might accidentally get commited. Someone could for example modify a checksum thus enabeling tampered dependencies to pass a verify check later.

Se #881 