### PR TITLE
✨ feat: Parallel downloading for RemoteChecksumCalculator

### DIFF
--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/checksum/AbstractChecksumCalculator.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/checksum/AbstractChecksumCalculator.java
@@ -5,6 +5,7 @@ import io.github.chains_project.maven_lockfile.reporting.PluginLogManager;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
+import java.util.Collection;
 import java.util.Locale;
 import org.apache.maven.artifact.Artifact;
 
@@ -36,6 +37,14 @@ public abstract class AbstractChecksumCalculator {
     public abstract RepositoryInformation getArtifactResolvedField(Artifact artifact);
 
     public abstract RepositoryInformation getPluginResolvedField(Artifact artifact);
+
+    /**
+     * Pre-warm internal caches for the given artifacts. Implementations may use this
+     * to fetch checksums and repository information in parallel. The default is a no-op.
+     */
+    public void prewarmArtifactCache(Collection<Artifact> artifacts) {
+        // No-op by default; overridden by RemoteChecksumCalculator
+    }
 
     public String calculatePomChecksum(Path path) {
         try {

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/checksum/RemoteChecksumCalculator.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/checksum/RemoteChecksumCalculator.java
@@ -9,10 +9,16 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.project.ProjectBuildingRequest;
@@ -222,6 +228,37 @@ public class RemoteChecksumCalculator extends AbstractChecksumCalculator {
                     .warn(String.format("Could not resolve url for artifact: %s", artifact.getArtifactId()), e);
             resolvedCache.put(cacheKey, RepositoryInformation.Unresolved());
             return Optional.empty();
+        }
+    }
+
+    @Override
+    public void prewarmArtifactCache(Collection<Artifact> artifacts) {
+        if (artifacts.isEmpty()) {
+            return;
+        }
+        int poolSize = Math.min(16, Math.max(4, Runtime.getRuntime().availableProcessors() * 2));
+        PluginLogManager.getLog()
+                .info(String.format(
+                        "Pre-warming checksum cache for %d unique artifacts with %d threads",
+                        artifacts.size(), poolSize));
+        ExecutorService executor = Executors.newFixedThreadPool(poolSize);
+        try {
+            List<Future<?>> futures = new ArrayList<>();
+            for (var artifact : artifacts) {
+                futures.add(executor.submit(() -> {
+                    calculateArtifactChecksum(artifact);
+                    getArtifactResolvedField(artifact);
+                }));
+            }
+            for (var future : futures) {
+                try {
+                    future.get();
+                } catch (Exception e) {
+                    PluginLogManager.getLog().debug("Pre-warm task failed: " + e.getMessage());
+                }
+            }
+        } finally {
+            executor.shutdown();
         }
     }
 

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/checksum/RemoteChecksumCalculator.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/checksum/RemoteChecksumCalculator.java
@@ -21,6 +21,7 @@ public class RemoteChecksumCalculator extends AbstractChecksumCalculator {
 
     private final ProjectBuildingRequest artifactBuildingRequest;
     private final ProjectBuildingRequest pluginBuildingRequest;
+    private final HttpClient httpClient;
     private final Map<String, String> checksumCache = new ConcurrentHashMap<>();
     private final Map<String, RepositoryInformation> resolvedCache = new ConcurrentHashMap<>();
 
@@ -39,6 +40,9 @@ public class RemoteChecksumCalculator extends AbstractChecksumCalculator {
 
         this.artifactBuildingRequest = artifactBuildingRequest;
         this.pluginBuildingRequest = pluginBuildingRequest;
+        this.httpClient = HttpClient.newBuilder()
+                .followRedirects(HttpClient.Redirect.ALWAYS)
+                .build();
     }
 
     private String getCacheKey(Artifact artifact) {
@@ -72,9 +76,6 @@ public class RemoteChecksumCalculator extends AbstractChecksumCalculator {
             String filename = artifactId + "-" + version + classifier + "." + extension;
 
             BaseEncoding baseEncoding = BaseEncoding.base16();
-            HttpClient client = HttpClient.newBuilder()
-                    .followRedirects(HttpClient.Redirect.ALWAYS)
-                    .build();
 
             for (ArtifactRepository repository : buildingRequest.getRemoteRepositories()) {
                 String artifactUrl = repository.getUrl().replaceAll("/$", "") + "/" + groupId + "/" + artifactId + "/"
@@ -87,7 +88,7 @@ public class RemoteChecksumCalculator extends AbstractChecksumCalculator {
                 HttpRequest checksumRequest =
                         HttpRequest.newBuilder().uri(URI.create(checksumUrl)).build();
                 HttpResponse<String> checksumResponse =
-                        client.send(checksumRequest, HttpResponse.BodyHandlers.ofString());
+                        httpClient.send(checksumRequest, HttpResponse.BodyHandlers.ofString());
 
                 if (checksumResponse.statusCode() >= 200 && checksumResponse.statusCode() < 300) {
                     String checksum = checksumResponse.body().strip();
@@ -100,7 +101,7 @@ public class RemoteChecksumCalculator extends AbstractChecksumCalculator {
                             .uri(URI.create(artifactUrl))
                             .build();
                     HttpResponse<byte[]> artifactResponse =
-                            client.send(artifactRequest, HttpResponse.BodyHandlers.ofByteArray());
+                            httpClient.send(artifactRequest, HttpResponse.BodyHandlers.ofByteArray());
 
                     if (artifactResponse.statusCode() < 200 || artifactResponse.statusCode() >= 300) {
                         continue;
@@ -116,7 +117,7 @@ public class RemoteChecksumCalculator extends AbstractChecksumCalculator {
                             .uri(URI.create(artifactUrl + ".sha1"))
                             .build();
                     HttpResponse<String> artifactVerificationResponse =
-                            client.send(artifactVerificationRequest, HttpResponse.BodyHandlers.ofString());
+                            httpClient.send(artifactVerificationRequest, HttpResponse.BodyHandlers.ofString());
 
                     // Extract first part of string to handle sha1sum format, `hash_in_hex /path/to/file`.
                     // For example provided by:
@@ -193,10 +194,6 @@ public class RemoteChecksumCalculator extends AbstractChecksumCalculator {
             String extension = artifact.getArtifactHandler().getExtension();
             String filename = artifactId + "-" + version + classifier + "." + extension;
 
-            HttpClient client = HttpClient.newBuilder()
-                    .followRedirects(HttpClient.Redirect.ALWAYS)
-                    .build();
-
             for (ArtifactRepository repository : buildingRequest.getRemoteRepositories()) {
                 String url = repository.getUrl().replaceAll("/$", "") + "/" + groupId + "/" + artifactId + "/"
                         + baseVersion + "/" + filename;
@@ -207,7 +204,7 @@ public class RemoteChecksumCalculator extends AbstractChecksumCalculator {
                         .uri(URI.create(url))
                         .method("HEAD", HttpRequest.BodyPublishers.noBody())
                         .build();
-                HttpResponse<Void> response = client.send(request, HttpResponse.BodyHandlers.discarding());
+                HttpResponse<Void> response = httpClient.send(request, HttpResponse.BodyHandlers.discarding());
 
                 if (response.statusCode() >= 200 && response.statusCode() < 300) {
                     RepositoryInformation result =

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/graph/DependencyGraph.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/graph/DependencyGraph.java
@@ -12,10 +12,8 @@ import io.github.chains_project.maven_lockfile.data.MavenScope;
 import io.github.chains_project.maven_lockfile.data.VersionNumber;
 import io.github.chains_project.maven_lockfile.reporting.PluginLogManager;
 import java.util.*;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.stream.Collectors;
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.shared.dependency.graph.internal.SpyingDependencyNodeUtils;
 
 public class DependencyGraph {
@@ -67,43 +65,20 @@ public class DependencyGraph {
                 .filter(it -> graph.predecessors(it).isEmpty())
                 .collect(Collectors.toList());
 
-        // Pre-warm checksum cache in parallel for I/O-bound remote fetching
-        var nonRootNodes = graph.nodes().stream()
-                .filter(it -> !graph.predecessors(it).isEmpty())
-                .collect(Collectors.toList());
+        // Collect unique non-root artifacts and let the calculator pre-warm its cache
         Set<String> seen = new HashSet<>();
-        List<org.apache.maven.shared.dependency.graph.DependencyNode> uniqueNodes = new ArrayList<>();
-        for (var node : nonRootNodes) {
-            var a = node.getArtifact();
-            String key = a.getGroupId() + ":" + a.getArtifactId() + ":" + a.getVersion() + ":"
-                    + (a.getClassifier() != null ? a.getClassifier() : "") + ":" + a.getType();
-            if (seen.add(key)) {
-                uniqueNodes.add(node);
-            }
-        }
-        if (!uniqueNodes.isEmpty()) {
-            int poolSize = Math.min(16, Math.max(4, Runtime.getRuntime().availableProcessors() * 2));
-            PluginLogManager.getLog()
-                    .info(String.format(
-                            "Pre-warming checksum cache for %d unique artifacts with %d threads",
-                            uniqueNodes.size(), poolSize));
-            ExecutorService executor = Executors.newFixedThreadPool(poolSize);
-            List<Future<?>> futures = new ArrayList<>();
-            for (var node : uniqueNodes) {
-                futures.add(executor.submit(() -> {
-                    calc.calculateArtifactChecksum(node.getArtifact());
-                    calc.getArtifactResolvedField(node.getArtifact());
-                }));
-            }
-            for (var future : futures) {
-                try {
-                    future.get();
-                } catch (Exception e) {
-                    PluginLogManager.getLog().debug("Pre-warm task failed: " + e.getMessage());
+        List<Artifact> uniqueArtifacts = new ArrayList<>();
+        for (var node : graph.nodes()) {
+            if (!graph.predecessors(node).isEmpty()) {
+                var a = node.getArtifact();
+                String key = a.getGroupId() + ":" + a.getArtifactId() + ":" + a.getVersion() + ":"
+                        + (a.getClassifier() != null ? a.getClassifier() : "") + ":" + a.getType();
+                if (seen.add(key)) {
+                    uniqueArtifacts.add(a);
                 }
             }
-            executor.shutdown();
         }
+        calc.prewarmArtifactCache(uniqueArtifacts);
 
         Set<DependencyNode> nodes = new TreeSet<>(Comparator.comparing(DependencyNode::getComparatorString));
         for (var artifact : roots) {

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/graph/DependencyGraph.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/graph/DependencyGraph.java
@@ -12,6 +12,9 @@ import io.github.chains_project.maven_lockfile.data.MavenScope;
 import io.github.chains_project.maven_lockfile.data.VersionNumber;
 import io.github.chains_project.maven_lockfile.reporting.PluginLogManager;
 import java.util.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 import org.apache.maven.shared.dependency.graph.internal.SpyingDependencyNodeUtils;
 
@@ -63,6 +66,45 @@ public class DependencyGraph {
         var roots = graph.nodes().stream()
                 .filter(it -> graph.predecessors(it).isEmpty())
                 .collect(Collectors.toList());
+
+        // Pre-warm checksum cache in parallel for I/O-bound remote fetching
+        var nonRootNodes = graph.nodes().stream()
+                .filter(it -> !graph.predecessors(it).isEmpty())
+                .collect(Collectors.toList());
+        Set<String> seen = new HashSet<>();
+        List<org.apache.maven.shared.dependency.graph.DependencyNode> uniqueNodes = new ArrayList<>();
+        for (var node : nonRootNodes) {
+            var a = node.getArtifact();
+            String key = a.getGroupId() + ":" + a.getArtifactId() + ":" + a.getVersion() + ":"
+                    + (a.getClassifier() != null ? a.getClassifier() : "") + ":" + a.getType();
+            if (seen.add(key)) {
+                uniqueNodes.add(node);
+            }
+        }
+        if (!uniqueNodes.isEmpty()) {
+            int poolSize = Math.min(16, Math.max(4, Runtime.getRuntime().availableProcessors() * 2));
+            PluginLogManager.getLog()
+                    .info(String.format(
+                            "Pre-warming checksum cache for %d unique artifacts with %d threads",
+                            uniqueNodes.size(), poolSize));
+            ExecutorService executor = Executors.newFixedThreadPool(poolSize);
+            List<Future<?>> futures = new ArrayList<>();
+            for (var node : uniqueNodes) {
+                futures.add(executor.submit(() -> {
+                    calc.calculateArtifactChecksum(node.getArtifact());
+                    calc.getArtifactResolvedField(node.getArtifact());
+                }));
+            }
+            for (var future : futures) {
+                try {
+                    future.get();
+                } catch (Exception e) {
+                    PluginLogManager.getLog().debug("Pre-warm task failed: " + e.getMessage());
+                }
+            }
+            executor.shutdown();
+        }
+
         Set<DependencyNode> nodes = new TreeSet<>(Comparator.comparing(DependencyNode::getComparatorString));
         for (var artifact : roots) {
             createDependencyNode(artifact, graph, calc, true, reduced).ifPresent(nodes::add);


### PR DESCRIPTION
Second part of #1476. Adds prewarming of the cache using parallel downloading and a shared http client. Affects only the remote checksum calculator.

## Speed tests
### Spoon using maven-lockfile 5.13.3 (with caching)
```
[INFO] Lockfile written to /Users/elias/code/kth/CHAINS/spoon/lockfile.json
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:10 min
[INFO] Finished at: 2026-02-24T11:29:54+01:00
[INFO] ------------------------------------------------------------------------
```
### Spoon using maven-lockfile 5.13.4-SNAPSHOT
```
[INFO] Lockfile written to /Users/elias/code/kth/CHAINS/spoon/lockfile.json
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  13.199 s
[INFO] Finished at: 2026-02-24T11:30:22+01:00
[INFO] ------------------------------------------------------------------------
```