### PR TITLE
👷 ci: Remove pinDigest update from Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,8 +28,7 @@
     {
       "updateTypes": [
         "lockFileMaintenance",
-        "pin",
-        "pinDigest"
+        "pin"
       ],
       "semanticCommitType": ":pushpin:",
       "automerge": true,


### PR DESCRIPTION
See #1220. No longer needed with [ghasum](https://github.com/ericcornelissen/ghasum/).