### PR TITLE
✨ feat: Only include allowed plugin dependency scopes...

### DIFF
--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/LockFileFacade.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/LockFileFacade.java
@@ -349,8 +349,8 @@ public class LockFileFacade {
                     String scope = dep.getScope().getValue();
                     return scope.equals("compile") || scope.equals("runtime") || scope.equals("system");
                 })
-                .collect(Collectors.toCollection(() -> new TreeSet<>(
-                        Comparator.comparing(io.github.chains_project.maven_lockfile.graph.DependencyNode::getComparatorString))));
+                .collect(Collectors.toCollection(() -> new TreeSet<>(Comparator.comparing(
+                        io.github.chains_project.maven_lockfile.graph.DependencyNode::getComparatorString))));
     }
 
     private static DependencyGraph graph(


### PR DESCRIPTION
...and overwrite potential scope from project pom if declared as it may change the scope from test to compile, meaning the dependency should be included.

Fixes #1445 and prerequisite for #1463. 

Still causes error. Overwriting from project pom if declared fixes this error when trying to build from freeze:
```
[ERROR] Failed to execute goal org.codehaus.gmavenplus:gmavenplus-plugin:4.2.1:execute (default) on projec      t maven-lockfile-parent: Execution default of goal org.codehaus.gmavenplus:gmavenplus-plugin:4.2.1:execute       failed: Unable to determine Groovy version. Is Groovy declared as a dependency? -> [Help 1]
```
but instead causes this error:
```
[ERROR] Failed to execute goal dev.sigstore:sigstore-maven-plugin:2.0.0:sign (sign) on project maven-lockfile-parent: Execution sign of goal dev.sigstore:sigstore-maven-plugin:2.0.0:sign failed: Plugin dev.sigstore:sigstore-maven-plugin:2.0.0 or one of its dependencies could not be resolved:
[ERROR]         com.kohlschutter.junixsocket:junixsocket-core:jar:2.10.1 was not found in https://repo.maven.apache.org/maven2
```