### PR TITLE
🚀 build: Remove comment in maven.config for older maven versions

### DIFF
--- a/.github/workflows/publish-action-artifact.yml
+++ b/.github/workflows/publish-action-artifact.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - main
 permissions:
-  id-token: write
   contents: read
 jobs:
   build-and-push-action:
@@ -14,6 +13,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
 
     steps:
       - name: Harden Runner

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,2 +1,1 @@
-# Do not sign .sha1,.md5 for sigstore.json files. Automatic for maven > 3.9.2. See https://github.com/sigstore/sigstore-java/tree/main/sigstore-maven-plugin#github-actions-oidc-support
 -Daether.checksums.omitChecksumsForExtensions=.asc,.sigstore.json


### PR DESCRIPTION
Some older maven versions and other tooling does not handle comments in maven.config.