### PR TITLE
chore(cd): Use newest version of maven lockfile in release script

### DIFF
--- a/.github/workflows/jreleaser-beta.yml
+++ b/.github/workflows/jreleaser-beta.yml
@@ -86,8 +86,11 @@ jobs:
       - name: Generate Readme
         run : mvn generate-resources resources:copy-resources
 
+      - name: Stage release
+        run:  mvn --no-transfer-progress --batch-mode -Ppublication clean deploy -DaltDeploymentRepository=local::file:./target/staging-deploy -Dsigstore.skip=false
+
       - name: run maven-lockfile (generate new lockfile for release version)
-        run: mvn io.github.chains-project:maven-lockfile:5.9.0:generate
+        run: mvn io.github.chains-project:maven-lockfile:$NEXT_BETA_VERSION:generate
         shell: bash
 
       - name: commit changes
@@ -95,9 +98,6 @@ jobs:
           git checkout -b ${{ env.BRANCH_NAME }}
           git commit -am "🔖 Releasing version ${{ env.NEXT_BETA_VERSION }}"
           git push --set-upstream origin ${{ env.BRANCH_NAME }}
-
-      - name: Stage release
-        run:  mvn --no-transfer-progress --batch-mode -Ppublication clean deploy -DaltDeploymentRepository=local::file:./target/staging-deploy -Dsigstore.skip=false
 
       - name: generate buildinfo file
         run: mvn org.apache.maven.plugins:maven-artifact-plugin:3.4.1:buildinfo

--- a/.github/workflows/jreleaser.yml
+++ b/.github/workflows/jreleaser.yml
@@ -99,8 +99,11 @@ jobs:
       - name: Generate Readme
         run : mvn generate-resources resources:copy-resources
 
+      - name: Stage release
+        run:  mvn --no-transfer-progress --batch-mode -Ppublication clean deploy -DaltDeploymentRepository=local::file:./target/staging-deploy -Dsigstore.skip=false
+
       - name: run maven-lockfile (generate new lockfile for release version)
-        run: mvn io.github.chains-project:maven-lockfile:5.9.0:generate
+        run: mvn io.github.chains-project:maven-lockfile:$NEXT_VERSION:generate
         shell: bash
 
       - name: commit changes
@@ -109,8 +112,6 @@ jobs:
           git commit -am "🔖 Releasing version ${{ env.NEXT_VERSION }}"
           git push --set-upstream origin ${{ env.BRANCH_NAME }}
 
-      - name: Stage release
-        run:  mvn --no-transfer-progress --batch-mode -Ppublication clean deploy -DaltDeploymentRepository=local::file:./target/staging-deploy -Dsigstore.skip=false
 
       - name: generate buildinfo file
         run: mvn org.apache.maven.plugins:maven-artifact-plugin:3.4.1:buildinfo


### PR DESCRIPTION
Use newest version of maven lockfile in release script instead of having to update lockfile with chore for release.