### PR TITLE
👷 ci: Trigger ghasum update action for renovate PRs

### DIFF
--- a/.github/workflows/ghasum.yml
+++ b/.github/workflows/ghasum.yml
@@ -1,14 +1,13 @@
 name: ghasum
 on:
   pull_request:
-    branches:
-      - renovate/**
 
 permissions: read-all
 
 jobs:
   update:
     name: Update gha.sum
+    if: startsWith(github.head_ref, 'renovate/')
     runs-on: ubuntu-24.04
     permissions:
       contents: write # To push a commit


### PR DESCRIPTION
Previous invalid branch filter. Now checks and only runs where PR is created from `renovate/**`.