### PR TITLE
👷 ci: Reset ossf/scorecard to without ghasum to only include allowlisted steps

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -43,7 +43,6 @@ jobs:
             api.scorecard.dev:443
             fulcio.sigstore.dev:443
             github.com:443
-            objects.githubusercontent.com:443
             oss-fuzz-build-logs.storage.googleapis.com:443
             rekor.sigstore.dev:443
             repo.maven.apache.org:443
@@ -56,11 +55,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Verify action checksums
-        uses: ./.github/actions/ghasum
-
       - name: Run analysis
-        uses: ossf/scorecard-action@v2.4.2
+        uses: ossf/scorecard-action@05b42c624433fc40578a4040d5cf5e36ddca8cde # v2.4.2
         with:
           results_file: results.sarif
           results_format: sarif
@@ -82,7 +78,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: Upload artifact
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: SARIF file
           path: results.sarif
@@ -90,6 +86,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@v3.28.18
+        uses: github/codeql-action/upload-sarif@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
See #1226.