### PR TITLE
👷 ci: Run release action in environment release

### DIFF
--- a/.github/workflows/jreleaser.yml
+++ b/.github/workflows/jreleaser.yml
@@ -23,6 +23,8 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    environment: release
+
     steps:
       - uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
         with:


### PR DESCRIPTION
Have to update to have environment secrets available.