### PR TITLE
👷 ci: Verify lockfile in case commit-lockfile is false

### DIFF
--- a/.github/workflows/LockfilePR.yml
+++ b/.github/workflows/LockfilePR.yml
@@ -36,3 +36,4 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           include-maven-plugins: true
+          commit-lockfile: false # verify lockfile is up-to-date (not possible to update lockfile in forks)

--- a/README.md
+++ b/README.md
@@ -186,6 +186,19 @@ A lockfile is incorrect if any dependency has changed since the lockfile was gen
 
 ⚠️**Warning**: Commiting the changed lockfile does not work for pull requests from forks. See https://github.com/EndBug/add-and-commit#working-with-prs. You can add a personal access token to your repository to resolve this issue.
 It still works for pull requests from the same repository. Renovate also works with this action because these PRs are created from the same repository.
+
+### Arguments
+
+- `github-token` (required): The GitHub token used to commit the lockfile to the repository.
+- `commit-lockfile` (optional, default=true): Whether to commit the lockfile to the repository. If this is true, the action can be used to update the lockfile in e.g. pull requests (se warning about pull-requests from forks). The action **will not** fail if the lockfile is outdated/invalid but push the correct version. If this is false, the action be used to verify the lockfile is correct. The action **will** fail on an outdated/invalid lockfile.
+- `commit-message` (optional, default='chore: update lockfile'): The commit message for the lockfile if `commit-lockfile` is true.
+- `commit-author` (optional, default='github\_actions'): The author for the lockfile commit if `commit-lockfile` is true. GitHub provides three values for this field.
+  - github\_actor -> `UserName <UserName@users.noreply.github.com>`
+  - user\_info -> `Your Display Name <your-actual@email.com>`
+  - github\_actions -> `github-actions <email associated with the github logo>`
+- `include-maven-plugins` (optional, default='false'): Whether to include Maven plugins in the lockfile.
+- `workflow-filename` (optional, default='Lockfile.yml'): The name of the workflow file, to automatically trigger lockfile generation when the workflow is updated.
+
 ## Related work
 
 Here we list some related work that we found while researching this topic.

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ It still works for pull requests from the same repository. Renovate also works w
 ### Arguments
 
 - `github-token` (required): The GitHub token used to commit the lockfile to the repository.
-- `commit-lockfile` (optional, default=true): Whether to commit the lockfile to the repository. If this is true, the action can be used to update the lockfile in e.g. pull requests (se warning about pull-requests from forks). The action **will not** fail if the lockfile is outdated/invalid but push the correct version. If this is false, the action be used to verify the lockfile is correct. The action **will** fail on an outdated/invalid lockfile.
+- `commit-lockfile` (optional, default=true): Whether to commit an updated lockfile to the repository. The action can be used to update lockfiles automatically in e.g. pull requests (se warning about pull-requests from forks). If this is true and the pom.xml or workflow-file has updated it will create and commit the new lockfile - the action **will not** fail if the lockfile is outdated or invalid and only push the correct version. If this is false or the pom.xml and workflow-file remain unchanged, the action be used to verify the lockfile is correct - the action **will** fail in case of an outdated or invalid lockfile.
 - `commit-message` (optional, default='chore: update lockfile'): The commit message for the lockfile if `commit-lockfile` is true.
 - `commit-author` (optional, default='github\_actions'): The author for the lockfile commit if `commit-lockfile` is true. GitHub provides three values for this field.
   - github\_actor -> `UserName <UserName@users.noreply.github.com>`

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
     description: 'GitHub token'
     required: true
   commit-lockfile: 
-    description: 'Commit the lockfile to the repository'
+    description: 'Commit the lockfile to the repository in case the pom.xml or workflow file has updated. If this is false or the pom.xml and workflow.yml files are unchanged the action will verify the current lockfile.json.'
     required: false
     default: 'true'
   commit-message:
@@ -58,7 +58,6 @@ runs:
       with:
         files: |
               **/pom.xml
-              **/lockfile.json
               **/${{ inputs.workflow-filename}}
     - name: print all changed files
       run: echo all changed files are ${{ steps.changed-files.outputs.all_changed_files }}
@@ -68,6 +67,9 @@ runs:
       shell: bash
     - name: print POM-CHANGED
       run: echo "pom changed ${{ env.POM_CHANGED }}"
+      shell: bash
+    - name: Set COMMIT_UPDATED_LOCKFILE environment variable
+      run: echo "COMMIT_UPDATED_LOCKFILE=${{ inputs.commit-lockfile }}" >> $GITHUB_ENV
       shell: bash
 
     - id: action

--- a/github_action/src/main/java/io/github/chains_project/maven_lockfile/GithubAction.java
+++ b/github_action/src/main/java/io/github/chains_project/maven_lockfile/GithubAction.java
@@ -25,7 +25,11 @@ public class GithubAction {
     void run(Inputs inputs, Commands commands, Context context) {
 
         boolean includeMavenPlugins = inputs.getBoolean("include-maven-plugins").orElse(false);
-        if (Boolean.parseBoolean(System.getenv("POM_CHANGED"))) {
+
+        boolean pomChanged = Boolean.parseBoolean(System.getenv("POM_CHANGED"));
+        boolean commitUpdatedLockfile = Boolean.parseBoolean(System.getenv("COMMIT_UPDATED_LOCKFILE"));
+
+        if (pomChanged && commitUpdatedLockfile) {
             commands.group("maven-lockfile");
             commands.notice("Pom file changed, running lockfile generation");
             commands.endGroup();

--- a/template/action.yml
+++ b/template/action.yml
@@ -8,7 +8,7 @@ inputs:
     description: 'GitHub token'
     required: true
   commit-lockfile: 
-    description: 'Commit the lockfile to the repository'
+    description: 'Commit the lockfile to the repository in case the pom.xml or workflow file has updated. If this is false or the pom.xml and workflow.yml files are unchanged the action will verify the current lockfile.json.'
     required: false
     default: 'true'
   commit-message:
@@ -58,7 +58,6 @@ runs:
       with:
         files: |
               **/pom.xml
-              **/lockfile.json
               **/${{ inputs.workflow-filename}}
     - name: print all changed files
       run: echo all changed files are ${{ steps.changed-files.outputs.all_changed_files }}
@@ -68,6 +67,9 @@ runs:
       shell: bash
     - name: print POM-CHANGED
       run: echo "pom changed ${{ env.POM_CHANGED }}"
+      shell: bash
+    - name: Set COMMIT_UPDATED_LOCKFILE environment variable
+      run: echo "COMMIT_UPDATED_LOCKFILE=${{ inputs.commit-lockfile }}" >> $GITHUB_ENV
       shell: bash
 
     - id: action


### PR DESCRIPTION
In case `commit-lockfile` is false it will verify the lockfile instead of commiting a new one. Previously if you set `commit-lockfile` and only wanted it to check the lockfile, in case the pom.xml had updated. It would create the new lockfile, not commit it, and then successfully finish the action.

It now allways runs the verify in case commit-lockfile is false, if commit-lockfile is true it will verify if pom is same and update/commit if pom has changed.

Added documentation in the README.md for the action parameters.