### PR TITLE
🛠️ Do not push lockfile as part of release

### DIFF
--- a/.github/workflows/jreleaser.yml
+++ b/.github/workflows/jreleaser.yml
@@ -67,6 +67,7 @@ jobs:
         with:
             github-token: ${{ secrets.GITHUB_TOKEN }}
             include-maven-plugins: true
+            commit-lockfile: false
       - name: set branchname to next version
         run: echo "BRANCH_NAME=release/$NEXT_VERSION" >> $GITHUB_ENV
       - name: Set release version


### PR DESCRIPTION
Triggers error when trying to release as main branch is protected. Lockfile is guaranteed to be updated by CI.