### PR TITLE
✨ feat: add dirty-waters to CI

### DIFF
--- a/.github/workflows/code-qualitiy.yml
+++ b/.github/workflows/code-qualitiy.yml
@@ -1,6 +1,11 @@
 name: Maven test
 on:
   workflow_dispatch:
+    inputs:
+      ignore_cache:
+        description: "Ignore the repository cache for this run"
+        required: false
+        default: "false"
   pull_request:
 
 permissions:
@@ -77,7 +82,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Dirty Waters Analysis
-        uses: chains-project/dirty-waters-action@v1.6
+        uses: chains-project/dirty-waters-action@v1.7
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           package_manager: maven

--- a/.github/workflows/code-qualitiy.yml
+++ b/.github/workflows/code-qualitiy.yml
@@ -82,10 +82,8 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Dirty Waters Analysis
-        uses: chains-project/dirty-waters-action@v1.10
+        uses: chains-project/dirty-waters-action@v1.11.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           package_manager: maven
-          project_repo: ${{ github.repository }}
-          latest_commit_sha: ${{ github.sha }}
-          github_event_before: ${{ github.event.before }}
+          gradual_report: true

--- a/.github/workflows/code-qualitiy.yml
+++ b/.github/workflows/code-qualitiy.yml
@@ -84,7 +84,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Dirty Waters Analysis
-        uses: chains-project/dirty-waters-action@v1.11.9
+        uses: chains-project/dirty-waters-action@v1.11.14
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           package_manager: maven

--- a/.github/workflows/code-qualitiy.yml
+++ b/.github/workflows/code-qualitiy.yml
@@ -72,6 +72,8 @@ jobs:
   dirty-waters:
     runs-on:
         ubuntu-latest
+    permissions:
+      pull-requests: write # To comment on a Pull Request
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/code-qualitiy.yml
+++ b/.github/workflows/code-qualitiy.yml
@@ -82,7 +82,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Dirty Waters Analysis
-        uses: chains-project/dirty-waters-action@v1.11.2
+        uses: chains-project/dirty-waters-action@v1.11.9
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           package_manager: maven

--- a/.github/workflows/code-qualitiy.yml
+++ b/.github/workflows/code-qualitiy.yml
@@ -64,3 +64,23 @@ jobs:
         run: mvn --batch-mode --update-snapshots clean install
       - name: Run reproducibility check
         run: mvn clean install
+  dirty-waters:
+    runs-on:
+        ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Setup JDK17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Dirty Waters Analysis
+        uses: chains-project/dirty-waters-action@v1.6
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          package_manager: maven
+          project_repo: ${{ github.repository }}
+          latest_commit_sha: ${{ github.sha }}
+          github_event_before: ${{github.event.before}}

--- a/.github/workflows/code-qualitiy.yml
+++ b/.github/workflows/code-qualitiy.yml
@@ -82,10 +82,10 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Dirty Waters Analysis
-        uses: chains-project/dirty-waters-action@v1.7
+        uses: chains-project/dirty-waters-action@v1.9
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           package_manager: maven
           project_repo: ${{ github.repository }}
           latest_commit_sha: ${{ github.sha }}
-          github_event_before: ${{github.event.before}}
+          github_event_before: ${{ github.event.before }}

--- a/.github/workflows/code-qualitiy.yml
+++ b/.github/workflows/code-qualitiy.yml
@@ -82,7 +82,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Dirty Waters Analysis
-        uses: chains-project/dirty-waters-action@v1.9
+        uses: chains-project/dirty-waters-action@v1.10
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           package_manager: maven

--- a/.github/workflows/code-qualitiy.yml
+++ b/.github/workflows/code-qualitiy.yml
@@ -84,7 +84,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Dirty Waters Analysis
-        uses: chains-project/dirty-waters-action@v1.11.14
+        uses: chains-project/dirty-waters-action@v1.11.19
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           package_manager: maven


### PR DESCRIPTION
cc @monperrus @Stamp9

Relates to https://github.com/INRIA/spoon/issues/5216, https://github.com/chains-project/dirty-waters/issues/37, https://github.com/chains-project/dirty-waters/issues/58

Key notes:

- [ ] `x_to_fail` parameter: the percentage of a single non-high severity issue present among the dependencies for the CI to break. It defaults to 5%, so what should it be here?
- [ ] `comment_on_commit`: whether the reports are allowed to be pasted as comments in the commits, in the case of high-severity issues breaking CI. Defaults to false, what do we want here?
- [ ] `allow_pr_comments`: whether the reports are allowed to be pasted as comments in pull requests. Defaults to true, what do we want here?
- [ ] By default, only static analysis happens. Do we want differential to be performed in certain scenarios too? If so, which ones?
- [ ] Gradual reporting is enabled by default -- only one of the reported smells has its table displayed per time, with the higher severity issues showing up first.
- [ ] Which maven build commands should be ran before running the dirty-waters action (if any)?

For more information on the action, see the [wiki](https://github.com/chains-project/dirty-waters-action/wiki).