### PR TITLE
:broom: chore: remove digest updates as tags are mutable

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
     "helpers:pinGitHubActionDigests"

--- a/renovate.json
+++ b/renovate.json
@@ -15,10 +15,7 @@
         "major",
         "minor",
         "patch",
-        "pin",
-        "digest",
-        "fix",
-        "action"
+        "pin"
       ],
       "automerge": true,
       "automergeType": "pr",

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,9 @@
     "41898282+github-actions[bot]@users.noreply.github.com",
     "github-actions[bot]@users.noreply.github.com"
   ],
+  "digest": {
+    "enabled": false
+  },
   "semanticCommitType": ":arrow_up:",
   "semanticCommits": true,
   "packageRules": [
@@ -42,7 +45,6 @@
     },
     {
       "updateTypes": [
-        "digest",
         "bump"
       ],
       "semanticCommitType": ":bookmark:",


### PR DESCRIPTION
We remove renovate updates for digest as we saw in #1111 that a malicious commit can be pointed by latest tag. However, we are still prone to attack if attacker releases the malicious commit with a new tag.

