### PR TITLE
👷 ci: Add minimum release age of 1d to renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,7 @@
   },
   "semanticCommitType": ":arrow_up:",
   "semanticCommits": "enabled",
+  "minimumReleaseAge": "1d",
   "packageRules": [
     {
       "matchUpdateTypes": [


### PR DESCRIPTION
Wait for 1d before releases are updated. To avoid similar attacks as changed-files in the future.