### PR TITLE
👷 ci: Reset action to current version and use release 5.4.2

### DIFF
--- a/.github/workflows/Lockfile.yml
+++ b/.github/workflows/Lockfile.yml
@@ -26,7 +26,7 @@ jobs:
             sh.jbang.dev:443
 
       - name: run maven-lockfile
-        uses: chains-project/maven-lockfile@c9d7656e5a161eddff354c8159a199ecd8133473 # v5.4.1+ (interim)
+        uses: chains-project/maven-lockfile@dd58d822ff049b321fc93bfc3902780c7257e680 # v5.4.2
         with:
           github-token: ${{ secrets.JRELEASER_GITHUB_TOKEN }}
           include-maven-plugins: true

--- a/.github/workflows/LockfilePR.yml
+++ b/.github/workflows/LockfilePR.yml
@@ -25,14 +25,14 @@ jobs:
 
       - name: run maven-lockfile
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: chains-project/maven-lockfile@c9d7656e5a161eddff354c8159a199ecd8133473 # v5.4.1+ (interim)
+        uses: chains-project/maven-lockfile@dd58d822ff049b321fc93bfc3902780c7257e680 # v5.4.2
         with:
           github-token: ${{ secrets.JRELEASER_GITHUB_TOKEN }}
           include-maven-plugins: true
     
       - name: run maven-lockfile (fork/external)
         if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
-        uses: chains-project/maven-lockfile@c9d7656e5a161eddff354c8159a199ecd8133473 # v5.4.1+ (interim)
+        uses: chains-project/maven-lockfile@dd58d822ff049b321fc93bfc3902780c7257e680 # v5.4.2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           include-maven-plugins: true

--- a/.github/workflows/jreleaser.yml
+++ b/.github/workflows/jreleaser.yml
@@ -64,7 +64,7 @@ jobs:
         if: ${{ github.event.inputs.version == 'major'  || github.event.inputs.version == 'minor' }}
         run: echo "NEXT_VERSION=$(semver next ${{ github.event.inputs.version }} $CURRENT_VERSION)" >> $GITHUB_ENV
       - name: run maven-lockfile (validate lockfile)
-        uses: chains-project/maven-lockfile@c9d7656e5a161eddff354c8159a199ecd8133473 # v5.4.1+ (interim)
+        uses: chains-project/maven-lockfile@dd58d822ff049b321fc93bfc3902780c7257e680 # v5.4.2
         with:
             github-token: ${{ secrets.GITHUB_TOKEN }}
             include-maven-plugins: true

--- a/.github/workflows/jreleaser.yml
+++ b/.github/workflows/jreleaser.yml
@@ -163,7 +163,7 @@ jobs:
 # Log failure:
       - name: JReleaser release output
         if: always()
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: jreleaser-release
           path: |

--- a/.github/workflows/regenerate-lockfile.yml
+++ b/.github/workflows/regenerate-lockfile.yml
@@ -24,6 +24,6 @@ jobs:
             sh.jbang.dev:443
 
       - name: run maven-lockfile
-        uses: chains-project/maven-lockfile@c9d7656e5a161eddff354c8159a199ecd8133473 # v5.4.1+ (interim)
+        uses: chains-project/maven-lockfile@dd58d822ff049b321fc93bfc3902780c7257e680 # v5.4.2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -80,7 +80,7 @@ runs:
       run: echo "COMMIT_UPDATED_LOCKFILE=${{ inputs.commit-lockfile }}" >> $GITHUB_ENV
       shell: bash
     - id: action
-      run: ~/.jbang/bin/jbang --repos 'mavencentral' io.github.chains-project:maven-lockfile-github-action:5.4.1
+      run: ~/.jbang/bin/jbang --repos 'mavencentral' io.github.chains-project:maven-lockfile-github-action:5.4.3-SNAPSHOT
       shell: bash
       env:
         JSON_INPUTS: ${{ toJSON(inputs) }}

--- a/template/action.yml
+++ b/template/action.yml
@@ -80,7 +80,7 @@ runs:
       run: echo "COMMIT_UPDATED_LOCKFILE=${{ inputs.commit-lockfile }}" >> $GITHUB_ENV
       shell: bash
     - id: action
-      run: ~/.jbang/bin/jbang --repos 'mavencentral' io.github.chains-project:maven-lockfile-github-action:5.4.1
+      run: ~/.jbang/bin/jbang --repos 'mavencentral' io.github.chains-project:maven-lockfile-github-action:${project.version}
       shell: bash
       env:
         JSON_INPUTS: ${{ toJSON(inputs) }}


### PR DESCRIPTION
After #1129, a new release with a working action has been created. This resets from the interim commit with the working action to a release.