### PR TITLE
👷 ci: Remove renovate pinGitHubActionDigests helper

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
-    "helpers:pinGitHubActionDigests"
+    "config:recommended"
   ],
   "gitIgnoredAuthors": [
     "41898282+github-actions[bot]@users.noreply.github.com",


### PR DESCRIPTION
Not needed for all actions with ghasum.