### PR TITLE
🔧 fix: ensure plugin version is updated in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -92,7 +92,7 @@ runs:
         COMMIT_UPDATED_LOCKFILE="${COMMIT_UPDATED_LOCKFILE}"
         
         # Convert to Maven plugin args
-        PLUGIN_VERSION="5.5.2" # 5.6.1-SNAPSHOT
+        PLUGIN_VERSION="5.6.1-SNAPSHOT" # 5.6.1-SNAPSHOT
         MAVEN_ARGS=""
         
         if [ "$INCLUDE_MAVEN_PLUGINS" == "true" ]; then

--- a/template/action.yml
+++ b/template/action.yml
@@ -92,7 +92,7 @@ runs:
         COMMIT_UPDATED_LOCKFILE="${COMMIT_UPDATED_LOCKFILE}"
         
         # Convert to Maven plugin args
-        PLUGIN_VERSION=${project.version} # ${project.version}
+        PLUGIN_VERSION="${project.version}" # ${project.version}
         MAVEN_ARGS=""
         
         if [ "$INCLUDE_MAVEN_PLUGINS" == "true" ]; then

--- a/template/action.yml
+++ b/template/action.yml
@@ -92,7 +92,7 @@ runs:
         COMMIT_UPDATED_LOCKFILE="${COMMIT_UPDATED_LOCKFILE}"
         
         # Convert to Maven plugin args
-        PLUGIN_VERSION="5.5.2" # ${project.version}
+        PLUGIN_VERSION=${project.version} # ${project.version}
         MAVEN_ARGS=""
         
         if [ "$INCLUDE_MAVEN_PLUGINS" == "true" ]; then


### PR DESCRIPTION
The `$PLUGIN_VERSION` is pinned to `5.5.2`. It was accidentally introduced in https://github.com/chains-project/maven-lockfile/pull/1211/files#diff-e23072be6fce0672ff37f9bae970d4df7189edd43bccee7223ae0b0c25b090f5R95. These changes ensure that `action.yml` is updated accordingly with each release.