### PR TITLE
chore(cd): Use latest version of maven lockfile in release script

### DIFF
--- a/.github/workflows/jreleaser.yml
+++ b/.github/workflows/jreleaser.yml
@@ -159,7 +159,7 @@ jobs:
         run : mvn generate-resources resources:copy-resources -q
 
       - name: run maven-lockfile (generate new lockfile for -SNAPSHOT version)
-        run: mvn io.github.chains-project:maven-lockfile:5.9.0:generate
+        run: mvn io.github.chains-project:maven-lockfile:$NEXT_VERSION:generate
         shell: bash
 
       - name: Commit & Push changes


### PR DESCRIPTION
During release script when regenerating the lockfile for the new SNAPSHOT version it removes most lines from the lockfile:
https://github.com/chains-project/maven-lockfile/pull/1473/changes/aea25de23e66e882260fd11951ef02e3f573ce7f

This is then added back in the chore which regenerates the lockfile:
https://github.com/chains-project/maven-lockfile/pull/1473/changes/f318129205d8352d9f6aaa610fc2bd9603fe0bb4