### PR TITLE
📝 👷 docs: ci: Document and update syncronizing lockfile with release

### DIFF
--- a/.github/workflows/jreleaser.yml
+++ b/.github/workflows/jreleaser.yml
@@ -38,9 +38,6 @@ jobs:
         uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
         with:
           maven-version: 3.9.6
-      - id: install-jbang
-        run: curl -Ls https://sh.jbang.dev | bash -s - app setup
-        shell: bash
       - name: Set git user
         run: |
           git config --global user.name "GitHub Actions Bot"
@@ -78,10 +75,7 @@ jobs:
       - name: Generate Readme
         run : mvn generate-resources resources:copy-resources
       - name: run maven-lockfile (generate new lockfile for release version)
-        env:
-          POM_CHANGED: true # the version has changed, new lockfile is needed
-          COMMIT_UPDATED_LOCKFILE: true
-        run: ~/.jbang/bin/jbang --repos 'mavencentral' io.github.chains-project:maven-lockfile-github-action:5.3.5
+        run: mvn io.github.chains-project:maven-lockfile:5.3.5 generate
         shell: bash
       - name: commit changes
         run: |
@@ -130,10 +124,7 @@ jobs:
       - name: Generate Readme
         run : mvn generate-resources resources:copy-resources -q
       - name: run maven-lockfile (generate new lockfile for -SNAPSHOT version)
-        env:
-          POM_CHANGED: true # the version has changed, new lockfile is needed
-          COMMIT_UPDATED_LOCKFILE: true
-        run: ~/.jbang/bin/jbang --repos 'mavencentral' io.github.chains-project:maven-lockfile-github-action:5.3.5
+        run: mvn io.github.chains-project:maven-lockfile:5.3.5 generate
         shell: bash
 # Commit and push changes
       - name: Commit & Push changes

--- a/.github/workflows/jreleaser.yml
+++ b/.github/workflows/jreleaser.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Generate Readme
         run : mvn generate-resources resources:copy-resources
       - name: run maven-lockfile (generate new lockfile for release version)
-        run: mvn io.github.chains-project:maven-lockfile:5.3.5 generate
+        run: mvn io.github.chains-project:maven-lockfile:5.3.5:generate
         shell: bash
       - name: commit changes
         run: |
@@ -124,7 +124,7 @@ jobs:
       - name: Generate Readme
         run : mvn generate-resources resources:copy-resources -q
       - name: run maven-lockfile (generate new lockfile for -SNAPSHOT version)
-        run: mvn io.github.chains-project:maven-lockfile:5.3.5 generate
+        run: mvn io.github.chains-project:maven-lockfile:5.3.5:generate
         shell: bash
 # Commit and push changes
       - name: Commit & Push changes

--- a/README.md
+++ b/README.md
@@ -206,11 +206,11 @@ If you are setting the `-SNAPSHOT` version in the release action/script as well 
 
 As an example, the steps for the CI in maven-lockfile is:
 * set the version from `X.Y.Z-SNAPSHOT` to `X.Y.Z` in `pom.xml`
-* run maven-lockfile using `mvn io.github.chains-project:maven-lockfile generate`
+* run maven-lockfile using `mvn io.github.chains-project:maven-lockfile:5.3.5:generate`
 * build and release
 * create `Releasing version X.Y.Z` commit and tag it with `vX.Y.Z`
 * set the version to `X.Y.(Z+1)-SNAPSHOT` in `pom.xml`
-* run maven-lockfile using `mvn io.github.chains-project:maven-lockfile generate`
+* run maven-lockfile using `mvn io.github.chains-project:maven-lockfile:5.3.5:generate`
 * create `Setting SNAPSHOT version X.Y.(Z+1)-SNAPSHOT` commit
 
 ## Related work

--- a/README.md
+++ b/README.md
@@ -198,6 +198,22 @@ It still works for pull requests from the same repository. Renovate also works w
 - `include-maven-plugins` (optional, default='false'): Whether to include Maven plugins in the lockfile.
 - `lockfile-name` (optional, default="lockfile.json"): The name of the lockfile to generate/validate.
 - `workflow-filename` (optional, default='Lockfile.yml'): The name of the workflow file, to automatically trigger lockfile generation when the workflow is updated.
+- `ref` (optional, default='`${{ github.event.pull_request.head.ref }}`'): The branch, tag, or SHA to checkout and run maven-lockfile on. Defaults to the head ref of the pull request that triggered the workflow.
+- `repository` (optional, default='`${{ github.event.pull_request.head.repo.full_name }}`'): The full name of the repository to checkout (in owner/repo format). Defaults to the repository containing the pull request that triggered the workflow.
+
+### Using Action in Release with `-SNAPSHOT`-versions (synchronizing lockfile with release)
+
+If you are updating your POM.xml during your release (e.g. by using `mvn version:set`) to remove `-SNAPSHOT` suffixes or increase the version during the release process the lockfile will need to be regenerated as well or the commit tagged with the release will contain a lockfile with the wrong version. 
+If you are setting the `-SNAPSHOT` version in the release action/script as well it is a good idea to update the lockfile to avoid a separate `chore: lockfile` commit. 
+
+As an example, the steps for the CI in maven-lockfile is:
+* set the version from `X.Y.Z-SNAPSHOT` to `X.Y.Z` in `pom.xml`
+* run maven-lockfile
+* build and release
+* create `Releasing version X.Y.Z` commit and tag it with `vX.Y.Z`
+* set the version to `X.Y.(Z+1)-SNAPSHOT` in `pom.xml`
+* run maven-lockfile
+* create `Setting SNAPSHOT version X.Y.(Z+1)-SNAPSHOT` commit
 
 ## Related work
 

--- a/README.md
+++ b/README.md
@@ -198,8 +198,6 @@ It still works for pull requests from the same repository. Renovate also works w
 - `include-maven-plugins` (optional, default='false'): Whether to include Maven plugins in the lockfile.
 - `lockfile-name` (optional, default="lockfile.json"): The name of the lockfile to generate/validate.
 - `workflow-filename` (optional, default='Lockfile.yml'): The name of the workflow file, to automatically trigger lockfile generation when the workflow is updated.
-- `ref` (optional, default='`${{ github.event.pull_request.head.ref }}`'): The branch, tag, or SHA to checkout and run maven-lockfile on. Defaults to the head ref of the pull request that triggered the workflow.
-- `repository` (optional, default='`${{ github.event.pull_request.head.repo.full_name }}`'): The full name of the repository to checkout (in owner/repo format). Defaults to the repository containing the pull request that triggered the workflow.
 
 ### Using Action in Release with `-SNAPSHOT`-versions (synchronizing lockfile with release)
 
@@ -208,11 +206,11 @@ If you are setting the `-SNAPSHOT` version in the release action/script as well 
 
 As an example, the steps for the CI in maven-lockfile is:
 * set the version from `X.Y.Z-SNAPSHOT` to `X.Y.Z` in `pom.xml`
-* run maven-lockfile
+* run maven-lockfile using `mvn io.github.chains-project:maven-lockfile generate`
 * build and release
 * create `Releasing version X.Y.Z` commit and tag it with `vX.Y.Z`
 * set the version to `X.Y.(Z+1)-SNAPSHOT` in `pom.xml`
-* run maven-lockfile
+* run maven-lockfile using `mvn io.github.chains-project:maven-lockfile generate`
 * create `Setting SNAPSHOT version X.Y.(Z+1)-SNAPSHOT` commit
 
 ## Related work

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,14 @@ inputs:
     description: 'Name of the workflow file'
     required: false
     default: 'Lockfile.yml'
+  ref:
+    description: 'The branch, tag, or SHA to checkout. Defaults to the head ref of the pull request that triggered the workflow.'
+    required: false
+    default: ${{ github.event.pull_request.head.ref }}
+  repository:
+    description: 'The full name of the repository to checkout (in owner/repo format). Defaults to the repository containing the pull request that triggered the workflow.'
+    required: false
+    default: ${{ github.event.pull_request.head.repo.full_name }}
 runs:
   using: "composite"
   steps:
@@ -44,8 +52,8 @@ runs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
         fetch-depth: 0
-        ref: ${{ github.event.pull_request.head.ref }}
-        repository: ${{github.event.pull_request.head.repo.full_name}}
+        ref: ${{ inputs.ref }}
+        repository: ${{ inputs.repository }}
         token: ${{ inputs.github-token }}
     - name: Setup Java
       uses: actions/setup-java@7a6d8a8234af8eb26422e24e3006232cccaa061b # v4

--- a/action.yml
+++ b/action.yml
@@ -37,14 +37,6 @@ inputs:
     description: 'Name of the workflow file'
     required: false
     default: 'Lockfile.yml'
-  ref:
-    description: 'The branch, tag, or SHA to checkout. Defaults to the head ref of the pull request that triggered the workflow.'
-    required: false
-    default: ${{ github.event.pull_request.head.ref }}
-  repository:
-    description: 'The full name of the repository to checkout (in owner/repo format). Defaults to the repository containing the pull request that triggered the workflow.'
-    required: false
-    default: ${{ github.event.pull_request.head.repo.full_name }}
 runs:
   using: "composite"
   steps:
@@ -52,8 +44,8 @@ runs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
         fetch-depth: 0
-        ref: ${{ inputs.ref }}
-        repository: ${{ inputs.repository }}
+        ref: ${{ github.event.pull_request.head.ref }}
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
         token: ${{ inputs.github-token }}
     - name: Setup Java
       uses: actions/setup-java@7a6d8a8234af8eb26422e24e3006232cccaa061b # v4

--- a/template/action.yml
+++ b/template/action.yml
@@ -37,6 +37,14 @@ inputs:
     description: 'Name of the workflow file'
     required: false
     default: 'Lockfile.yml'
+  ref:
+    description: 'The branch, tag, or SHA to checkout. Defaults to the head ref of the pull request that triggered the workflow.'
+    required: false
+    default: ${{ github.event.pull_request.head.ref }}
+  repository:
+    description: 'The full name of the repository to checkout (in owner/repo format). Defaults to the repository containing the pull request that triggered the workflow.'
+    required: false
+    default: ${{ github.event.pull_request.head.repo.full_name }}
 runs:
   using: "composite"
   steps:
@@ -44,8 +52,8 @@ runs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
         fetch-depth: 0
-        ref: ${{ github.event.pull_request.head.ref }}
-        repository: ${{github.event.pull_request.head.repo.full_name}}
+        ref: ${{ inputs.ref }}
+        repository: ${{ inputs.repository }}
         token: ${{ inputs.github-token }}
     - name: Setup Java
       uses: actions/setup-java@7a6d8a8234af8eb26422e24e3006232cccaa061b # v4

--- a/template/action.yml
+++ b/template/action.yml
@@ -37,14 +37,6 @@ inputs:
     description: 'Name of the workflow file'
     required: false
     default: 'Lockfile.yml'
-  ref:
-    description: 'The branch, tag, or SHA to checkout. Defaults to the head ref of the pull request that triggered the workflow.'
-    required: false
-    default: ${{ github.event.pull_request.head.ref }}
-  repository:
-    description: 'The full name of the repository to checkout (in owner/repo format). Defaults to the repository containing the pull request that triggered the workflow.'
-    required: false
-    default: ${{ github.event.pull_request.head.repo.full_name }}
 runs:
   using: "composite"
   steps:
@@ -52,8 +44,8 @@ runs:
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:
         fetch-depth: 0
-        ref: ${{ inputs.ref }}
-        repository: ${{ inputs.repository }}
+        ref: ${{ github.event.pull_request.head.ref }}
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
         token: ${{ inputs.github-token }}
     - name: Setup Java
       uses: actions/setup-java@7a6d8a8234af8eb26422e24e3006232cccaa061b # v4


### PR DESCRIPTION
See #1042.

The project itself currently runs maven-lockfile directly using `jbang` in the relase action. Some more thought has to be put into if/how the maven-lockfile/action.yml should/could be used instead. It would be more convenient as it automatically set up the environment needed with java, maven and jbang. But during the release action it must be able to be run on newly created (not yet pushed) branches, on updated pom.xml's that are not commited, etc.