### PR TITLE
💚 fix ci: Fix erroneous indentation in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,10 +49,10 @@ runs:
         token: ${{ inputs.github-token }}
     - name: Setup Java
       uses: actions/setup-java@7a6d8a8234af8eb26422e24e3006232cccaa061b # v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: maven
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: maven
     - name: Set up Maven
       uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
       with:

--- a/template/action.yml
+++ b/template/action.yml
@@ -49,10 +49,10 @@ runs:
         token: ${{ inputs.github-token }}
     - name: Setup Java
       uses: actions/setup-java@7a6d8a8234af8eb26422e24e3006232cccaa061b # v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: maven
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: maven
     - name: Set up Maven
       uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
       with:


### PR DESCRIPTION
This has been a journey. Because of an update to quarkus the CI now requires Java 17 in the github aciton. Do note that the maven plugin is still compiled and works with Java 11.

Because the action needed to be updated a release was required before the new version could be used. Unfortunately some releases (e.g. 5.3.0) will not work in CI since quarkus was automatically updated and no CI test caught that it required Java 17, thus merging it and it went with the 5.3.0 release while it still used Java 11 in the action.yml.

