### PR TITLE
fix alphabetical order

### DIFF
--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/graph/DependencyNode.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/graph/DependencyNode.java
@@ -233,7 +233,7 @@ public class DependencyNode implements Comparable<DependencyNode> {
     }
 
     public String getComparatorString() {
-        return this.getGroupId().getValue() + ":" + this.getArtifactId().getValue() + "@"
-                + this.getVersion().getValue() + "-" + this.getChecksum();
+        return this.getGroupId().getValue() + "#" + this.getArtifactId().getValue() + "#"
+                + this.getVersion().getValue() + "#" + this.getChecksum();
     }
 }


### PR DESCRIPTION
This minor fix to better handle alphabetical order.

The "#" character has a lower ASCII code then ".", ":" or other special character, so the dependencies are actually listed in a more natural order, based first on group and then on artifact id.

For instance, before:

and
group: a.b
artifactId: z

group: a.b.c
artifactId: a

where ordered in this way:

1. a.b.c:a
2. a.b:z

now instead they are ordered in this way:

1. a.b#z
2. a.b.c#a
