### PR TITLE
:sparkles: feat: Generate Dependencies of Plugins

### DIFF
--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/LockFileFacade.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/LockFileFacade.java
@@ -12,19 +12,27 @@ import io.github.chains_project.maven_lockfile.data.MetaData;
 import io.github.chains_project.maven_lockfile.data.Pom;
 import io.github.chains_project.maven_lockfile.data.VersionNumber;
 import io.github.chains_project.maven_lockfile.graph.DependencyGraph;
+import java.io.File;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.factory.ArtifactFactory;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.DefaultProjectBuildingRequest;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.project.ProjectBuildingResult;
 import org.apache.maven.shared.dependency.graph.DependencyCollectorBuilder;
 import org.apache.maven.shared.dependency.graph.DependencyNode;
 import org.apache.maven.shared.dependency.graph.traversal.DependencyNodeVisitor;
+import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolver;
+import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResult;
 
 /**
  * Entry point for the lock file generation. This class is responsible for generating the lock file for a project.
@@ -90,7 +98,7 @@ public class LockFileFacade {
         LOGGER.info("Generating lock file for project {}", project.getArtifactId());
         Set<MavenPlugin> plugins = new TreeSet<>(Comparator.comparing(MavenPlugin::getChecksum));
         if (metadata.getConfig().isIncludeMavenPlugins()) {
-            plugins = getAllPlugins(project, checksumCalculator);
+            plugins = getAllPlugins(project, session, dependencyCollectorBuilder, checksumCalculator);
         }
         // Get all the artifacts for the dependencies in the project
         var graph = LockFileFacade.graph(
@@ -114,10 +122,17 @@ public class LockFileFacade {
                 metadata);
     }
 
-    private static Set<MavenPlugin> getAllPlugins(MavenProject project, AbstractChecksumCalculator checksumCalculator) {
+    private static Set<MavenPlugin> getAllPlugins(
+            MavenProject project,
+            MavenSession session,
+            DependencyCollectorBuilder dependencyCollectorBuilder,
+            AbstractChecksumCalculator checksumCalculator) {
         Set<MavenPlugin> plugins = new TreeSet<>(Comparator.comparing(MavenPlugin::getChecksum));
         for (Artifact pluginArtifact : project.getPluginArtifacts()) {
             RepositoryInformation repositoryInformation = checksumCalculator.getPluginResolvedField(pluginArtifact);
+            Set<io.github.chains_project.maven_lockfile.graph.DependencyNode> pluginDependencies =
+                    resolvePluginDependencies(
+                            pluginArtifact, session, project, dependencyCollectorBuilder, checksumCalculator);
             plugins.add(new MavenPlugin(
                     GroupId.of(pluginArtifact.getGroupId()),
                     ArtifactId.of(pluginArtifact.getArtifactId()),
@@ -125,9 +140,199 @@ public class LockFileFacade {
                     repositoryInformation.getResolvedUrl(),
                     repositoryInformation.getRepositoryId(),
                     checksumCalculator.getChecksumAlgorithm(),
-                    checksumCalculator.calculatePluginChecksum(pluginArtifact)));
+                    checksumCalculator.calculatePluginChecksum(pluginArtifact),
+                    pluginDependencies));
         }
         return plugins;
+    }
+
+    /**
+     * Resolve the dependencies of a Maven plugin.
+     *
+     * @param pluginArtifact The plugin artifact to resolve dependencies for
+     * @param session The Maven session
+     * @param project The current Maven project (for repository configuration)
+     * @param dependencyCollectorBuilder The dependency collector builder
+     * @param checksumCalculator The checksum calculator
+     * @return A set of dependency nodes representing the plugin's dependencies
+     */
+    private static Set<io.github.chains_project.maven_lockfile.graph.DependencyNode> resolvePluginDependencies(
+            Artifact pluginArtifact,
+            MavenSession session,
+            MavenProject project,
+            DependencyCollectorBuilder dependencyCollectorBuilder,
+            AbstractChecksumCalculator checksumCalculator) {
+        LOGGER.info(
+                "Attempting to resolve dependencies for plugin {}:{}",
+                pluginArtifact.getGroupId(),
+                pluginArtifact.getArtifactId());
+        try {
+            // Resolve the plugin's POM artifact
+            File pluginPomFile = null;
+
+            // Try to get POM from the JAR file location first (faster if already resolved)
+            File pluginJarFile = pluginArtifact.getFile();
+            if (pluginJarFile != null && pluginJarFile.exists()) {
+                // Construct POM file path by replacing .jar with .pom
+                String jarPath = pluginJarFile.getAbsolutePath();
+                String pomPath = jarPath.replace(".jar", ".pom");
+                File potentialPomFile = new File(pomPath);
+                if (potentialPomFile.exists()) {
+                    pluginPomFile = potentialPomFile;
+                }
+            }
+
+            // If POM not found, try to construct path using Maven repository layout
+            if (pluginPomFile == null || !pluginPomFile.exists()) {
+                try {
+                    // Try to find POM in local repository using standard Maven layout
+                    // Format: groupId/artifactId/version/artifactId-version.pom
+                    var repositorySession = session.getRepositorySession();
+
+                    // getBasedir is deprecated, but is compatible with Maven 3.9.x.
+                    @SuppressWarnings("deprecation")
+                    File localRepoBase = repositorySession.getLocalRepository().getBasedir();
+
+                    String groupPath = pluginArtifact.getGroupId().replace(".", "/");
+                    String artifactId = pluginArtifact.getArtifactId();
+                    String version = pluginArtifact.getVersion();
+                    String pomFileName = artifactId + "-" + version + ".pom";
+
+                    Path localPomPath =
+                            Paths.get(localRepoBase.getAbsolutePath(), groupPath, artifactId, version, pomFileName);
+                    if (Files.exists(localPomPath)) {
+                        pluginPomFile = localPomPath.toFile();
+                    } else {
+                        // If not in local repo, try to resolve it using artifact resolver
+                        @SuppressWarnings("deprecation")
+                        ArtifactFactory artifactFactory = session.getContainer().lookup(ArtifactFactory.class);
+                        Artifact pomArtifact = artifactFactory.createArtifact(
+                                pluginArtifact.getGroupId(),
+                                pluginArtifact.getArtifactId(),
+                                pluginArtifact.getVersion(),
+                                null,
+                                "pom");
+
+                        ProjectBuildingRequest pomBuildingRequest =
+                                new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
+                        pomBuildingRequest.setRemoteRepositories(project.getPluginArtifactRepositories());
+
+                        @SuppressWarnings("deprecation")
+                        ArtifactResolver artifactResolver =
+                                session.getContainer().lookup(ArtifactResolver.class);
+                        ArtifactResult result = artifactResolver.resolveArtifact(pomBuildingRequest, pomArtifact);
+                        if (result != null
+                                && result.getArtifact() != null
+                                && result.getArtifact().getFile() != null) {
+                            pluginPomFile = result.getArtifact().getFile();
+                        }
+                    }
+                } catch (Exception e) {
+                    LOGGER.debug(
+                            "Could not resolve POM artifact for plugin {}:{}: {}",
+                            pluginArtifact.getGroupId(),
+                            pluginArtifact.getArtifactId(),
+                            e.getMessage());
+                }
+            }
+
+            if (pluginPomFile == null || !pluginPomFile.exists()) {
+                LOGGER.warn(
+                        "Could not find POM file for plugin {}:{}, skipping dependency resolution",
+                        pluginArtifact.getGroupId(),
+                        pluginArtifact.getArtifactId());
+                return Collections.emptySet();
+            }
+
+            LOGGER.debug(
+                    "Resolving dependencies for plugin {}:{} using POM: {}",
+                    pluginArtifact.getGroupId(),
+                    pluginArtifact.getArtifactId(),
+                    pluginPomFile.getAbsolutePath());
+
+            // Build MavenProject from plugin POM
+            ProjectBuildingRequest buildingRequest =
+                    new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
+            buildingRequest.setRemoteRepositories(project.getPluginArtifactRepositories());
+            buildingRequest.setProcessPlugins(false);
+            buildingRequest.setResolveDependencies(true);
+
+            // Note: getContainer() is deprecated but there's no clear replacement in the current Maven API
+            @SuppressWarnings("deprecation")
+            ProjectBuilder projectBuilder = session.getContainer().lookup(ProjectBuilder.class);
+            ProjectBuildingResult result = projectBuilder.build(pluginPomFile, buildingRequest);
+
+            if (result.getProblems() != null && !result.getProblems().isEmpty()) {
+                LOGGER.warn(
+                        "Problems building plugin project for {}:{}: {}",
+                        pluginArtifact.getGroupId(),
+                        pluginArtifact.getArtifactId(),
+                        result.getProblems());
+            }
+
+            MavenProject pluginProject = result.getProject();
+            if (pluginProject == null) {
+                LOGGER.warn(
+                        "Could not build project for plugin {}:{}",
+                        pluginArtifact.getGroupId(),
+                        pluginArtifact.getArtifactId());
+                return Collections.emptySet();
+            }
+
+            int declaredDeps = pluginProject.getDependencies() != null
+                    ? pluginProject.getDependencies().size()
+                    : 0;
+            LOGGER.info(
+                    "Built plugin project {}:{} with {} declared dependencies",
+                    pluginArtifact.getGroupId(),
+                    pluginArtifact.getArtifactId(),
+                    declaredDeps);
+
+            // Resolve dependencies using DependencyCollectorBuilder
+            ProjectBuildingRequest dependencyBuildingRequest =
+                    new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
+            dependencyBuildingRequest.setProject(pluginProject);
+            dependencyBuildingRequest.setRemoteRepositories(project.getPluginArtifactRepositories());
+
+            var rootNode = dependencyCollectorBuilder.collectDependencyGraph(dependencyBuildingRequest, null);
+
+            int rootChildren =
+                    rootNode.getChildren() != null ? rootNode.getChildren().size() : 0;
+            LOGGER.info(
+                    "Collected dependency graph for plugin {}:{}, root node has {} children",
+                    pluginArtifact.getGroupId(),
+                    pluginArtifact.getArtifactId(),
+                    rootChildren);
+
+            // Convert to DependencyGraph and extract root nodes
+            MutableGraph<DependencyNode> graph = GraphBuilder.directed().build();
+            rootNode.accept(new GraphBuildingNodeVisitor(graph));
+
+            LOGGER.debug(
+                    "Built graph with {} nodes for plugin {}:{}",
+                    graph.nodes().size(),
+                    pluginArtifact.getGroupId(),
+                    pluginArtifact.getArtifactId());
+
+            DependencyGraph dependencyGraph = DependencyGraph.of(graph, checksumCalculator, false);
+
+            // Get root dependency nodes (excluding the plugin project itself)
+            Set<io.github.chains_project.maven_lockfile.graph.DependencyNode> roots = dependencyGraph.getRoots();
+            LOGGER.info(
+                    "Resolved {} dependencies for plugin {}:{}",
+                    roots.size(),
+                    pluginArtifact.getGroupId(),
+                    pluginArtifact.getArtifactId());
+            return roots;
+
+        } catch (Exception e) {
+            LOGGER.warn(
+                    "Could not resolve dependencies for plugin {}:{}",
+                    pluginArtifact.getGroupId(),
+                    pluginArtifact.getArtifactId(),
+                    e);
+            return Collections.emptySet();
+        }
     }
 
     private static DependencyGraph graph(

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/MavenPlugin.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/MavenPlugin.java
@@ -1,6 +1,9 @@
 package io.github.chains_project.maven_lockfile.data;
 
+import io.github.chains_project.maven_lockfile.graph.DependencyNode;
+import java.util.Collections;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * This class represents a maven plugin. It contains a group id, an artifact id, and a version number. A plugin is uniquely identified by its group id, artifact id, and version number.
@@ -15,6 +18,7 @@ public class MavenPlugin {
     private final String checksum;
     private final ResolvedUrl resolved;
     private final RepositoryId repositoryId;
+    private final Set<DependencyNode> dependencies;
 
     public MavenPlugin(
             GroupId groupId,
@@ -24,6 +28,18 @@ public class MavenPlugin {
             RepositoryId repositoryId,
             String checksumAlgorithm,
             String checksum) {
+        this(groupId, artifactId, version, resolvedUrl, repositoryId, checksumAlgorithm, checksum, null);
+    }
+
+    public MavenPlugin(
+            GroupId groupId,
+            ArtifactId artifactId,
+            VersionNumber version,
+            ResolvedUrl resolvedUrl,
+            RepositoryId repositoryId,
+            String checksumAlgorithm,
+            String checksum,
+            Set<DependencyNode> dependencies) {
         this.groupId = groupId;
         this.artifactId = artifactId;
         this.version = version;
@@ -31,6 +47,7 @@ public class MavenPlugin {
         this.repositoryId = repositoryId;
         this.checksumAlgorithm = checksumAlgorithm;
         this.checksum = checksum;
+        this.dependencies = dependencies == null ? Collections.emptySet() : dependencies;
     }
 
     public GroupId getGroupId() {
@@ -61,9 +78,16 @@ public class MavenPlugin {
         return repositoryId;
     }
 
+    /**
+     * @return the dependencies of this plugin
+     */
+    public Set<DependencyNode> getDependencies() {
+        return dependencies;
+    }
+
     @Override
     public int hashCode() {
-        return Objects.hash(groupId, artifactId, version, checksumAlgorithm, checksum);
+        return Objects.hash(groupId, artifactId, version, checksumAlgorithm, checksum, dependencies);
     }
 
     @Override
@@ -79,6 +103,13 @@ public class MavenPlugin {
                 && Objects.equals(artifactId, other.artifactId)
                 && Objects.equals(version, other.version)
                 && Objects.equals(checksumAlgorithm, other.checksumAlgorithm)
-                && Objects.equals(checksum, other.checksum);
+                && Objects.equals(checksum, other.checksum)
+                && Objects.equals(dependencies, other.dependencies);
+    }
+
+    @Override
+    public String toString() {
+        // only show the group id, artifact id, and version - this is sufficient for debugging purposes
+        return "MavenPlugin [groupId=" + groupId + ", artifactId=" + artifactId + ", version=" + version + "]";
     }
 }

--- a/maven_plugin/src/test/java/it/IntegrationTestsIT.java
+++ b/maven_plugin/src/test/java/it/IntegrationTestsIT.java
@@ -84,7 +84,7 @@ public class IntegrationTestsIT {
     @MavenTest
     public void pluginProject(MavenExecutionResult result) throws Exception {
         // contract: if including maven plugins the lockfile should contain these and be able to calculate checksums for
-        // them.
+        // them. Plugin dependencies should also be resolved and recorded.
         // Note that remote does not work as the maven-lockfile plugin with SNAPSHOT version is not available on remote.
         assertThat(result).isSuccessful();
         Path lockFilePath = findFile(result, "lockfile.json");
@@ -94,6 +94,12 @@ public class IntegrationTestsIT {
         assertThat(lockFile.getMavenPlugins())
                 .allMatch(v -> !v.getChecksum().isBlank()
                         && v.getChecksumAlgorithm().equals(lockFile.getConfig().getChecksumAlgorithm()));
+
+        // This uses the Maven lockfile plugin itself as a plugin in the test project's build lifecycle.
+        // All dependencies of this plugin should be recorded.
+        assertThat(lockFile.getMavenPlugins())
+                .allMatch(
+                        p -> p.getDependencies() != null && !p.getDependencies().isEmpty());
     }
 
     @MavenTest


### PR DESCRIPTION
Extend the Maven Lockfile plugin to generate and validate the dependencies of plugins. It uses logic similar to the Maven Dependency Plugin to resolve the compile and provided scope dependencies of the plugins, so that they can be validated and potentially pre-fetched prior to building the Maven project.

Generated using the following coding assistant prompt, with subsequent prompts to address issues identified during testing:

```
Create an implementation plan for the @maven_plugin to record the
dependencies of Maven plugins in a project. This is a critical missing
feature. The related Apache Maven Dependency plugin is capable of doing
this through the "resolve-plugins" goal. Code for the Apache Maven
dependency plugin is available here: https://github.com/apache/maven-dependency-plugin/tree/maven-dependency-plugin-3.9.0.
Compare the Apache Maven dependency plugin implementation to the
implementation here, and describe the tasks that need to be executed to
implement this feature.
```

Fixes #424 