### PR TITLE
👷 ci: Use version 5.4.0 with removed non-allowlisted github actions

### DIFF
--- a/.github/workflows/Lockfile.yml
+++ b/.github/workflows/Lockfile.yml
@@ -26,7 +26,7 @@ jobs:
             sh.jbang.dev:443
 
       - name: run maven-lockfile
-        uses: chains-project/maven-lockfile@7a3323799269e0f3f1c1921411bb04aadf98eb77 # 5.4.0
+        uses: chains-project/maven-lockfile@7a3323799269e0f3f1c1921411bb04aadf98eb77 # v5.4.0
         with:
           github-token: ${{ secrets.JRELEASER_GITHUB_TOKEN }}
           include-maven-plugins: true

--- a/.github/workflows/Lockfile.yml
+++ b/.github/workflows/Lockfile.yml
@@ -26,7 +26,7 @@ jobs:
             sh.jbang.dev:443
 
       - name: run maven-lockfile
-        uses: chains-project/maven-lockfile@bdabb56b82feb242cd543af007b333bd8276e44e # v5.3.5
+        uses: chains-project/maven-lockfile@7a3323799269e0f3f1c1921411bb04aadf98eb77 # 5.4.0
         with:
           github-token: ${{ secrets.JRELEASER_GITHUB_TOKEN }}
           include-maven-plugins: true

--- a/.github/workflows/LockfilePR.yml
+++ b/.github/workflows/LockfilePR.yml
@@ -25,14 +25,14 @@ jobs:
 
       - name: run maven-lockfile
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: chains-project/maven-lockfile@7a3323799269e0f3f1c1921411bb04aadf98eb77 # 5.4.0
+        uses: chains-project/maven-lockfile@7a3323799269e0f3f1c1921411bb04aadf98eb77 # v5.4.0
         with:
           github-token: ${{ secrets.JRELEASER_GITHUB_TOKEN }}
           include-maven-plugins: true
     
       - name: run maven-lockfile (fork/external)
         if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
-        uses: chains-project/maven-lockfile@7a3323799269e0f3f1c1921411bb04aadf98eb77 # 5.4.0
+        uses: chains-project/maven-lockfile@7a3323799269e0f3f1c1921411bb04aadf98eb77 # v5.4.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           include-maven-plugins: true

--- a/.github/workflows/LockfilePR.yml
+++ b/.github/workflows/LockfilePR.yml
@@ -25,14 +25,14 @@ jobs:
 
       - name: run maven-lockfile
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: chains-project/maven-lockfile@bdabb56b82feb242cd543af007b333bd8276e44e # v5.3.5
+        uses: chains-project/maven-lockfile@7a3323799269e0f3f1c1921411bb04aadf98eb77 # 5.4.0
         with:
           github-token: ${{ secrets.JRELEASER_GITHUB_TOKEN }}
           include-maven-plugins: true
     
       - name: run maven-lockfile (fork/external)
         if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
-        uses: chains-project/maven-lockfile@bdabb56b82feb242cd543af007b333bd8276e44e # v5.3.5
+        uses: chains-project/maven-lockfile@7a3323799269e0f3f1c1921411bb04aadf98eb77 # 5.4.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           include-maven-plugins: true

--- a/.github/workflows/jreleaser.yml
+++ b/.github/workflows/jreleaser.yml
@@ -64,7 +64,7 @@ jobs:
         if: ${{ github.event.inputs.version == 'major'  || github.event.inputs.version == 'minor' }}
         run: echo "NEXT_VERSION=$(semver next ${{ github.event.inputs.version }} $CURRENT_VERSION)" >> $GITHUB_ENV
       - name: run maven-lockfile (validate lockfile)
-        uses: chains-project/maven-lockfile@7a3323799269e0f3f1c1921411bb04aadf98eb77 # 5.4.0
+        uses: chains-project/maven-lockfile@7a3323799269e0f3f1c1921411bb04aadf98eb77 # v5.4.0
         with:
             github-token: ${{ secrets.GITHUB_TOKEN }}
             include-maven-plugins: true

--- a/.github/workflows/jreleaser.yml
+++ b/.github/workflows/jreleaser.yml
@@ -64,7 +64,7 @@ jobs:
         if: ${{ github.event.inputs.version == 'major'  || github.event.inputs.version == 'minor' }}
         run: echo "NEXT_VERSION=$(semver next ${{ github.event.inputs.version }} $CURRENT_VERSION)" >> $GITHUB_ENV
       - name: run maven-lockfile (validate lockfile)
-        uses: chains-project/maven-lockfile@6d8b811f6ff24135623a50e511d75dcad2402cf2 # v5.3.6-SNAPSHOT
+        uses: chains-project/maven-lockfile@7a3323799269e0f3f1c1921411bb04aadf98eb77 # 5.4.0
         with:
             github-token: ${{ secrets.GITHUB_TOKEN }}
             include-maven-plugins: true
@@ -76,7 +76,7 @@ jobs:
       - name: Generate Readme
         run : mvn generate-resources resources:copy-resources
       - name: run maven-lockfile (generate new lockfile for release version)
-        run: mvn io.github.chains-project:maven-lockfile:5.3.5:generate
+        run: mvn io.github.chains-project:maven-lockfile:5.4.0:generate
         shell: bash
       - name: commit changes
         run: |
@@ -125,7 +125,7 @@ jobs:
       - name: Generate Readme
         run : mvn generate-resources resources:copy-resources -q
       - name: run maven-lockfile (generate new lockfile for -SNAPSHOT version)
-        run: mvn io.github.chains-project:maven-lockfile:5.3.5:generate
+        run: mvn io.github.chains-project:maven-lockfile:5.4.0:generate
         shell: bash
 # Commit and push changes
       - name: Commit & Push changes

--- a/.github/workflows/jreleaser.yml
+++ b/.github/workflows/jreleaser.yml
@@ -64,7 +64,7 @@ jobs:
         if: ${{ github.event.inputs.version == 'major'  || github.event.inputs.version == 'minor' }}
         run: echo "NEXT_VERSION=$(semver next ${{ github.event.inputs.version }} $CURRENT_VERSION)" >> $GITHUB_ENV
       - name: run maven-lockfile (validate lockfile)
-        uses: chains-project/maven-lockfile@7a3323799269e0f3f1c1921411bb04aadf98eb77 # v5.4.0
+        uses: chains-project/maven-lockfile@6d8b811f6ff24135623a50e511d75dcad2402cf2 # v5.3.6-SNAPSHOT
         with:
             github-token: ${{ secrets.GITHUB_TOKEN }}
             include-maven-plugins: true

--- a/.github/workflows/regenerate-lockfile.yml
+++ b/.github/workflows/regenerate-lockfile.yml
@@ -24,6 +24,6 @@ jobs:
             sh.jbang.dev:443
 
       - name: run maven-lockfile
-        uses: chains-project/maven-lockfile@bdabb56b82feb242cd543af007b333bd8276e44e # v5.3.5
+        uses: chains-project/maven-lockfile@7a3323799269e0f3f1c1921411bb04aadf98eb77 # 5.4.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/regenerate-lockfile.yml
+++ b/.github/workflows/regenerate-lockfile.yml
@@ -24,6 +24,6 @@ jobs:
             sh.jbang.dev:443
 
       - name: run maven-lockfile
-        uses: chains-project/maven-lockfile@7a3323799269e0f3f1c1921411bb04aadf98eb77 # 5.4.0
+        uses: chains-project/maven-lockfile@7a3323799269e0f3f1c1921411bb04aadf98eb77 # v5.4.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -47,21 +47,17 @@ runs:
       run: curl -Ls https://sh.jbang.dev | bash -s - app setup
       shell: bash
     - name: Get all changed pom.xml and workflow file(s)
-      id: detect-changes
-      run: |
-        CHANGED_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} -- '**/pom.xml' '**/${{ inputs.workflow-filename }}')
-        echo "CHANGED_FILES=$CHANGED_FILES" >> $GITHUB_ENV
-      shell: bash
-    - name: Print all changed files
-      run: echo "All changed files are $CHANGED_FILES"
+      id: changed-files
+      uses: tj-actions/changed-files@d6e91a2266cdb9d62096cebf1e8546899c6aa18f # v45
+      with:
+        files: |
+              **/pom.xml
+              **/${{ inputs.workflow-filename}}
+    - name: print all changed files
+      run: echo all changed files are ${{ steps.changed-files.outputs.all_changed_files }}
       shell: bash
     - name: Set POM_CHANGED environment variable
-      run: |
-        if [[ -n "$CHANGED_FILES" ]]; then
-          echo "POM_CHANGED=true" >> $GITHUB_ENV
-        else
-          echo "POM_CHANGED=false" >> $GITHUB_ENV
-        fi
+      run: echo "POM_CHANGED=${{ steps.changed-files.outputs.any_changed}}" >> $GITHUB_ENV
       shell: bash
     - name: print POM-CHANGED
       run: echo "pom changed ${{ env.POM_CHANGED }}"
@@ -70,7 +66,7 @@ runs:
       run: echo "COMMIT_UPDATED_LOCKFILE=${{ inputs.commit-lockfile }}" >> $GITHUB_ENV
       shell: bash
     - id: action
-      run: ~/.jbang/bin/jbang --repos 'mavencentral' io.github.chains-project:maven-lockfile-github-action:5.3.6-SNAPSHOT
+      run: ~/.jbang/bin/jbang --repos 'mavencentral' io.github.chains-project:maven-lockfile-github-action:5.4.1-SNAPSHOT
       shell: bash
       env:
         JSON_INPUTS: ${{ toJSON(inputs) }}

--- a/action.yml
+++ b/action.yml
@@ -70,7 +70,7 @@ runs:
       run: echo "COMMIT_UPDATED_LOCKFILE=${{ inputs.commit-lockfile }}" >> $GITHUB_ENV
       shell: bash
     - id: action
-      run: ~/.jbang/bin/jbang --repos 'mavencentral' io.github.chains-project:maven-lockfile-github-action:5.3.5
+      run: ~/.jbang/bin/jbang --repos 'mavencentral' io.github.chains-project:maven-lockfile-github-action:5.3.6-SNAPSHOT
       shell: bash
       env:
         JSON_INPUTS: ${{ toJSON(inputs) }}

--- a/template/action.yml
+++ b/template/action.yml
@@ -70,7 +70,7 @@ runs:
       run: echo "COMMIT_UPDATED_LOCKFILE=${{ inputs.commit-lockfile }}" >> $GITHUB_ENV
       shell: bash
     - id: action
-      run: ~/.jbang/bin/jbang --repos 'mavencentral' io.github.chains-project:maven-lockfile-github-action:5.3.5
+      run: ~/.jbang/bin/jbang --repos 'mavencentral' io.github.chains-project:maven-lockfile-github-action:${project.version}
       shell: bash
       env:
         JSON_INPUTS: ${{ toJSON(inputs) }}

--- a/template/action.yml
+++ b/template/action.yml
@@ -47,21 +47,17 @@ runs:
       run: curl -Ls https://sh.jbang.dev | bash -s - app setup
       shell: bash
     - name: Get all changed pom.xml and workflow file(s)
-      id: detect-changes
-      run: |
-        CHANGED_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} -- '**/pom.xml' '**/${{ inputs.workflow-filename }}')
-        echo "CHANGED_FILES=$CHANGED_FILES" >> $GITHUB_ENV
-      shell: bash
-    - name: Print all changed files
-      run: echo "All changed files are $CHANGED_FILES"
+      id: changed-files
+      uses: tj-actions/changed-files@d6e91a2266cdb9d62096cebf1e8546899c6aa18f # v45
+      with:
+        files: |
+              **/pom.xml
+              **/${{ inputs.workflow-filename}}
+    - name: print all changed files
+      run: echo all changed files are ${{ steps.changed-files.outputs.all_changed_files }}
       shell: bash
     - name: Set POM_CHANGED environment variable
-      run: |
-        if [[ -n "$CHANGED_FILES" ]]; then
-          echo "POM_CHANGED=true" >> $GITHUB_ENV
-        else
-          echo "POM_CHANGED=false" >> $GITHUB_ENV
-        fi
+      run: echo "POM_CHANGED=${{ steps.changed-files.outputs.any_changed}}" >> $GITHUB_ENV
       shell: bash
     - name: print POM-CHANGED
       run: echo "pom changed ${{ env.POM_CHANGED }}"


### PR DESCRIPTION
5.4.1 will have to be used, see #1085 . Changed-files has been allowlisted.