### PR TITLE
:lock: security: Remove github.head_ref from echo of ensure-release-action-is-not-running

### DIFF
--- a/.github/workflows/ensure-release-notrunning.yml
+++ b/.github/workflows/ensure-release-notrunning.yml
@@ -43,5 +43,5 @@ jobs:
       - name: Skip check for release branch
         if: ${{ startsWith(github.head_ref, 'release/') }}
         run: |
-          echo "✅ Skipping release workflow check for release branch: ${{ github.head_ref }}"
+          echo "✅ Skipping release workflow check for release branch"
         shell: bash


### PR DESCRIPTION
Fixes https://github.com/chains-project/maven-lockfile/security/code-scanning/355.