### PR TITLE
👷 ci: Add repo.spring.io to allowlisted endpoints for ossf/scorecard

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -47,6 +47,7 @@ jobs:
             oss-fuzz-build-logs.storage.googleapis.com:443
             rekor.sigstore.dev:443
             repo.maven.apache.org:443
+            repo.spring.io:443
             tuf-repo-cdn.sigstore.dev:443
             www.bestpractices.dev:443
 


### PR DESCRIPTION
See #1223.