### PR TITLE
💚  fix ci: Do not try to commit lockfile to main branch in relesae

### DIFF
--- a/.github/workflows/jreleaser.yml
+++ b/.github/workflows/jreleaser.yml
@@ -67,6 +67,7 @@ jobs:
         with:
             github-token: ${{ secrets.GITHUB_TOKEN }}
             include-maven-plugins: true
+            commit-lockfile: false
       - name: set branchname to next version
         run: echo "BRANCH_NAME=release/$NEXT_VERSION" >> $GITHUB_ENV
       - name: Set release version


### PR DESCRIPTION
This is a temporary fix, I want to do the release using 5.2.4 which is not yet released. This way it will do the release but will not verify the lockfile (as it runs 5.2.0 and #880 is not implemented). We can then update to 5.2.4 which has #880 merged and will validate.

The pom.xml is updated, and we do know that lockfile.json is correct from the action running on the main branch.