### PR TITLE
👷 ci: Only scan main pom.xml:s in OSV Scanner, ignore integration tests poms

### DIFF
--- a/.github/workflows/osv-scanner-pr.yml
+++ b/.github/workflows/osv-scanner-pr.yml
@@ -54,8 +54,8 @@ jobs:
         scan-args: |-
           --format=json
           --output=old-results.json
-          -r
-          ./
+          ./pom.xml
+          ./maven_plugin/pom.xml
 
     - name: "Checkout current branch"
       # Use -f in case any changes were made by osv-scanner (there should be no changes)

--- a/.github/workflows/osv-scanner-scheduled.yml
+++ b/.github/workflows/osv-scanner-scheduled.yml
@@ -42,13 +42,13 @@ jobs:
 
     - name: Run scanner
       uses: google/osv-scanner-action/osv-scanner-action@e92b5d07338d4f0ba0981dffed17c48976ca4730 # v2.2.3
+      continue-on-error: true
       with:
         scan-args: |-
           --output=results.json
           --format=json
-          -r
-          ./
-      continue-on-error: true
+          ./pom.xml
+          ./maven_plugin/pom.xml
 
     - name: "Run osv-scanner-reporter"
       uses: google/osv-scanner-action/osv-reporter-action@e92b5d07338d4f0ba0981dffed17c48976ca4730 # v2.2.3


### PR DESCRIPTION
See #1370.