### PR TITLE
✨ feat: resolve parent POMs and their BOMs

### DIFF
--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/LockFileFacade.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/LockFileFacade.java
@@ -9,9 +9,11 @@ import io.github.chains_project.maven_lockfile.graph.DependencyGraph;
 import io.github.chains_project.maven_lockfile.reporting.PluginLogManager;
 import io.github.chains_project.maven_lockfile.resolvers.BomResolver;
 import io.github.chains_project.maven_lockfile.resolvers.ProjectBuilder;
+
 import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
+
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
 import org.apache.maven.artifact.handler.DefaultArtifactHandler;
@@ -42,8 +44,8 @@ import org.eclipse.aether.util.artifact.JavaScopes;
  */
 public class LockFileFacade {
 
-    private static final Set<String> writtenParentPoms = new HashSet<>();
-    private static final Set<String> visitedBoms = new HashSet<>();
+    private static final Map<MavenProject, Pom> parentsResolved = new HashMap<>();
+    private static final Map<MavenProject, Set<Pom>> bomsResolved = new HashMap<>();
 
     /**
      * This visitor is used to traverse the dependency graph and add the edges to the graph.
@@ -123,7 +125,7 @@ public class LockFileFacade {
         var roots = graph.getRoots();
         var pom = constructRecursivePom(project, session, checksumCalculator);
 
-        resolveParentsAndBomsForDependencies(graph, session, project, checksumCalculator, writtenParentPoms, visitedBoms);
+        resolveParentsAndBomsForDependencies(graph, session, project, checksumCalculator);
         var boms = resolveBoms(session, project, checksumCalculator);
 
         return new LockFile(
@@ -168,6 +170,8 @@ public class LockFileFacade {
         DependencyRequest dependencyRequest = new DependencyRequest();
         dependencyRequest.setCollectRequest(collectRequest);
 
+        ProjectBuilder extensionProjectBuilder = new ProjectBuilder(session, project.getPluginArtifactRepositories());
+
         try {
             DependencyResult dependencyResult = repositorySystem.resolveDependencies(repoSession, dependencyRequest);
 
@@ -189,12 +193,15 @@ public class LockFileFacade {
 
                 RepositoryInformation repositoryInformation = checksumCalculator.getPluginResolvedField(mavenArtifact);
 
+                Optional<MavenProject> extensionProjectOptional = extensionProjectBuilder.buildFromGav(
+                        artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion());
+
                 // Resolve extension's transitive dependencies using the existing mechanism
                 Set<io.github.chains_project.maven_lockfile.graph.DependencyNode> transitiveDeps =
                         resolveComponentDependencies(
-                                project,
+                                extensionProjectOptional.get(),
                                 session,
-                                project.getRemoteArtifactRepositories(),
+                                project.getPluginArtifactRepositories(),
                                 dependencyCollectorBuilder,
                                 checksumCalculator,
                                 Collections.emptyList());
@@ -251,20 +258,12 @@ public class LockFileFacade {
             DependencyGraph graph,
             MavenSession session,
             MavenProject rootProject,
-            AbstractChecksumCalculator checksumCalculator,
-            Set<String> writtenParentPoms,
-            Set<String> visitedBoms) {
+            AbstractChecksumCalculator checksumCalculator) {
         ProjectBuilder builder = new ProjectBuilder(session, rootProject.getRemoteArtifactRepositories());
         BomResolver bomResolver =
                 new BomResolver(session, rootProject.getRemoteArtifactRepositories(), checksumCalculator);
 
         graph.getDependencySet().forEach(node -> {
-            boolean needsParentPom = !writtenParentPoms.contains(node.getChecksum());
-            boolean needsBom = !visitedBoms.contains(node.getChecksum());
-
-            if (!needsParentPom && !needsBom) {
-                return;
-            }
 
             var projectOptional = builder.buildFromGav(
                     node.getGroupId().getValue(),
@@ -280,21 +279,28 @@ public class LockFileFacade {
             }
             var mavenProject = projectOptional.get();
 
-            if (needsParentPom) {
-                if (mavenProject.hasParent()) {
-                    PluginLogManager.getLog().debug(String.format("Writting parent POM for dependency %s", node));
-                    var pom = constructRecursivePom(mavenProject.getParent(), session, checksumCalculator);
+            if (mavenProject.hasParent()) {
+                PluginLogManager.getLog().debug(String.format("Writting parent POM for dependency %s", node));
+
+                //Optimization, not to resolve parent if already resolved
+                //It has to be written in full form before lockfile v2
+                if (parentsResolved.containsKey(mavenProject.getParent())) {
+                    node.setParentPom(parentsResolved.get(mavenProject.getParent()));
+                } else {
+                    Pom pom = constructRecursivePom(mavenProject.getParent(), session, checksumCalculator);
+                    parentsResolved.put(mavenProject.getParent(), pom);
                     node.setParentPom(pom);
                 }
-                writtenParentPoms.add(node.getChecksum());
             }
 
-            if (needsBom) {
+            if (bomsResolved.containsKey(mavenProject)) {
+                node.setBoms(bomsResolved.get(mavenProject));
+            } else {
                 Set<Pom> boms = bomResolver.resolveForProject(mavenProject);
                 if (!boms.isEmpty()) {
                     node.setBoms(boms);
                 }
-                visitedBoms.add(node.getChecksum());
+                bomsResolved.put(mavenProject,boms);
             }
         });
     }
@@ -370,12 +376,12 @@ public class LockFileFacade {
     /**
      * Resolve the dependencies of a Maven plugin.
      *
-     * @param pluginProject The plugin project to resolve dependencies for
-     * @param session The Maven session
-     * @param repositories The repositories to use for resolving dependencies
+     * @param pluginProject              The plugin project to resolve dependencies for
+     * @param session                    The Maven session
+     * @param repositories               The repositories to use for resolving dependencies
      * @param dependencyCollectorBuilder The dependency collector builder
-     * @param checksumCalculator The checksum calculator
-     * @param userDeclaredDeps User-declared dependencies for this plugin (from the project's pom.xml)
+     * @param checksumCalculator         The checksum calculator
+     * @param userDeclaredDeps           User-declared dependencies for this plugin (from the project's pom.xml)
      * @return A set of dependency nodes representing the plugin's dependencies
      */
     private static Set<io.github.chains_project.maven_lockfile.graph.DependencyNode> resolveComponentDependencies(
@@ -443,7 +449,7 @@ public class LockFileFacade {
                     filter,
                     false);
 
-            resolveParentsAndBomsForDependencies(dependencyGraph, session, pluginProject, checksumCalculator, writtenParentPoms, visitedBoms);
+            resolveParentsAndBomsForDependencies(dependencyGraph, session, pluginProject, checksumCalculator);
 
             // Get root dependency nodes (excluding the plugin project itself)
             Set<io.github.chains_project.maven_lockfile.graph.DependencyNode> roots = dependencyGraph.getRoots();
@@ -529,10 +535,10 @@ public class LockFileFacade {
             String relativePath = project.getFile() == null
                     ? null
                     : initialProject
-                            .getBasedir()
-                            .toPath()
-                            .relativize(project.getFile().toPath())
-                            .toString();
+                    .getBasedir()
+                    .toPath()
+                    .relativize(project.getFile().toPath())
+                    .toString();
             String checksum;
             ResolvedUrl resolved = null;
             RepositoryId repoId = null;
@@ -567,7 +573,7 @@ public class LockFileFacade {
                     checksumAlgorithm,
                     checksum,
                     lastPom);
-            if(!boms.isEmpty()) {
+            if (!boms.isEmpty()) {
                 lastPom.setBoms(boms);
             }
         }
@@ -578,8 +584,8 @@ public class LockFileFacade {
     /**
      * Resolve the BOM POMs for the current project.
      *
-     * @param session The Maven session
-     * @param rootProject The current Maven project (for repository configuration)
+     * @param session            The Maven session
+     * @param rootProject        The current Maven project (for repository configuration)
      * @param checksumCalculator The checksum calculator
      * @return A set of BOM POMs
      */

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/LockFileFacade.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/LockFileFacade.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
 import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.resolver.filter.ArtifactFilter;
 import org.apache.maven.artifact.resolver.filter.ScopeArtifactFilter;
 import org.apache.maven.execution.MavenSession;
@@ -25,6 +26,7 @@ import org.apache.maven.project.DefaultProjectBuildingRequest;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuildingRequest;
 import org.apache.maven.shared.dependency.graph.DependencyCollectorBuilder;
+import org.apache.maven.shared.dependency.graph.DependencyCollectorBuilderException;
 import org.apache.maven.shared.dependency.graph.DependencyNode;
 import org.apache.maven.shared.dependency.graph.traversal.DependencyNodeVisitor;
 import org.eclipse.aether.RepositorySystem;
@@ -115,10 +117,7 @@ public class LockFileFacade {
                 dependencyCollectorBuilder,
                 checksumCalculator,
                 metadata.getConfig().isReduced());
-        var roots = graph.getGraph().stream()
-                .filter(v -> v.getParent() == null)
-                .collect(Collectors.toCollection(() -> new TreeSet<>(Comparator.comparing(
-                        io.github.chains_project.maven_lockfile.graph.DependencyNode::getComparatorString))));
+        var roots = graph.getRoots();
         var pom = constructRecursivePom(project, session, checksumCalculator);
 
         resolveParentPomsForDependencies(graph, session, project, checksumCalculator);
@@ -191,9 +190,9 @@ public class LockFileFacade {
                 // Resolve extension's transitive dependencies using the existing mechanism
                 Set<io.github.chains_project.maven_lockfile.graph.DependencyNode> transitiveDeps =
                         resolveComponentDependencies(
-                                mavenArtifact,
-                                session,
                                 project,
+                                session,
+                                project.getRemoteArtifactRepositories(),
                                 dependencyCollectorBuilder,
                                 checksumCalculator,
                                 Collections.emptyList());
@@ -258,7 +257,7 @@ public class LockFileFacade {
                 var projectDep = projectOptional.get();
 
                 if(projectDep.hasParent()) {
-                    PluginLogManager.getLog().info(String.format("Writing parent POM for %s", node));
+                    PluginLogManager.getLog().debug(String.format("Writing parent POM for %s", node));
                     var pom = constructRecursivePom(projectDep.getParent(), session, checksumCalculator);
                     node.setParentPom(pom);
                 }
@@ -287,22 +286,32 @@ public class LockFileFacade {
                 }
             }
         }
+        ProjectBuilder projectBuilder = new ProjectBuilder(session, project.getPluginArtifactRepositories());
 
         for (Artifact pluginArtifact : project.getPluginArtifacts()) {
             RepositoryInformation repositoryInformation = checksumCalculator.getPluginResolvedField(pluginArtifact);
             String pluginKey = pluginArtifact.getGroupId() + ":" + pluginArtifact.getArtifactId();
             List<Dependency> userDeclaredDeps = userPluginDependencies.getOrDefault(pluginKey, Collections.emptyList());
 
+            Optional<MavenProject> pluginProjectOptional = projectBuilder.buildFromGav(
+                    pluginArtifact.getGroupId(), pluginArtifact.getArtifactId(), pluginArtifact.getBaseVersion());
+
+            if (pluginProjectOptional.isEmpty()) {
+                PluginLogManager.getLog().warn(String.format("Could not build project for plugin %s", pluginArtifact));
+                continue;
+            }
+            MavenProject pluginProject = pluginProjectOptional.get();
+
             Set<io.github.chains_project.maven_lockfile.graph.DependencyNode> pluginDependencies =
                     resolveComponentDependencies(
-                            pluginArtifact,
+                            pluginProject,
                             session,
-                            project,
+                            project.getPluginArtifactRepositories(),
                             dependencyCollectorBuilder,
                             checksumCalculator,
                             userDeclaredDeps);
 
-            Pom parent = resolvePluginParents(pluginArtifact, session, project, checksumCalculator);
+            Pom parent = resolvePluginParents(pluginProject, session, checksumCalculator);
 
             plugins.add(new MavenPlugin(
                     GroupId.of(pluginArtifact.getGroupId()),
@@ -318,59 +327,42 @@ public class LockFileFacade {
         return plugins;
     }
 
-    private static Pom resolvePluginParents(Artifact pluginArtifact, MavenSession session, MavenProject project, AbstractChecksumCalculator checksumCalculator) {
-        ProjectBuilder projectBuilder = new ProjectBuilder(session, project.getPluginArtifactRepositories());
-
-        // TODO: avoid building the plugin project twice (it is already being done to resolve dependencies)
-        Optional<MavenProject> pluginProjectOptional = projectBuilder.buildFromGav(
-                pluginArtifact.getGroupId(), pluginArtifact.getArtifactId(), pluginArtifact.getBaseVersion());
-
-        if (pluginProjectOptional.isEmpty()) {
-            PluginLogManager.getLog().warn(String.format("Could not build project for plugin %s", pluginArtifact));
+    private static Pom resolvePluginParents(
+            MavenProject pluginProject, MavenSession session, AbstractChecksumCalculator checksumCalculator) {
+        if (!pluginProject.hasParent()) {
             return null;
         }
-
-        return constructRecursivePom(pluginProjectOptional.get(), session, checksumCalculator);
+        return constructRecursivePom(pluginProject.getParent(), session, checksumCalculator);
     }
 
     /**
      * Resolve the dependencies of a Maven plugin.
      *
-     * @param pluginArtifact             The plugin artifact to resolve dependencies for
-     * @param session                    The Maven session
-     * @param project                    The current Maven project (for repository configuration)
+     * @param pluginProject The plugin project to resolve dependencies for
+     * @param session The Maven session
+     * @param repositories The repositories to use for resolving dependencies
      * @param dependencyCollectorBuilder The dependency collector builder
-     * @param checksumCalculator         The checksum calculator
-     * @param userDeclaredDeps           User-declared dependencies for this plugin (from the project's pom.xml)
+     * @param checksumCalculator The checksum calculator
+     * @param userDeclaredDeps User-declared dependencies for this plugin (from the project's pom.xml)
      * @return A set of dependency nodes representing the plugin's dependencies
      */
     private static Set<io.github.chains_project.maven_lockfile.graph.DependencyNode> resolveComponentDependencies(
-            Artifact pluginArtifact,
+            MavenProject pluginProject,
             MavenSession session,
-            MavenProject project,
+            List<ArtifactRepository> repositories,
             DependencyCollectorBuilder dependencyCollectorBuilder,
             AbstractChecksumCalculator checksumCalculator,
             List<Dependency> userDeclaredDeps) {
         PluginLogManager.getLog()
-                .debug(String.format("Attempting to resolve dependencies for plugin %s", pluginArtifact));
+                .debug(String.format("Attempting to resolve dependencies for plugin %s", pluginProject.getArtifact()));
         try {
-            ProjectBuilder projectBuilder = new ProjectBuilder(session, project.getPluginArtifactRepositories());
-            Optional<MavenProject> pluginProjectOptional = projectBuilder.buildFromGav(
-                    pluginArtifact.getGroupId(), pluginArtifact.getArtifactId(), pluginArtifact.getBaseVersion());
-
-            if (pluginProjectOptional.isEmpty()) {
-                PluginLogManager.getLog().warn(String.format("Could not build project for plugin %s", pluginArtifact));
-                return Collections.emptySet();
-            }
-
-            var pluginProject = pluginProjectOptional.get();
 
             int declaredDeps = pluginProject.getDependencies() != null
                     ? pluginProject.getDependencies().size()
                     : 0;
             PluginLogManager.getLog()
                     .debug(String.format(
-                            "Built plugin project %s with %d declared dependencies", pluginArtifact, declaredDeps));
+                            "Built plugin project %s with %d declared dependencies", pluginProject.getArtifact(), declaredDeps));
 
             // Merge user-declared dependencies into the plugin project
             // User-declared dependencies override the plugin's default dependencies (e.g., scope changes)
@@ -395,7 +387,7 @@ public class LockFileFacade {
                     } else {
                         PluginLogManager.getLog()
                                 .debug(String.format(
-                                        "Adding user-declared dependency %s to plugin %s", key, pluginArtifact));
+                                        "Adding user-declared dependency %s to plugin %s", key, pluginProject.getArtifact()));
                     }
                     pluginDeps.add(userDep);
                 }
@@ -403,51 +395,34 @@ public class LockFileFacade {
                 PluginLogManager.getLog()
                         .debug(String.format(
                                 "Plugin %s now has %d dependencies after merging user-declared dependencies",
-                                pluginArtifact, pluginDeps.size()));
+                                pluginProject.getArtifact(), pluginDeps.size()));
             }
-
-            // Resolve dependencies using DependencyCollectorBuilder
-            ProjectBuildingRequest dependencyBuildingRequest =
-                    new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
-            dependencyBuildingRequest.setProject(pluginProject);
-            dependencyBuildingRequest.setRemoteRepositories(project.getPluginArtifactRepositories());
 
             // Filter artifacts to "compile+runtime" scopes. Maven plugins require their runtime
             // scope dependencies to be present alongside any compile-time dependencies.
             // Test scope dependencies of plugins should be excluded.
             ArtifactFilter filter = new ScopeArtifactFilter("compile+runtime");
-            var rootNode = dependencyCollectorBuilder.collectDependencyGraph(dependencyBuildingRequest, filter);
+            DependencyGraph dependencyGraph = createDependencyGraph(
+                    pluginProject,
+                    session,
+                    repositories,
+                    dependencyCollectorBuilder,
+                    checksumCalculator,
+                    filter,
+                    false);
 
-            int rootChildren =
-                    rootNode.getChildren() != null ? rootNode.getChildren().size() : 0;
-            PluginLogManager.getLog()
-                    .debug(String.format(
-                            "Collected dependency graph for plugin %s, root node has %d children",
-                            pluginArtifact, rootChildren));
-
-            // Convert to DependencyGraph and extract root nodes
-            MutableGraph<DependencyNode> graph = GraphBuilder.directed().build();
-            rootNode.accept(new GraphBuildingNodeVisitor(graph));
-
-            PluginLogManager.getLog()
-                    .debug(String.format(
-                            "Built graph with %d nodes for plugin %s",
-                            graph.nodes().size(), pluginArtifact));
-
-            DependencyGraph dependencyGraph = DependencyGraph.of(graph, checksumCalculator, false);
-
-            resolveParentPomsForDependencies(dependencyGraph, session, project, checksumCalculator);
-            resolveBomsForDependencies(dependencyGraph, session, project, checksumCalculator);
+            resolveParentPomsForDependencies(dependencyGraph, session, pluginProject, checksumCalculator);
+            resolveBomsForDependencies(dependencyGraph, session, pluginProject, checksumCalculator);
 
             // Get root dependency nodes (excluding the plugin project itself)
             Set<io.github.chains_project.maven_lockfile.graph.DependencyNode> roots = dependencyGraph.getRoots();
             PluginLogManager.getLog()
-                    .info(String.format("Resolved %4d dependencies for plugin %s", roots.size(), pluginArtifact));
+                    .info(String.format("Resolved %4d dependencies for plugin %s", roots.size(), pluginProject.getArtifact()));
             return roots;
 
         } catch (Exception e) {
             PluginLogManager.getLog()
-                    .warn(String.format("Could not resolve dependencies for plugin %s", pluginArtifact), e);
+                    .warn(String.format("Could not resolve dependencies for plugin %s", pluginProject.getArtifact()), e);
             return Collections.emptySet();
         }
     }
@@ -458,21 +433,43 @@ public class LockFileFacade {
             DependencyCollectorBuilder dependencyCollectorBuilder,
             AbstractChecksumCalculator checksumCalculator,
             boolean reduced) {
+        return createDependencyGraph(
+                project,
+                session,
+                project.getRemoteArtifactRepositories(),
+                dependencyCollectorBuilder,
+                checksumCalculator,
+                null,
+                reduced);
+    }
+
+    private static DependencyGraph createDependencyGraph(
+            MavenProject project,
+            MavenSession session,
+            List<ArtifactRepository> repositories,
+            DependencyCollectorBuilder dependencyCollectorBuilder,
+            AbstractChecksumCalculator checksumCalculator,
+            ArtifactFilter filter,
+            boolean reduced) {
         try {
             ProjectBuildingRequest buildingRequest =
                     new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
-
             buildingRequest.setProject(project);
-            var rootNode = dependencyCollectorBuilder.collectDependencyGraph(buildingRequest, null);
+            buildingRequest.setRemoteRepositories(repositories);
+
+            DependencyNode rootNode =
+                    dependencyCollectorBuilder.collectDependencyGraph(buildingRequest, filter);
 
             MutableGraph<DependencyNode> graph = GraphBuilder.directed().build();
             rootNode.accept(new GraphBuildingNodeVisitor(graph));
+
             PluginLogManager.getLog()
                     .info(String.format(
                             "Resolved %4d dependencies for project %s",
-                            graph.nodes().size(), project));
+                            graph.nodes().size(), project.getArtifactId()));
+
             return DependencyGraph.of(graph, checksumCalculator, reduced);
-        } catch (Exception e) {
+        } catch (DependencyCollectorBuilderException e) {
             PluginLogManager.getLog().warn("Could not generate graph", e);
             return DependencyGraph.of(GraphBuilder.directed().build(), checksumCalculator, reduced);
         }

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/LockFileFacade.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/LockFileFacade.java
@@ -9,11 +9,9 @@ import io.github.chains_project.maven_lockfile.graph.DependencyGraph;
 import io.github.chains_project.maven_lockfile.reporting.PluginLogManager;
 import io.github.chains_project.maven_lockfile.resolvers.BomResolver;
 import io.github.chains_project.maven_lockfile.resolvers.ProjectBuilder;
-
 import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
-
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
 import org.apache.maven.artifact.handler.DefaultArtifactHandler;
@@ -263,7 +261,6 @@ public class LockFileFacade {
                 new BomResolver(session, rootProject.getRemoteArtifactRepositories(), checksumCalculator);
 
         graph.getDependencySet().forEach(node -> {
-
             var projectOptional = builder.buildFromGav(
                     node.getGroupId().getValue(),
                     node.getArtifactId().getValue(),
@@ -281,8 +278,8 @@ public class LockFileFacade {
             if (mavenProject.hasParent()) {
                 PluginLogManager.getLog().debug(String.format("Writting parent POM for dependency %s", node));
 
-                //Optimization, not to resolve parent if already resolved
-                //It has to be written in full form before lockfile v2
+                // Optimization, not to resolve parent if already resolved
+                // It has to be written in full form before lockfile v2
                 Pom pom = constructRecursivePom(mavenProject.getParent(), session, checksumCalculator);
                 node.setParentPom(pom);
             }
@@ -389,7 +386,8 @@ public class LockFileFacade {
                     : 0;
             PluginLogManager.getLog()
                     .debug(String.format(
-                            "Built plugin project %s with %d declared dependencies", pluginProject.getArtifact(), declaredDeps));
+                            "Built plugin project %s with %d declared dependencies",
+                            pluginProject.getArtifact(), declaredDeps));
 
             // Merge user-declared dependencies into the plugin project
             // User-declared dependencies override the plugin's default dependencies (e.g., scope changes)
@@ -414,7 +412,8 @@ public class LockFileFacade {
                     } else {
                         PluginLogManager.getLog()
                                 .debug(String.format(
-                                        "Adding user-declared dependency %s to plugin %s", key, pluginProject.getArtifact()));
+                                        "Adding user-declared dependency %s to plugin %s",
+                                        key, pluginProject.getArtifact()));
                     }
                     pluginDeps.add(userDep);
                 }
@@ -443,12 +442,15 @@ public class LockFileFacade {
             // Get root dependency nodes (excluding the plugin project itself)
             Set<io.github.chains_project.maven_lockfile.graph.DependencyNode> roots = dependencyGraph.getRoots();
             PluginLogManager.getLog()
-                    .info(String.format("Resolved %4d dependencies for plugin %s", roots.size(), pluginProject.getArtifact()));
+                    .info(String.format(
+                            "Resolved %4d dependencies for plugin %s", roots.size(), pluginProject.getArtifact()));
             return roots;
 
         } catch (Exception e) {
             PluginLogManager.getLog()
-                    .warn(String.format("Could not resolve dependencies for plugin %s", pluginProject.getArtifact()), e);
+                    .warn(
+                            String.format("Could not resolve dependencies for plugin %s", pluginProject.getArtifact()),
+                            e);
             return Collections.emptySet();
         }
     }
@@ -467,8 +469,7 @@ public class LockFileFacade {
             buildingRequest.setProject(project);
             buildingRequest.setRemoteRepositories(repositories);
 
-            DependencyNode rootNode =
-                    dependencyCollectorBuilder.collectDependencyGraph(buildingRequest, filter);
+            DependencyNode rootNode = dependencyCollectorBuilder.collectDependencyGraph(buildingRequest, filter);
 
             MutableGraph<DependencyNode> graph = GraphBuilder.directed().build();
             rootNode.accept(new GraphBuildingNodeVisitor(graph));
@@ -493,7 +494,8 @@ public class LockFileFacade {
             MavenProject initialProject, MavenSession session, AbstractChecksumCalculator checksumCalculator) {
         String checksumAlgorithm = checksumCalculator.getChecksumAlgorithm();
 
-        BomResolver bomResolver = new BomResolver(session, initialProject.getRemoteArtifactRepositories(), checksumCalculator);
+        BomResolver bomResolver =
+                new BomResolver(session, initialProject.getRemoteArtifactRepositories(), checksumCalculator);
         List<MavenProject> recursiveProjects = new ArrayList<>();
         MavenProject currentProject = initialProject;
         recursiveProjects.add(currentProject);
@@ -503,16 +505,14 @@ public class LockFileFacade {
         }
 
         @SuppressWarnings("deprecation")
-        Path localRepoBasePath = session.getRepositorySession()
-                .getLocalRepository()
-                .getBasedir()
-                .toPath();
+        Path localRepoBasePath =
+                session.getRepositorySession().getLocalRepository().getBasedir().toPath();
 
         Pom lastPom = null;
         Collections.reverse(recursiveProjects);
         for (MavenProject project : recursiveProjects) {
-            boolean cachedInLocalRepo = project.getFile() != null
-                    && project.getFile().toPath().startsWith(localRepoBasePath);
+            boolean cachedInLocalRepo =
+                    project.getFile() != null && project.getFile().toPath().startsWith(localRepoBasePath);
             boolean isExternalPom = project.getFile() == null || cachedInLocalRepo;
 
             String relativePath = isExternalPom
@@ -542,7 +542,8 @@ public class LockFileFacade {
                     // Pre-set the file so getArtifactResolvedField can read _remote.repositories
                     // even if the POM-type dependency resolution fails
                     pomArtifact.setFile(project.getFile());
-                    checksum = checksumCalculator.calculatePomChecksum(project.getFile().toPath());
+                    checksum = checksumCalculator.calculatePomChecksum(
+                            project.getFile().toPath());
                 } else {
                     checksum = checksumCalculator.calculateArtifactChecksum(pomArtifact);
                 }

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/LockFileFacade.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/LockFileFacade.java
@@ -119,8 +119,10 @@ public class LockFileFacade {
                 .filter(v -> v.getParent() == null)
                 .collect(Collectors.toCollection(() -> new TreeSet<>(Comparator.comparing(
                         io.github.chains_project.maven_lockfile.graph.DependencyNode::getComparatorString))));
-        var pom = constructRecursivePom(project, checksumCalculator);
-        var boms = resolveBoms(graph, session, project, checksumCalculator);
+        var pom = constructRecursivePom(project, session, checksumCalculator);
+        //var boms = resolveBoms(graph, session, project, checksumCalculator);
+        resolveBomsForDependencies(graph, session, project, checksumCalculator);
+        var boms = resolveBoms(session, project, checksumCalculator);
 
         return new LockFile(
                 GroupId.of(project.getGroupId()),
@@ -392,6 +394,7 @@ public class LockFileFacade {
 
             DependencyGraph dependencyGraph = DependencyGraph.of(graph, checksumCalculator, false);
 
+            resolveBomsForDependencies(dependencyGraph, session, project, checksumCalculator);
             // Get root dependency nodes (excluding the plugin project itself)
             Set<io.github.chains_project.maven_lockfile.graph.DependencyNode> roots = dependencyGraph.getRoots();
             PluginLogManager.getLog()
@@ -436,9 +439,10 @@ public class LockFileFacade {
      * POMs may be relative to the project being built, or are specified from an external POM.
      */
     private static Pom constructRecursivePom(
-            MavenProject initialProject, AbstractChecksumCalculator checksumCalculator) {
+            MavenProject initialProject, MavenSession session, AbstractChecksumCalculator checksumCalculator) {
         String checksumAlgorithm = checksumCalculator.getChecksumAlgorithm();
 
+        BomResolver bomResolver = new BomResolver(session, initialProject.getRemoteArtifactRepositories(), checksumCalculator);
         List<MavenProject> recursiveProjects = new ArrayList<>();
         MavenProject currentProject = initialProject;
         recursiveProjects.add(currentProject);
@@ -479,6 +483,8 @@ public class LockFileFacade {
                 checksum = checksumCalculator.calculatePomChecksum(
                         project.getFile().toPath());
             }
+
+            Set<Pom> boms = bomResolver.resolveForProject(project);
             lastPom = new Pom(
                     GroupId.of(project.getGroupId()),
                     ArtifactId.of(project.getArtifactId()),
@@ -489,6 +495,9 @@ public class LockFileFacade {
                     checksumAlgorithm,
                     checksum,
                     lastPom);
+            if(!boms.isEmpty()) {
+                lastPom.setBoms(boms);
+            }
         }
 
         return lastPom;
@@ -501,16 +510,49 @@ public class LockFileFacade {
      *
      * @param graph              The dependency graph
      * @param session            The Maven session
-     * @param project            The current Maven project
+     * @param rootProject        The current Maven project
      * @param checksumCalculator The checksum calculator
      */
-    private static Set<Pom> resolveBoms(
+    private static void resolveBomsForDependencies(
             DependencyGraph graph,
             MavenSession session,
-            MavenProject project,
+            MavenProject rootProject,
             AbstractChecksumCalculator checksumCalculator) {
-        BomResolver resolver = new BomResolver(session, project.getRemoteArtifactRepositories(), checksumCalculator);
-        resolver.resolveBomsForDependencies(graph);
-        return resolver.resolveForProject(project);
+        ProjectBuilder projectBuilder = new ProjectBuilder(session, rootProject.getRemoteArtifactRepositories());
+        BomResolver bomResolver =
+                new BomResolver(session, rootProject.getRemoteArtifactRepositories(), checksumCalculator);
+
+        graph.getDependencySet().forEach(node -> {
+            var projectOptional = projectBuilder.buildFromGav(
+                    node.getGroupId().getValue(),
+                    node.getArtifactId().getValue(),
+                    node.getVersion().getValue());
+
+            if (projectOptional.isEmpty()) {
+                PluginLogManager.getLog().warn(String.format("Skipping BOM resolution for %s", node));
+                return;
+            }
+
+            Set<Pom> boms = bomResolver.resolveForProject(projectOptional.get());
+
+            if (!boms.isEmpty()) {
+                node.setBoms(boms);
+            }
+        });
+    }
+
+    /**
+     * Resolve the BOM POMs for the current project.
+     *
+     * @param session The Maven session
+     * @param rootProject The current Maven project (for repository configuration)
+     * @param checksumCalculator The checksum calculator
+     * @return A set of BOM POMs
+     */
+    private static Set<Pom> resolveBoms(
+            MavenSession session, MavenProject rootProject, AbstractChecksumCalculator checksumCalculator) {
+        BomResolver bomResolver =
+                new BomResolver(session, rootProject.getRemoteArtifactRepositories(), checksumCalculator);
+        return bomResolver.resolveForProject(rootProject);
     }
 }

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/LockFileFacade.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/LockFileFacade.java
@@ -502,22 +502,34 @@ public class LockFileFacade {
             recursiveProjects.add(currentProject);
         }
 
+        @SuppressWarnings("deprecation")
+        Path localRepoBasePath = session.getRepositorySession()
+                .getLocalRepository()
+                .getBasedir()
+                .toPath();
+
         Pom lastPom = null;
         Collections.reverse(recursiveProjects);
         for (MavenProject project : recursiveProjects) {
-            String relativePath = project.getFile() == null
+            boolean cachedInLocalRepo = project.getFile() != null
+                    && project.getFile().toPath().startsWith(localRepoBasePath);
+            boolean isExternalPom = project.getFile() == null || cachedInLocalRepo;
+
+            String relativePath = isExternalPom
                     ? null
                     : initialProject
-                    .getBasedir()
-                    .toPath()
-                    .relativize(project.getFile().toPath())
-                    .toString();
+                            .getBasedir()
+                            .toPath()
+                            .relativize(project.getFile().toPath())
+                            .toString();
             String checksum;
             ResolvedUrl resolved = null;
             RepositoryId repoId = null;
-            if (project.getFile() == null) {
-                // External POM - get repository information
+            if (isExternalPom) {
+                // External POM (not in project directory) - get repository information
                 Artifact artifact = project.getArtifact();
+                // Use an explicit POM handler so getArtifactHandler().getExtension() reliably
+                // returns "pom", which is required for parsing _remote.repositories correctly.
                 Artifact pomArtifact = new DefaultArtifact(
                         artifact.getGroupId(),
                         artifact.getArtifactId(),
@@ -525,8 +537,15 @@ public class LockFileFacade {
                         artifact.getScope(),
                         "pom",
                         artifact.getClassifier(),
-                        artifact.getArtifactHandler());
-                checksum = checksumCalculator.calculateArtifactChecksum(pomArtifact);
+                        new org.apache.maven.artifact.handler.DefaultArtifactHandler("pom"));
+                if (cachedInLocalRepo) {
+                    // Pre-set the file so getArtifactResolvedField can read _remote.repositories
+                    // even if the POM-type dependency resolution fails
+                    pomArtifact.setFile(project.getFile());
+                    checksum = checksumCalculator.calculatePomChecksum(project.getFile().toPath());
+                } else {
+                    checksum = checksumCalculator.calculateArtifactChecksum(pomArtifact);
+                }
                 RepositoryInformation repoInfo = checksumCalculator.getArtifactResolvedField(pomArtifact);
                 resolved = repoInfo.getResolvedUrl();
                 repoId = repoInfo.getRepositoryId();

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/LockFileFacade.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/LockFileFacade.java
@@ -43,10 +43,6 @@ import org.eclipse.aether.util.artifact.JavaScopes;
  *
  */
 public class LockFileFacade {
-
-    private static final Map<MavenProject, Pom> parentsResolved = new HashMap<>();
-    private static final Map<MavenProject, Set<Pom>> bomsResolved = new HashMap<>();
-
     /**
      * This visitor is used to traverse the dependency graph and add the edges to the graph.
      */
@@ -287,23 +283,13 @@ public class LockFileFacade {
 
                 //Optimization, not to resolve parent if already resolved
                 //It has to be written in full form before lockfile v2
-                if (parentsResolved.containsKey(mavenProject.getParent())) {
-                    node.setParentPom(parentsResolved.get(mavenProject.getParent()));
-                } else {
-                    Pom pom = constructRecursivePom(mavenProject.getParent(), session, checksumCalculator);
-                    parentsResolved.put(mavenProject.getParent(), pom);
-                    node.setParentPom(pom);
-                }
+                Pom pom = constructRecursivePom(mavenProject.getParent(), session, checksumCalculator);
+                node.setParentPom(pom);
             }
 
-            if (bomsResolved.containsKey(mavenProject)) {
-                node.setBoms(bomsResolved.get(mavenProject));
-            } else {
-                Set<Pom> boms = bomResolver.resolveForProject(mavenProject);
-                if (!boms.isEmpty()) {
-                    node.setBoms(boms);
-                }
-                bomsResolved.put(mavenProject, boms);
+            Set<Pom> boms = bomResolver.resolveForProject(mavenProject);
+            if (!boms.isEmpty()) {
+                node.setBoms(boms);
             }
         });
     }

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/LockFileFacade.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/LockFileFacade.java
@@ -120,7 +120,8 @@ public class LockFileFacade {
                 .collect(Collectors.toCollection(() -> new TreeSet<>(Comparator.comparing(
                         io.github.chains_project.maven_lockfile.graph.DependencyNode::getComparatorString))));
         var pom = constructRecursivePom(project, session, checksumCalculator);
-        //var boms = resolveBoms(graph, session, project, checksumCalculator);
+
+        resolveParentPomsForDependencies(graph, session, project, checksumCalculator);
         resolveBomsForDependencies(graph, session, project, checksumCalculator);
         var boms = resolveBoms(session, project, checksumCalculator);
 
@@ -245,6 +246,28 @@ public class LockFileFacade {
         return Optional.of(new org.eclipse.aether.graph.Dependency(artifact, JavaScopes.RUNTIME));
     }
 
+    private static void resolveParentPomsForDependencies(DependencyGraph graph, MavenSession session, MavenProject project, AbstractChecksumCalculator checksumCalculator) {
+        ProjectBuilder builder = new ProjectBuilder(session, project.getRemoteArtifactRepositories());
+        graph.getDependencySet().forEach(node -> {
+            var projectOptional = builder.buildFromGav(
+                    node.getGroupId().getValue(),
+                    node.getArtifactId().getValue(),
+                    node.getVersion().getValue());
+
+            if(projectOptional.isPresent()) {
+                var projectDep = projectOptional.get();
+
+                if(projectDep.hasParent()) {
+                    PluginLogManager.getLog().info(String.format("Writing parent POM for %s", node));
+                    var pom = constructRecursivePom(projectDep.getParent(), session, checksumCalculator);
+                    node.setParentPom(pom);
+                }
+            } else {
+                PluginLogManager.getLog().warn(String.format("Could not build project for dependency %s", node));
+            }
+        });
+    }
+
     private static Set<MavenPlugin> getAllPlugins(
             MavenProject project,
             MavenSession session,
@@ -278,6 +301,9 @@ public class LockFileFacade {
                             dependencyCollectorBuilder,
                             checksumCalculator,
                             userDeclaredDeps);
+
+            Pom parent = resolvePluginParents(pluginArtifact, session, project, checksumCalculator);
+
             plugins.add(new MavenPlugin(
                     GroupId.of(pluginArtifact.getGroupId()),
                     ArtifactId.of(pluginArtifact.getArtifactId()),
@@ -286,9 +312,25 @@ public class LockFileFacade {
                     repositoryInformation.getRepositoryId(),
                     checksumCalculator.getChecksumAlgorithm(),
                     checksumCalculator.calculatePluginChecksum(pluginArtifact),
-                    pluginDependencies));
+                    pluginDependencies,
+                    parent));
         }
         return plugins;
+    }
+
+    private static Pom resolvePluginParents(Artifact pluginArtifact, MavenSession session, MavenProject project, AbstractChecksumCalculator checksumCalculator) {
+        ProjectBuilder projectBuilder = new ProjectBuilder(session, project.getPluginArtifactRepositories());
+
+        // TODO: avoid building the plugin project twice (it is already being done to resolve dependencies)
+        Optional<MavenProject> pluginProjectOptional = projectBuilder.buildFromGav(
+                pluginArtifact.getGroupId(), pluginArtifact.getArtifactId(), pluginArtifact.getBaseVersion());
+
+        if (pluginProjectOptional.isEmpty()) {
+            PluginLogManager.getLog().warn(String.format("Could not build project for plugin %s", pluginArtifact));
+            return null;
+        }
+
+        return constructRecursivePom(pluginProjectOptional.get(), session, checksumCalculator);
     }
 
     /**
@@ -394,7 +436,9 @@ public class LockFileFacade {
 
             DependencyGraph dependencyGraph = DependencyGraph.of(graph, checksumCalculator, false);
 
+            resolveParentPomsForDependencies(dependencyGraph, session, project, checksumCalculator);
             resolveBomsForDependencies(dependencyGraph, session, project, checksumCalculator);
+
             // Get root dependency nodes (excluding the plugin project itself)
             Set<io.github.chains_project.maven_lockfile.graph.DependencyNode> roots = dependencyGraph.getRoots();
             PluginLogManager.getLog()

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/LockFileFacade.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/LockFileFacade.java
@@ -116,16 +116,19 @@ public class LockFileFacade {
                 getAllExtensions(project, session, dependencyCollectorBuilder, checksumCalculator, repositorySystem);
 
         // Get all the artifacts for the dependencies in the project
-        var graph = LockFileFacade.graph(
-                session,
+        DependencyGraph dependencyGraph = createDependencyGraph(
                 project,
+                session,
+                project.getRemoteArtifactRepositories(),
                 dependencyCollectorBuilder,
                 checksumCalculator,
+                null,
                 metadata.getConfig().isReduced());
-        var roots = graph.getRoots();
+
+        var roots = dependencyGraph.getRoots();
         var pom = constructRecursivePom(project, session, checksumCalculator);
 
-        resolveParentsAndBomsForDependencies(graph, session, project, checksumCalculator);
+        resolveParentsAndBomsForDependencies(dependencyGraph, session, project, checksumCalculator);
         var boms = resolveBoms(session, project, checksumCalculator);
 
         return new LockFile(
@@ -300,7 +303,7 @@ public class LockFileFacade {
                 if (!boms.isEmpty()) {
                     node.setBoms(boms);
                 }
-                bomsResolved.put(mavenProject,boms);
+                bomsResolved.put(mavenProject, boms);
             }
         });
     }
@@ -462,22 +465,6 @@ public class LockFileFacade {
                     .warn(String.format("Could not resolve dependencies for plugin %s", pluginProject.getArtifact()), e);
             return Collections.emptySet();
         }
-    }
-
-    private static DependencyGraph graph(
-            MavenSession session,
-            MavenProject project,
-            DependencyCollectorBuilder dependencyCollectorBuilder,
-            AbstractChecksumCalculator checksumCalculator,
-            boolean reduced) {
-        return createDependencyGraph(
-                project,
-                session,
-                project.getRemoteArtifactRepositories(),
-                dependencyCollectorBuilder,
-                checksumCalculator,
-                null,
-                reduced);
     }
 
     private static DependencyGraph createDependencyGraph(

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/LockFileFacade.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/LockFileFacade.java
@@ -42,6 +42,9 @@ import org.eclipse.aether.util.artifact.JavaScopes;
  */
 public class LockFileFacade {
 
+    private static final Set<String> writtenParentPoms = new HashSet<>();
+    private static final Set<String> visitedBoms = new HashSet<>();
+
     /**
      * This visitor is used to traverse the dependency graph and add the edges to the graph.
      */
@@ -120,8 +123,7 @@ public class LockFileFacade {
         var roots = graph.getRoots();
         var pom = constructRecursivePom(project, session, checksumCalculator);
 
-        resolveParentPomsForDependencies(graph, session, project, checksumCalculator);
-        resolveBomsForDependencies(graph, session, project, checksumCalculator);
+        resolveParentsAndBomsForDependencies(graph, session, project, checksumCalculator, writtenParentPoms, visitedBoms);
         var boms = resolveBoms(session, project, checksumCalculator);
 
         return new LockFile(
@@ -245,24 +247,54 @@ public class LockFileFacade {
         return Optional.of(new org.eclipse.aether.graph.Dependency(artifact, JavaScopes.RUNTIME));
     }
 
-    private static void resolveParentPomsForDependencies(DependencyGraph graph, MavenSession session, MavenProject project, AbstractChecksumCalculator checksumCalculator) {
-        ProjectBuilder builder = new ProjectBuilder(session, project.getRemoteArtifactRepositories());
+    private static void resolveParentsAndBomsForDependencies(
+            DependencyGraph graph,
+            MavenSession session,
+            MavenProject rootProject,
+            AbstractChecksumCalculator checksumCalculator,
+            Set<String> writtenParentPoms,
+            Set<String> visitedBoms) {
+        ProjectBuilder builder = new ProjectBuilder(session, rootProject.getRemoteArtifactRepositories());
+        BomResolver bomResolver =
+                new BomResolver(session, rootProject.getRemoteArtifactRepositories(), checksumCalculator);
+
         graph.getDependencySet().forEach(node -> {
+            boolean needsParentPom = !writtenParentPoms.contains(node.getChecksum());
+            boolean needsBom = !visitedBoms.contains(node.getChecksum());
+
+            if (!needsParentPom && !needsBom) {
+                return;
+            }
+
             var projectOptional = builder.buildFromGav(
                     node.getGroupId().getValue(),
                     node.getArtifactId().getValue(),
                     node.getVersion().getValue());
 
-            if(projectOptional.isPresent()) {
-                var projectDep = projectOptional.get();
+            if (projectOptional.isEmpty()) {
+                PluginLogManager.getLog()
+                        .warn(String.format(
+                                "Could not build project for dependency %s. Skipping parent and BOM resolution.",
+                                node));
+                return;
+            }
+            var mavenProject = projectOptional.get();
 
-                if(projectDep.hasParent()) {
-                    PluginLogManager.getLog().debug(String.format("Writing parent POM for %s", node));
-                    var pom = constructRecursivePom(projectDep.getParent(), session, checksumCalculator);
+            if (needsParentPom) {
+                if (mavenProject.hasParent()) {
+                    PluginLogManager.getLog().debug(String.format("Writting parent POM for dependency %s", node));
+                    var pom = constructRecursivePom(mavenProject.getParent(), session, checksumCalculator);
                     node.setParentPom(pom);
                 }
-            } else {
-                PluginLogManager.getLog().warn(String.format("Could not build project for dependency %s", node));
+                writtenParentPoms.add(node.getChecksum());
+            }
+
+            if (needsBom) {
+                Set<Pom> boms = bomResolver.resolveForProject(mavenProject);
+                if (!boms.isEmpty()) {
+                    node.setBoms(boms);
+                }
+                visitedBoms.add(node.getChecksum());
             }
         });
     }
@@ -411,8 +443,7 @@ public class LockFileFacade {
                     filter,
                     false);
 
-            resolveParentPomsForDependencies(dependencyGraph, session, pluginProject, checksumCalculator);
-            resolveBomsForDependencies(dependencyGraph, session, pluginProject, checksumCalculator);
+            resolveParentsAndBomsForDependencies(dependencyGraph, session, pluginProject, checksumCalculator, writtenParentPoms, visitedBoms);
 
             // Get root dependency nodes (excluding the plugin project itself)
             Set<io.github.chains_project.maven_lockfile.graph.DependencyNode> roots = dependencyGraph.getRoots();
@@ -502,7 +533,7 @@ public class LockFileFacade {
                             .toPath()
                             .relativize(project.getFile().toPath())
                             .toString();
-            String checksum = null;
+            String checksum;
             ResolvedUrl resolved = null;
             RepositoryId repoId = null;
             if (project.getFile() == null) {
@@ -542,44 +573,6 @@ public class LockFileFacade {
         }
 
         return lastPom;
-    }
-
-    /**
-     * Resolve the BOM POMs for the current project and its dependencies.
-     * <p>
-     * Note that this function will mutate the graph nodes by adding to each one the list of resolved BOMs.
-     *
-     * @param graph              The dependency graph
-     * @param session            The Maven session
-     * @param rootProject        The current Maven project
-     * @param checksumCalculator The checksum calculator
-     */
-    private static void resolveBomsForDependencies(
-            DependencyGraph graph,
-            MavenSession session,
-            MavenProject rootProject,
-            AbstractChecksumCalculator checksumCalculator) {
-        ProjectBuilder projectBuilder = new ProjectBuilder(session, rootProject.getRemoteArtifactRepositories());
-        BomResolver bomResolver =
-                new BomResolver(session, rootProject.getRemoteArtifactRepositories(), checksumCalculator);
-
-        graph.getDependencySet().forEach(node -> {
-            var projectOptional = projectBuilder.buildFromGav(
-                    node.getGroupId().getValue(),
-                    node.getArtifactId().getValue(),
-                    node.getVersion().getValue());
-
-            if (projectOptional.isEmpty()) {
-                PluginLogManager.getLog().warn(String.format("Skipping BOM resolution for %s", node));
-                return;
-            }
-
-            Set<Pom> boms = bomResolver.resolveForProject(projectOptional.get());
-
-            if (!boms.isEmpty()) {
-                node.setBoms(boms);
-            }
-        });
     }
 
     /**

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/checksum/FileSystemChecksumCalculator.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/checksum/FileSystemChecksumCalculator.java
@@ -101,31 +101,16 @@ public class FileSystemChecksumCalculator extends AbstractChecksumCalculator {
 
             String type = artifact.getArtifactHandler().getExtension();
 
-            String classifier = artifact.getClassifier();
-            if (classifier == null) {
-                classifier = "";
-            } else {
-                classifier = "-" + classifier;
-            }
-
-            String target = artifact.getArtifactId() + "-" + artifact.getVersion() + classifier + "." + type;
+            String classifier = artifact.getClassifier() == null ? "" : "-" + artifact.getClassifier();
+            String artifactFileName = artifact.getArtifactId() + "-" + artifact.getVersion() + classifier + "." + type;
 
             for (String remoteRepository : locallySavedRemoteRepositories) {
-                if (!remoteRepository.startsWith(target)) {
+                if (!remoteRepository.startsWith(artifactFileName)) {
                     continue;
                 }
-
                 // Parsing 'repository' from 'artifactId-version.type>repository='
-                int start = remoteRepository.indexOf(">");
-                int end = remoteRepository.indexOf("=");
-
-                if (start == -1 || end == -1) {
-                    PluginLogManager.getLog().warn("Possible unknown _remote.repositories format");
-                    continue;
-                }
-
-                repository = remoteRepository.substring(start + 1, end);
-                if (repository.isEmpty()) {
+                repository = parseRepositoryIdFromLine(remoteRepository, artifactFileName);
+                if (repository != null && repository.isEmpty()) {
                     // Empty repo ID means the artifact was resolved locally (e.g. copied from user's
                     // .m2 to an isolated repo). Record this and keep looking for a non-empty entry.
                     foundWithEmptyRepoId = true;
@@ -150,16 +135,14 @@ public class FileSystemChecksumCalculator extends AbstractChecksumCalculator {
                         Path relPath = isoRepoBase.relativize(artifactFolderPath);
                         Path userM2 = java.nio.file.Paths.get(System.getProperty("user.home"), ".m2", "repository");
                         Path fallbackFolder = userM2.resolve(relPath);
-                        Path fallbackRemoteRepo = fallbackFolder.resolve("_remote.repositories");
-                        if (Files.exists(fallbackRemoteRepo)) {
-                            for (String line : Files.readAllLines(fallbackRemoteRepo)) {
-                                if (!line.startsWith(target)) continue;
-                                int s = line.indexOf(">");
-                                int e = line.indexOf("=");
-                                if (s == -1 || e == -1) continue;
-                                String fallbackId = line.substring(s + 1, e);
-                                if (!fallbackId.isEmpty() && remoteRepositoriesSet.contains(fallbackId)) {
-                                    repository = fallbackId;
+                        Path remoteRepositoriesFile = fallbackFolder.resolve("_remote.repositories");
+                        if (Files.exists(remoteRepositoriesFile)) {
+                            for (String line : Files.readAllLines(remoteRepositoriesFile)) {
+                                if (!line.startsWith(artifactFileName)) continue;
+
+                                String remoteRepository = parseRepositoryIdFromLine(line, artifactFileName);
+                                if (remoteRepository != null && !remoteRepository.isEmpty() && remoteRepositoriesSet.contains(remoteRepository)) {
+                                    repository = remoteRepository;
                                     break;
                                 }
                             }
@@ -189,7 +172,7 @@ public class FileSystemChecksumCalculator extends AbstractChecksumCalculator {
             String baseVersion = artifact.getBaseVersion();
 
             String url = remoteRepository.get().getUrl().replaceAll("/$", "") + "/" + groupId + "/" + artifactId + "/"
-                    + baseVersion + "/" + target;
+                    + baseVersion + "/" + artifactFileName;
 
             return Optional.of(new RepositoryInformation(ResolvedUrl.of(url), RepositoryId.of(repository)));
         } catch (Exception e) {
@@ -197,6 +180,30 @@ public class FileSystemChecksumCalculator extends AbstractChecksumCalculator {
                     .warn(String.format("Could not fetch remote repository for artifact %s", artifact), e);
             return Optional.empty();
         }
+    }
+
+    /**
+     * Parses a repository ID from a _remote.repositories file line.
+     * Format: "filename&gt;repositoryId="
+     *
+     * @param line The line to parse
+     * @param artifactFilename The artifact filename to match
+     * @return The repository ID if line matches (may be empty string), null if line doesn't match
+     */
+    private String parseRepositoryIdFromLine(String line, String artifactFilename) {
+        if (!line.startsWith(artifactFilename + ">")) {
+            return null;
+        }
+
+        int start = line.indexOf(">");
+        int end = line.indexOf("=");
+
+        if (start == -1 || end == -1) {
+            PluginLogManager.getLog().warn("Possible unknown _remote.repositories format: " + line);
+            return null;
+        }
+
+        return line.substring(start + 1, end);
     }
 
     @Override

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/checksum/FileSystemChecksumCalculator.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/checksum/FileSystemChecksumCalculator.java
@@ -97,6 +97,7 @@ public class FileSystemChecksumCalculator extends AbstractChecksumCalculator {
                     .collect(Collectors.toSet());
 
             String repository = null;
+            boolean foundWithEmptyRepoId = false;
 
             String type = artifact.getArtifactHandler().getExtension();
 
@@ -124,6 +125,13 @@ public class FileSystemChecksumCalculator extends AbstractChecksumCalculator {
                 }
 
                 repository = remoteRepository.substring(start + 1, end);
+                if (repository.isEmpty()) {
+                    // Empty repo ID means the artifact was resolved locally (e.g. copied from user's
+                    // .m2 to an isolated repo). Record this and keep looking for a non-empty entry.
+                    foundWithEmptyRepoId = true;
+                    repository = null;
+                    continue;
+                }
                 if (!remoteRepositoriesSet.contains(repository)) {
                     continue;
                 }
@@ -132,8 +140,36 @@ public class FileSystemChecksumCalculator extends AbstractChecksumCalculator {
             }
 
             if (repository == null) {
-                // No repository found, possible locally installed artifact or unknown _remote.repositories format
-                return Optional.empty();
+                if (foundWithEmptyRepoId) {
+                    // Artifact was locally installed/copied (no remote attribution in _remote.repositories).
+                    // Attempt to find the correct repo by checking the user's default .m2 repository,
+                    // which retains the original remote attribution from when the artifact was downloaded.
+                    Path isoRepoBase = java.nio.file.Paths.get(
+                            buildingRequest.getLocalRepository().getBasedir());
+                    if (artifactFolderPath.startsWith(isoRepoBase)) {
+                        Path relPath = isoRepoBase.relativize(artifactFolderPath);
+                        Path userM2 = java.nio.file.Paths.get(System.getProperty("user.home"), ".m2", "repository");
+                        Path fallbackFolder = userM2.resolve(relPath);
+                        Path fallbackRemoteRepo = fallbackFolder.resolve("_remote.repositories");
+                        if (Files.exists(fallbackRemoteRepo)) {
+                            for (String line : Files.readAllLines(fallbackRemoteRepo)) {
+                                if (!line.startsWith(target)) continue;
+                                int s = line.indexOf(">");
+                                int e = line.indexOf("=");
+                                if (s == -1 || e == -1) continue;
+                                String fallbackId = line.substring(s + 1, e);
+                                if (!fallbackId.isEmpty() && remoteRepositoriesSet.contains(fallbackId)) {
+                                    repository = fallbackId;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+                if (repository == null) {
+                    // No repository found, possible locally installed artifact or unknown format
+                    return Optional.empty();
+                }
             }
 
             // Convert repository to url
@@ -182,13 +218,19 @@ public class FileSystemChecksumCalculator extends AbstractChecksumCalculator {
 
     @Override
     public RepositoryInformation getArtifactResolvedField(Artifact artifact) {
-        return getResolvedFieldInternal(resolveDependency(artifact, artifactBuildingRequest), artifactBuildingRequest)
+        // If the artifact already has its file set (e.g. pre-resolved from local .m2),
+        // skip re-resolution — the resolver may return a new Artifact without the file.
+        Artifact toCheck =
+                artifact.getFile() != null ? artifact : resolveDependency(artifact, artifactBuildingRequest);
+        return getResolvedFieldInternal(toCheck, artifactBuildingRequest)
                 .orElse(RepositoryInformation.Unresolved());
     }
 
     @Override
     public RepositoryInformation getPluginResolvedField(Artifact artifact) {
-        return getResolvedFieldInternal(resolveDependency(artifact, pluginBuildingRequest), pluginBuildingRequest)
+        Artifact toCheck =
+                artifact.getFile() != null ? artifact : resolveDependency(artifact, pluginBuildingRequest);
+        return getResolvedFieldInternal(toCheck, pluginBuildingRequest)
                 .orElse(RepositoryInformation.Unresolved());
     }
 }

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/checksum/FileSystemChecksumCalculator.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/checksum/FileSystemChecksumCalculator.java
@@ -141,7 +141,9 @@ public class FileSystemChecksumCalculator extends AbstractChecksumCalculator {
                                 if (!line.startsWith(artifactFileName)) continue;
 
                                 String remoteRepository = parseRepositoryIdFromLine(line, artifactFileName);
-                                if (remoteRepository != null && !remoteRepository.isEmpty() && remoteRepositoriesSet.contains(remoteRepository)) {
+                                if (remoteRepository != null
+                                        && !remoteRepository.isEmpty()
+                                        && remoteRepositoriesSet.contains(remoteRepository)) {
                                     repository = remoteRepository;
                                     break;
                                 }
@@ -227,17 +229,13 @@ public class FileSystemChecksumCalculator extends AbstractChecksumCalculator {
     public RepositoryInformation getArtifactResolvedField(Artifact artifact) {
         // If the artifact already has its file set (e.g. pre-resolved from local .m2),
         // skip re-resolution — the resolver may return a new Artifact without the file.
-        Artifact toCheck =
-                artifact.getFile() != null ? artifact : resolveDependency(artifact, artifactBuildingRequest);
-        return getResolvedFieldInternal(toCheck, artifactBuildingRequest)
-                .orElse(RepositoryInformation.Unresolved());
+        Artifact toCheck = artifact.getFile() != null ? artifact : resolveDependency(artifact, artifactBuildingRequest);
+        return getResolvedFieldInternal(toCheck, artifactBuildingRequest).orElse(RepositoryInformation.Unresolved());
     }
 
     @Override
     public RepositoryInformation getPluginResolvedField(Artifact artifact) {
-        Artifact toCheck =
-                artifact.getFile() != null ? artifact : resolveDependency(artifact, pluginBuildingRequest);
-        return getResolvedFieldInternal(toCheck, pluginBuildingRequest)
-                .orElse(RepositoryInformation.Unresolved());
+        Artifact toCheck = artifact.getFile() != null ? artifact : resolveDependency(artifact, pluginBuildingRequest);
+        return getResolvedFieldInternal(toCheck, pluginBuildingRequest).orElse(RepositoryInformation.Unresolved());
     }
 }

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/AbstractMavenComponent.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/AbstractMavenComponent.java
@@ -33,7 +33,8 @@ public abstract class AbstractMavenComponent implements Comparable<AbstractMaven
             String checksumAlgorithm,
             ResolvedUrl resolved,
             RepositoryId repositoryId,
-            Set<DependencyNode> dependencies, Pom parentPom) {
+            Set<DependencyNode> dependencies,
+            Pom parentPom) {
         this.groupId = groupId;
         this.artifactId = artifactId;
         this.version = version;
@@ -80,7 +81,15 @@ public abstract class AbstractMavenComponent implements Comparable<AbstractMaven
     @Override
     public int hashCode() {
         return Objects.hash(
-                groupId, artifactId, version, checksum, checksumAlgorithm, resolved, repositoryId, dependencies, parentPom);
+                groupId,
+                artifactId,
+                version,
+                checksum,
+                checksumAlgorithm,
+                resolved,
+                repositoryId,
+                dependencies,
+                parentPom);
     }
 
     @Override

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/AbstractMavenComponent.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/AbstractMavenComponent.java
@@ -23,7 +23,7 @@ public abstract class AbstractMavenComponent implements Comparable<AbstractMaven
     protected final ResolvedUrl resolved;
     protected final RepositoryId repositoryId;
     protected final Set<DependencyNode> dependencies;
-    protected final Pom parent;
+    protected final Pom parentPom;
 
     protected AbstractMavenComponent(
             GroupId groupId,
@@ -33,7 +33,7 @@ public abstract class AbstractMavenComponent implements Comparable<AbstractMaven
             String checksumAlgorithm,
             ResolvedUrl resolved,
             RepositoryId repositoryId,
-            Set<DependencyNode> dependencies, Pom parent) {
+            Set<DependencyNode> dependencies, Pom parentPom) {
         this.groupId = groupId;
         this.artifactId = artifactId;
         this.version = version;
@@ -42,7 +42,7 @@ public abstract class AbstractMavenComponent implements Comparable<AbstractMaven
         this.resolved = resolved;
         this.repositoryId = repositoryId;
         this.dependencies = dependencies == null ? Collections.emptySet() : dependencies;
-        this.parent = parent;
+        this.parentPom = parentPom;
     }
 
     public GroupId getGroupId() {
@@ -80,7 +80,7 @@ public abstract class AbstractMavenComponent implements Comparable<AbstractMaven
     @Override
     public int hashCode() {
         return Objects.hash(
-                groupId, artifactId, version, checksum, checksumAlgorithm, resolved, repositoryId, dependencies, parent);
+                groupId, artifactId, version, checksum, checksumAlgorithm, resolved, repositoryId, dependencies, parentPom);
     }
 
     @Override
@@ -102,7 +102,7 @@ public abstract class AbstractMavenComponent implements Comparable<AbstractMaven
                 && Objects.equals(resolved, other.resolved)
                 && Objects.equals(repositoryId, other.repositoryId)
                 && Objects.equals(dependencies, other.dependencies)
-                && Objects.equals(parent, other.parent);
+                && Objects.equals(parentPom, other.parentPom);
     }
 
     @Override

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/AbstractMavenComponent.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/AbstractMavenComponent.java
@@ -23,6 +23,7 @@ public abstract class AbstractMavenComponent implements Comparable<AbstractMaven
     protected final ResolvedUrl resolved;
     protected final RepositoryId repositoryId;
     protected final Set<DependencyNode> dependencies;
+    protected final Pom parent;
 
     protected AbstractMavenComponent(
             GroupId groupId,
@@ -32,7 +33,7 @@ public abstract class AbstractMavenComponent implements Comparable<AbstractMaven
             String checksumAlgorithm,
             ResolvedUrl resolved,
             RepositoryId repositoryId,
-            Set<DependencyNode> dependencies) {
+            Set<DependencyNode> dependencies, Pom parent) {
         this.groupId = groupId;
         this.artifactId = artifactId;
         this.version = version;
@@ -41,6 +42,7 @@ public abstract class AbstractMavenComponent implements Comparable<AbstractMaven
         this.resolved = resolved;
         this.repositoryId = repositoryId;
         this.dependencies = dependencies == null ? Collections.emptySet() : dependencies;
+        this.parent = parent;
     }
 
     public GroupId getGroupId() {
@@ -99,7 +101,8 @@ public abstract class AbstractMavenComponent implements Comparable<AbstractMaven
                 && Objects.equals(checksumAlgorithm, other.checksumAlgorithm)
                 && Objects.equals(resolved, other.resolved)
                 && Objects.equals(repositoryId, other.repositoryId)
-                && Objects.equals(dependencies, other.dependencies);
+                && Objects.equals(dependencies, other.dependencies)
+                && Objects.equals(parent, other.parent);
     }
 
     @Override

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/AbstractMavenComponent.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/AbstractMavenComponent.java
@@ -80,7 +80,7 @@ public abstract class AbstractMavenComponent implements Comparable<AbstractMaven
     @Override
     public int hashCode() {
         return Objects.hash(
-                groupId, artifactId, version, checksum, checksumAlgorithm, resolved, repositoryId, dependencies);
+                groupId, artifactId, version, checksum, checksumAlgorithm, resolved, repositoryId, dependencies, parent);
     }
 
     @Override

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/LockFile.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/LockFile.java
@@ -151,7 +151,6 @@ public class LockFile {
                 groupId,
                 version,
                 lockfileVersion,
-                pom,
                 dependencies,
                 nullToEmpty(mavenPlugins),
                 nullToEmpty(mavenExtensions),
@@ -167,11 +166,13 @@ public class LockFile {
             return false;
         }
         LockFile other = (LockFile) obj;
+        // pom is intentionally excluded: it is compared separately in ValidateChecksumMojo
+        // using the onPomValidationFailure policy (warn vs error). Including it here would
+        // cause equals to fail even when pom validation failure is explicitly allowed.
         return Objects.equals(name, other.name)
                 && Objects.equals(groupId, other.groupId)
                 && Objects.equals(version, other.version)
                 && lockfileVersion == other.lockfileVersion
-                //&& Objects.equals(pom,other.pom)
                 && Objects.equals(nullToEmpty(dependencies), nullToEmpty(other.dependencies))
                 && Objects.equals(nullToEmpty(mavenPlugins), nullToEmpty(other.mavenPlugins))
                 && Objects.equals(nullToEmpty(mavenExtensions), nullToEmpty(other.mavenExtensions))

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/LockFile.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/LockFile.java
@@ -171,7 +171,7 @@ public class LockFile {
                 && Objects.equals(groupId, other.groupId)
                 && Objects.equals(version, other.version)
                 && lockfileVersion == other.lockfileVersion
-                && pom.equals(other.pom)
+                && Objects.equals(pom,other.pom)
                 && Objects.equals(nullToEmpty(dependencies), nullToEmpty(other.dependencies))
                 && Objects.equals(nullToEmpty(mavenPlugins), nullToEmpty(other.mavenPlugins))
                 && Objects.equals(nullToEmpty(mavenExtensions), nullToEmpty(other.mavenExtensions))

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/LockFile.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/LockFile.java
@@ -151,6 +151,7 @@ public class LockFile {
                 groupId,
                 version,
                 lockfileVersion,
+                pom,
                 dependencies,
                 nullToEmpty(mavenPlugins),
                 nullToEmpty(mavenExtensions),
@@ -166,9 +167,6 @@ public class LockFile {
             return false;
         }
         LockFile other = (LockFile) obj;
-        // pom is intentionally excluded: it is compared separately in ValidateChecksumMojo
-        // using the onPomValidationFailure policy (warn vs error). Including it here would
-        // cause equals to fail even when pom validation failure is explicitly allowed.
         return Objects.equals(name, other.name)
                 && Objects.equals(groupId, other.groupId)
                 && Objects.equals(version, other.version)

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/LockFile.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/LockFile.java
@@ -171,6 +171,7 @@ public class LockFile {
                 && Objects.equals(groupId, other.groupId)
                 && Objects.equals(version, other.version)
                 && lockfileVersion == other.lockfileVersion
+                && pom == other.pom
                 && Objects.equals(nullToEmpty(dependencies), nullToEmpty(other.dependencies))
                 && Objects.equals(nullToEmpty(mavenPlugins), nullToEmpty(other.mavenPlugins))
                 && Objects.equals(nullToEmpty(mavenExtensions), nullToEmpty(other.mavenExtensions))

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/LockFile.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/LockFile.java
@@ -171,7 +171,7 @@ public class LockFile {
                 && Objects.equals(groupId, other.groupId)
                 && Objects.equals(version, other.version)
                 && lockfileVersion == other.lockfileVersion
-                && Objects.equals(pom,other.pom)
+                //&& Objects.equals(pom,other.pom)
                 && Objects.equals(nullToEmpty(dependencies), nullToEmpty(other.dependencies))
                 && Objects.equals(nullToEmpty(mavenPlugins), nullToEmpty(other.mavenPlugins))
                 && Objects.equals(nullToEmpty(mavenExtensions), nullToEmpty(other.mavenExtensions))

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/LockFile.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/LockFile.java
@@ -171,7 +171,7 @@ public class LockFile {
                 && Objects.equals(groupId, other.groupId)
                 && Objects.equals(version, other.version)
                 && lockfileVersion == other.lockfileVersion
-                && pom == other.pom
+                && pom.equals(other.pom)
                 && Objects.equals(nullToEmpty(dependencies), nullToEmpty(other.dependencies))
                 && Objects.equals(nullToEmpty(mavenPlugins), nullToEmpty(other.mavenPlugins))
                 && Objects.equals(nullToEmpty(mavenExtensions), nullToEmpty(other.mavenExtensions))

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/MavenExtension.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/MavenExtension.java
@@ -30,7 +30,7 @@ public class MavenExtension extends AbstractMavenComponent {
             ResolvedUrl resolved,
             RepositoryId repositoryId,
             Set<DependencyNode> dependencies) {
-        super(groupId, artifactId, version, checksum, checksumAlgorithm, resolved, repositoryId, dependencies);
+        super(groupId, artifactId, version, checksum, checksumAlgorithm, resolved, repositoryId, dependencies, null);
     }
 
     @Override

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/MavenPlugin.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/MavenPlugin.java
@@ -18,7 +18,7 @@ public class MavenPlugin extends AbstractMavenComponent {
             RepositoryId repositoryId,
             String checksumAlgorithm,
             String checksum) {
-        this(groupId, artifactId, version, resolvedUrl, repositoryId, checksumAlgorithm, checksum, null);
+        this(groupId, artifactId, version, resolvedUrl, repositoryId, checksumAlgorithm, checksum, null,null);
     }
 
     public MavenPlugin(
@@ -29,8 +29,9 @@ public class MavenPlugin extends AbstractMavenComponent {
             RepositoryId repositoryId,
             String checksumAlgorithm,
             String checksum,
-            Set<DependencyNode> dependencies) {
-        super(groupId, artifactId, version, checksum, checksumAlgorithm, resolvedUrl, repositoryId, dependencies);
+            Set<DependencyNode> dependencies,
+            Pom parent) {
+        super(groupId, artifactId, version, checksum, checksumAlgorithm, resolvedUrl, repositoryId, dependencies, parent);
     }
 
     @Override

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/MavenPlugin.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/MavenPlugin.java
@@ -18,7 +18,7 @@ public class MavenPlugin extends AbstractMavenComponent {
             RepositoryId repositoryId,
             String checksumAlgorithm,
             String checksum) {
-        this(groupId, artifactId, version, resolvedUrl, repositoryId, checksumAlgorithm, checksum, null,null);
+        this(groupId, artifactId, version, resolvedUrl, repositoryId, checksumAlgorithm, checksum, null, null);
     }
 
     public MavenPlugin(
@@ -31,7 +31,16 @@ public class MavenPlugin extends AbstractMavenComponent {
             String checksum,
             Set<DependencyNode> dependencies,
             Pom parent) {
-        super(groupId, artifactId, version, checksum, checksumAlgorithm, resolvedUrl, repositoryId, dependencies, parent);
+        super(
+                groupId,
+                artifactId,
+                version,
+                checksum,
+                checksumAlgorithm,
+                resolvedUrl,
+                repositoryId,
+                dependencies,
+                parent);
     }
 
     @Override

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/Pom.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/Pom.java
@@ -1,6 +1,7 @@
 package io.github.chains_project.maven_lockfile.data;
 
 import java.util.Objects;
+import java.util.Set;
 
 public class Pom implements Comparable<Pom> {
 
@@ -13,6 +14,7 @@ public class Pom implements Comparable<Pom> {
     private final String checksumAlgorithm;
     private final String checksum;
     private final Pom parent;
+    private Set<Pom> boms;
 
     public Pom(
             GroupId groupId,
@@ -176,5 +178,13 @@ public class Pom implements Comparable<Pom> {
                 checksumAlgorithm,
                 checksum,
                 parent);
+    }
+
+    public Set<Pom> getBoms() {
+        return boms;
+    }
+
+    public void setBoms(Set<Pom> boms) {
+        this.boms = boms;
     }
 }

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/graph/DependencyNode.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/graph/DependencyNode.java
@@ -28,6 +28,7 @@ public class DependencyNode implements Comparable<DependencyNode> {
     private final MavenScope scope;
     private final ResolvedUrl resolved;
     private final RepositoryId repositoryId;
+    private Pom parentPom;
 
     private String selectedVersion;
 
@@ -205,7 +206,8 @@ public class DependencyNode implements Comparable<DependencyNode> {
                 id,
                 parent,
                 children,
-                boms);
+                boms,
+                parentPom);
     }
 
     @Override
@@ -229,7 +231,8 @@ public class DependencyNode implements Comparable<DependencyNode> {
                 && Objects.equals(id, other.id)
                 && Objects.equals(parent, other.parent)
                 && Objects.equals(children, other.children)
-                && Objects.equals(boms, other.boms);
+                && Objects.equals(boms, other.boms)
+                && Objects.equals(parentPom, other.parentPom);
     }
 
     @Override
@@ -264,11 +267,19 @@ public class DependencyNode implements Comparable<DependencyNode> {
                 + ", classifier=" + classifier + ", type=" + type + ", checksumAlgorithm=" + checksumAlgorithm
                 + ", checksum=" + checksum + ", scope=" + scope + ", resolved=" + resolved + ", repositoryId="
                 + repositoryId + ", selectedVersion=" + selectedVersion + ", id=" + id + ", parent=" + parent
-                + ", children=" + children + ", boms=" + boms + "]";
+                + ", children=" + children + ", boms=" + boms + ", parentPom=" + parentPom +  "]";
     }
 
     public String getComparatorString() {
         return this.getGroupId().getValue() + "#" + this.getArtifactId().getValue() + "#"
                 + this.getVersion().getValue() + "#" + this.getChecksum();
+    }
+
+    public Pom getParentPom() {
+        return parentPom;
+    }
+
+    public void setParentPom(Pom parentPom) {
+        this.parentPom = parentPom;
     }
 }

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/graph/DependencyNode.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/graph/DependencyNode.java
@@ -267,7 +267,7 @@ public class DependencyNode implements Comparable<DependencyNode> {
                 + ", classifier=" + classifier + ", type=" + type + ", checksumAlgorithm=" + checksumAlgorithm
                 + ", checksum=" + checksum + ", scope=" + scope + ", resolved=" + resolved + ", repositoryId="
                 + repositoryId + ", selectedVersion=" + selectedVersion + ", id=" + id + ", parent=" + parent
-                + ", children=" + children + ", boms=" + boms + ", parentPom=" + parentPom +  "]";
+                + ", children=" + children + ", boms=" + boms + ", parentPom=" + parentPom + "]";
     }
 
     public String getComparatorString() {

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/resolvers/BomResolver.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/resolvers/BomResolver.java
@@ -64,7 +64,12 @@ public class BomResolver {
                     continue;
                 }
 
-                var bomTree = resolveBomParents(bomProjectOptional.get());
+                var bomProject = bomProjectOptional.get();
+                var bomBoms = resolveForProject(bomProject);
+                var bomTree = resolveBomParents(bomProject);
+                if(!bomBoms.isEmpty() && bomTree != null) {
+                    bomTree.setBoms(bomBoms);
+                }
                 boms.add(bomTree);
             }
         }
@@ -139,6 +144,10 @@ public class BomResolver {
             } else {
                 var bom = mavenProjectToBom(project, checksumCalculator, current);
                 current = bom;
+            }
+            var bomBoms = resolveForProject(project);
+            if(!bomBoms.isEmpty()){
+                current.setBoms(bomBoms);
             }
         }
 

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/resolvers/BomResolver.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/resolvers/BomResolver.java
@@ -67,7 +67,7 @@ public class BomResolver {
                 var bomProject = bomProjectOptional.get();
                 var bomBoms = resolveForProject(bomProject);
                 var bomTree = resolveBomParents(bomProject);
-                if(!bomBoms.isEmpty() && bomTree != null) {
+                if (!bomBoms.isEmpty() && bomTree != null) {
                     bomTree.setBoms(bomBoms);
                 }
                 boms.add(bomTree);
@@ -146,7 +146,7 @@ public class BomResolver {
                 current = bom;
             }
             var bomBoms = resolveForProject(project);
-            if(!bomBoms.isEmpty()){
+            if (!bomBoms.isEmpty()) {
                 current.setBoms(bomBoms);
             }
         }

--- a/maven_plugin/src/test/resources-its/it/IntegrationTestsIT/remoteRepositoryShouldResolve/lockfile.json
+++ b/maven_plugin/src/test/resources-its/it/IntegrationTestsIT/remoteRepositoryShouldResolve/lockfile.json
@@ -36,6 +36,24 @@
       "scope": "compile",
       "resolved": "https://repo.maven.apache.org/maven2/fr/inria/gforge/spoon/spoon-core/10.3.0/spoon-core-10.3.0.jar",
       "repositoryId": "central",
+      "parentPom": {
+        "groupId": "fr.inria.gforge.spoon",
+        "artifactId": "spoon-pom",
+        "version": "1.0",
+        "resolved": "https://repo.maven.apache.org/maven2/fr/inria/gforge/spoon/spoon-pom/1.0/spoon-pom-1.0.pom",
+        "repositoryId": "central",
+        "checksumAlgorithm": "SHA-256",
+        "checksum": "fdfc220403bf9d01ca6444c221a7aaddc4cc0b2665265a36c94d23504c4a57cd",
+        "parent": {
+          "groupId": "org.sonatype.oss",
+          "artifactId": "oss-parent",
+          "version": "7",
+          "resolved": "https://repo.maven.apache.org/maven2/org/sonatype/oss/oss-parent/7/oss-parent-7.pom",
+          "repositoryId": "central",
+          "checksumAlgorithm": "SHA-256",
+          "checksum": "b51f8867c92b6a722499557fc3a1fdea77bdf9ef574722fe90ce436a29559454"
+        }
+      },
       "selectedVersion": "10.3.0",
       "included": true,
       "id": "fr.inria.gforge.spoon:spoon-core:10.3.0",
@@ -49,6 +67,42 @@
           "scope": "compile",
           "resolved": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-databind/2.14.2/jackson-databind-2.14.2.jar",
           "repositoryId": "central",
+          "parentPom": {
+            "groupId": "com.fasterxml.jackson",
+            "artifactId": "jackson-base",
+            "version": "2.14.2",
+            "resolved": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-base/2.14.2/jackson-base-2.14.2.pom",
+            "repositoryId": "central",
+            "checksumAlgorithm": "SHA-256",
+            "checksum": "3ae245b9df95127321f1f905f703bd32774fe557158a9d3a9e507d82b2bc4ed4",
+            "parent": {
+              "groupId": "com.fasterxml.jackson",
+              "artifactId": "jackson-bom",
+              "version": "2.14.2",
+              "resolved": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-bom/2.14.2/jackson-bom-2.14.2.pom",
+              "repositoryId": "central",
+              "checksumAlgorithm": "SHA-256",
+              "checksum": "9aa209bb32391cbf5f1bd3e7fa11901676169acd190d9896b5c1e877c999febc",
+              "parent": {
+                "groupId": "com.fasterxml.jackson",
+                "artifactId": "jackson-parent",
+                "version": "2.14",
+                "resolved": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-parent/2.14/jackson-parent-2.14.pom",
+                "repositoryId": "central",
+                "checksumAlgorithm": "SHA-256",
+                "checksum": "0906add855ae39f92357d63f485889b08fca4c43a5fe433522d75344e0757b19",
+                "parent": {
+                  "groupId": "com.fasterxml",
+                  "artifactId": "oss-parent",
+                  "version": "48",
+                  "resolved": "https://repo.maven.apache.org/maven2/com/fasterxml/oss-parent/48/oss-parent-48.pom",
+                  "repositoryId": "central",
+                  "checksumAlgorithm": "SHA-256",
+                  "checksum": "11bba22d8631816e09b623a200747453d6491a66eac8f5c089c73da2b749014f"
+                }
+              }
+            }
+          },
           "selectedVersion": "2.14.2",
           "included": true,
           "id": "com.fasterxml.jackson.core:jackson-databind:2.14.2",
@@ -63,6 +117,24 @@
               "scope": "compile",
               "resolved": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-annotations/2.14.2/jackson-annotations-2.14.2.jar",
               "repositoryId": "central",
+              "parentPom": {
+                "groupId": "com.fasterxml.jackson",
+                "artifactId": "jackson-parent",
+                "version": "2.14",
+                "resolved": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-parent/2.14/jackson-parent-2.14.pom",
+                "repositoryId": "central",
+                "checksumAlgorithm": "SHA-256",
+                "checksum": "0906add855ae39f92357d63f485889b08fca4c43a5fe433522d75344e0757b19",
+                "parent": {
+                  "groupId": "com.fasterxml",
+                  "artifactId": "oss-parent",
+                  "version": "48",
+                  "resolved": "https://repo.maven.apache.org/maven2/com/fasterxml/oss-parent/48/oss-parent-48.pom",
+                  "repositoryId": "central",
+                  "checksumAlgorithm": "SHA-256",
+                  "checksum": "11bba22d8631816e09b623a200747453d6491a66eac8f5c089c73da2b749014f"
+                }
+              },
               "selectedVersion": "2.14.2",
               "included": true,
               "id": "com.fasterxml.jackson.core:jackson-annotations:2.14.2",
@@ -79,6 +151,42 @@
               "scope": "compile",
               "resolved": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/core/jackson-core/2.14.2/jackson-core-2.14.2.jar",
               "repositoryId": "central",
+              "parentPom": {
+                "groupId": "com.fasterxml.jackson",
+                "artifactId": "jackson-base",
+                "version": "2.14.2",
+                "resolved": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-base/2.14.2/jackson-base-2.14.2.pom",
+                "repositoryId": "central",
+                "checksumAlgorithm": "SHA-256",
+                "checksum": "3ae245b9df95127321f1f905f703bd32774fe557158a9d3a9e507d82b2bc4ed4",
+                "parent": {
+                  "groupId": "com.fasterxml.jackson",
+                  "artifactId": "jackson-bom",
+                  "version": "2.14.2",
+                  "resolved": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-bom/2.14.2/jackson-bom-2.14.2.pom",
+                  "repositoryId": "central",
+                  "checksumAlgorithm": "SHA-256",
+                  "checksum": "9aa209bb32391cbf5f1bd3e7fa11901676169acd190d9896b5c1e877c999febc",
+                  "parent": {
+                    "groupId": "com.fasterxml.jackson",
+                    "artifactId": "jackson-parent",
+                    "version": "2.14",
+                    "resolved": "https://repo.maven.apache.org/maven2/com/fasterxml/jackson/jackson-parent/2.14/jackson-parent-2.14.pom",
+                    "repositoryId": "central",
+                    "checksumAlgorithm": "SHA-256",
+                    "checksum": "0906add855ae39f92357d63f485889b08fca4c43a5fe433522d75344e0757b19",
+                    "parent": {
+                      "groupId": "com.fasterxml",
+                      "artifactId": "oss-parent",
+                      "version": "48",
+                      "resolved": "https://repo.maven.apache.org/maven2/com/fasterxml/oss-parent/48/oss-parent-48.pom",
+                      "repositoryId": "central",
+                      "checksumAlgorithm": "SHA-256",
+                      "checksum": "11bba22d8631816e09b623a200747453d6491a66eac8f5c089c73da2b749014f"
+                    }
+                  }
+                }
+              },
               "selectedVersion": "2.14.2",
               "included": true,
               "id": "com.fasterxml.jackson.core:jackson-core:2.14.2",
@@ -114,6 +222,24 @@
           "scope": "compile",
           "resolved": "https://repo.maven.apache.org/maven2/commons-io/commons-io/2.11.0/commons-io-2.11.0.jar",
           "repositoryId": "central",
+          "parentPom": {
+            "groupId": "org.apache.commons",
+            "artifactId": "commons-parent",
+            "version": "52",
+            "resolved": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/52/commons-parent-52.pom",
+            "repositoryId": "central",
+            "checksumAlgorithm": "SHA-256",
+            "checksum": "75dbe8f34e98e4c3ff42daae4a2f9eb4cbcd3b5f1047d54460ace906dbb4502e",
+            "parent": {
+              "groupId": "org.apache",
+              "artifactId": "apache",
+              "version": "23",
+              "resolved": "https://repo.maven.apache.org/maven2/org/apache/apache/23/apache-23.pom",
+              "repositoryId": "central",
+              "checksumAlgorithm": "SHA-256",
+              "checksum": "bc10624e0623f36577fac5639ca2936d3240ed152fb6d8d533ab4d270543491c"
+            }
+          },
           "selectedVersion": "2.11.0",
           "included": true,
           "id": "commons-io:commons-io:2.11.0",
@@ -140,6 +266,35 @@
           "scope": "compile",
           "resolved": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-compress/1.22/commons-compress-1.22.jar",
           "repositoryId": "central",
+          "parentPom": {
+            "groupId": "org.apache.commons",
+            "artifactId": "commons-parent",
+            "version": "54",
+            "resolved": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/54/commons-parent-54.pom",
+            "repositoryId": "central",
+            "checksumAlgorithm": "SHA-256",
+            "checksum": "000d8187952b223702fde296df799563f35de82ce72adb4e7bf157342378fbe3",
+            "parent": {
+              "groupId": "org.apache",
+              "artifactId": "apache",
+              "version": "27",
+              "resolved": "https://repo.maven.apache.org/maven2/org/apache/apache/27/apache-27.pom",
+              "repositoryId": "central",
+              "checksumAlgorithm": "SHA-256",
+              "checksum": "b2b0fc69e22a650c3892f1c366d77076f29575c6738df4c7a70a44844484cdf9"
+            },
+            "boms": [
+              {
+                "groupId": "org.junit",
+                "artifactId": "junit-bom",
+                "version": "5.9.0",
+                "resolved": "https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.9.0/junit-bom-5.9.0.pom",
+                "repositoryId": "central",
+                "checksumAlgorithm": "SHA-256",
+                "checksum": "d83e87f1676cde44191eec5cda690492392f26923b1e498148ca739dfed75295"
+              }
+            ]
+          },
           "selectedVersion": "1.22",
           "included": true,
           "id": "org.apache.commons:commons-compress:1.22",
@@ -156,6 +311,24 @@
           "scope": "compile",
           "resolved": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar",
           "repositoryId": "central",
+          "parentPom": {
+            "groupId": "org.apache.commons",
+            "artifactId": "commons-parent",
+            "version": "52",
+            "resolved": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/52/commons-parent-52.pom",
+            "repositoryId": "central",
+            "checksumAlgorithm": "SHA-256",
+            "checksum": "75dbe8f34e98e4c3ff42daae4a2f9eb4cbcd3b5f1047d54460ace906dbb4502e",
+            "parent": {
+              "groupId": "org.apache",
+              "artifactId": "apache",
+              "version": "23",
+              "resolved": "https://repo.maven.apache.org/maven2/org/apache/apache/23/apache-23.pom",
+              "repositoryId": "central",
+              "checksumAlgorithm": "SHA-256",
+              "checksum": "bc10624e0623f36577fac5639ca2936d3240ed152fb6d8d533ab4d270543491c"
+            }
+          },
           "selectedVersion": "3.12.0",
           "included": true,
           "id": "org.apache.commons:commons-lang3:3.12.0",
@@ -182,6 +355,73 @@
           "scope": "compile",
           "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-model/4.0.0-rc-5/maven-model-4.0.0-rc-5.jar",
           "repositoryId": "central",
+          "parentPom": {
+            "groupId": "org.apache.maven",
+            "artifactId": "maven-compat-modules",
+            "version": "4.0.0-rc-5",
+            "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-compat-modules/4.0.0-rc-5/maven-compat-modules-4.0.0-rc-5.pom",
+            "repositoryId": "central",
+            "checksumAlgorithm": "SHA-256",
+            "checksum": "7fb3b7448ae0a60542a86cfccc96495726dc96fe1ff24f5283196b409f3a9bd9",
+            "parent": {
+              "groupId": "org.apache.maven",
+              "artifactId": "maven",
+              "version": "4.0.0-rc-5",
+              "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven/4.0.0-rc-5/maven-4.0.0-rc-5.pom",
+              "repositoryId": "central",
+              "checksumAlgorithm": "SHA-256",
+              "checksum": "8514a1eb3998f1222d24580909c4576d5cf0df53d4069dbbb4ca6d34313802f5",
+              "parent": {
+                "groupId": "org.apache.maven",
+                "artifactId": "maven-parent",
+                "version": "45",
+                "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/45/maven-parent-45.pom",
+                "repositoryId": "central",
+                "checksumAlgorithm": "SHA-256",
+                "checksum": "94fe869eb9b4ce9fce3995d05ea86b168c85d927f9d17beb814a1960c76d7e6f",
+                "parent": {
+                  "groupId": "org.apache",
+                  "artifactId": "apache",
+                  "version": "35",
+                  "resolved": "https://repo.maven.apache.org/maven2/org/apache/apache/35/apache-35.pom",
+                  "repositoryId": "central",
+                  "checksumAlgorithm": "SHA-256",
+                  "checksum": "ea297dcd114136e8b8e8b630230d52a76c2fc69f6c5db25d672b1857000728b8"
+                },
+                "boms": [
+                  {
+                    "groupId": "org.junit",
+                    "artifactId": "junit-bom",
+                    "version": "5.13.1",
+                    "resolved": "https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.13.1/junit-bom-5.13.1.pom",
+                    "repositoryId": "central",
+                    "checksumAlgorithm": "SHA-256",
+                    "checksum": "fa68451ea830572ed43ffe51d75b6a05f7a5e665a602a51f49d6be02063a65f3"
+                  }
+                ]
+              },
+              "boms": [
+                {
+                  "groupId": "org.junit",
+                  "artifactId": "junit-bom",
+                  "version": "5.13.4",
+                  "resolved": "https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.13.4/junit-bom-5.13.4.pom",
+                  "repositoryId": "central",
+                  "checksumAlgorithm": "SHA-256",
+                  "checksum": "d7a08a99b2502f0bb68cd4e1f984f0bf69324aaa208bd0f73366c03fc3548a42"
+                },
+                {
+                  "groupId": "org.mockito",
+                  "artifactId": "mockito-bom",
+                  "version": "5.20.0",
+                  "resolved": "https://repo.maven.apache.org/maven2/org/mockito/mockito-bom/5.20.0/mockito-bom-5.20.0.pom",
+                  "repositoryId": "central",
+                  "checksumAlgorithm": "SHA-256",
+                  "checksum": "626bc0f79f389d2c41543d16d8d9db0b53ad0848cc37a6e0b4ce771a4fe0bc49"
+                }
+              ]
+            }
+          },
           "selectedVersion": "4.0.0-rc-5",
           "included": true,
           "id": "org.apache.maven:maven-model:4.0.0-rc-5",
@@ -196,6 +436,73 @@
               "scope": "compile",
               "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-api-annotations/4.0.0-rc-5/maven-api-annotations-4.0.0-rc-5.jar",
               "repositoryId": "central",
+              "parentPom": {
+                "groupId": "org.apache.maven",
+                "artifactId": "maven-api",
+                "version": "4.0.0-rc-5",
+                "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-api/4.0.0-rc-5/maven-api-4.0.0-rc-5.pom",
+                "repositoryId": "central",
+                "checksumAlgorithm": "SHA-256",
+                "checksum": "610c044f0159a6e15c579ed0579403270fbf9e00e83edb276926b1cf77f5aca9",
+                "parent": {
+                  "groupId": "org.apache.maven",
+                  "artifactId": "maven",
+                  "version": "4.0.0-rc-5",
+                  "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven/4.0.0-rc-5/maven-4.0.0-rc-5.pom",
+                  "repositoryId": "central",
+                  "checksumAlgorithm": "SHA-256",
+                  "checksum": "8514a1eb3998f1222d24580909c4576d5cf0df53d4069dbbb4ca6d34313802f5",
+                  "parent": {
+                    "groupId": "org.apache.maven",
+                    "artifactId": "maven-parent",
+                    "version": "45",
+                    "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/45/maven-parent-45.pom",
+                    "repositoryId": "central",
+                    "checksumAlgorithm": "SHA-256",
+                    "checksum": "94fe869eb9b4ce9fce3995d05ea86b168c85d927f9d17beb814a1960c76d7e6f",
+                    "parent": {
+                      "groupId": "org.apache",
+                      "artifactId": "apache",
+                      "version": "35",
+                      "resolved": "https://repo.maven.apache.org/maven2/org/apache/apache/35/apache-35.pom",
+                      "repositoryId": "central",
+                      "checksumAlgorithm": "SHA-256",
+                      "checksum": "ea297dcd114136e8b8e8b630230d52a76c2fc69f6c5db25d672b1857000728b8"
+                    },
+                    "boms": [
+                      {
+                        "groupId": "org.junit",
+                        "artifactId": "junit-bom",
+                        "version": "5.13.1",
+                        "resolved": "https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.13.1/junit-bom-5.13.1.pom",
+                        "repositoryId": "central",
+                        "checksumAlgorithm": "SHA-256",
+                        "checksum": "fa68451ea830572ed43ffe51d75b6a05f7a5e665a602a51f49d6be02063a65f3"
+                      }
+                    ]
+                  },
+                  "boms": [
+                    {
+                      "groupId": "org.junit",
+                      "artifactId": "junit-bom",
+                      "version": "5.13.4",
+                      "resolved": "https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.13.4/junit-bom-5.13.4.pom",
+                      "repositoryId": "central",
+                      "checksumAlgorithm": "SHA-256",
+                      "checksum": "d7a08a99b2502f0bb68cd4e1f984f0bf69324aaa208bd0f73366c03fc3548a42"
+                    },
+                    {
+                      "groupId": "org.mockito",
+                      "artifactId": "mockito-bom",
+                      "version": "5.20.0",
+                      "resolved": "https://repo.maven.apache.org/maven2/org/mockito/mockito-bom/5.20.0/mockito-bom-5.20.0.pom",
+                      "repositoryId": "central",
+                      "checksumAlgorithm": "SHA-256",
+                      "checksum": "626bc0f79f389d2c41543d16d8d9db0b53ad0848cc37a6e0b4ce771a4fe0bc49"
+                    }
+                  ]
+                }
+              },
               "selectedVersion": "4.0.0-rc-5",
               "included": true,
               "id": "org.apache.maven:maven-api-annotations:4.0.0-rc-5",
@@ -212,6 +519,73 @@
               "scope": "compile",
               "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-api-model/4.0.0-rc-5/maven-api-model-4.0.0-rc-5.jar",
               "repositoryId": "central",
+              "parentPom": {
+                "groupId": "org.apache.maven",
+                "artifactId": "maven-api",
+                "version": "4.0.0-rc-5",
+                "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-api/4.0.0-rc-5/maven-api-4.0.0-rc-5.pom",
+                "repositoryId": "central",
+                "checksumAlgorithm": "SHA-256",
+                "checksum": "610c044f0159a6e15c579ed0579403270fbf9e00e83edb276926b1cf77f5aca9",
+                "parent": {
+                  "groupId": "org.apache.maven",
+                  "artifactId": "maven",
+                  "version": "4.0.0-rc-5",
+                  "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven/4.0.0-rc-5/maven-4.0.0-rc-5.pom",
+                  "repositoryId": "central",
+                  "checksumAlgorithm": "SHA-256",
+                  "checksum": "8514a1eb3998f1222d24580909c4576d5cf0df53d4069dbbb4ca6d34313802f5",
+                  "parent": {
+                    "groupId": "org.apache.maven",
+                    "artifactId": "maven-parent",
+                    "version": "45",
+                    "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/45/maven-parent-45.pom",
+                    "repositoryId": "central",
+                    "checksumAlgorithm": "SHA-256",
+                    "checksum": "94fe869eb9b4ce9fce3995d05ea86b168c85d927f9d17beb814a1960c76d7e6f",
+                    "parent": {
+                      "groupId": "org.apache",
+                      "artifactId": "apache",
+                      "version": "35",
+                      "resolved": "https://repo.maven.apache.org/maven2/org/apache/apache/35/apache-35.pom",
+                      "repositoryId": "central",
+                      "checksumAlgorithm": "SHA-256",
+                      "checksum": "ea297dcd114136e8b8e8b630230d52a76c2fc69f6c5db25d672b1857000728b8"
+                    },
+                    "boms": [
+                      {
+                        "groupId": "org.junit",
+                        "artifactId": "junit-bom",
+                        "version": "5.13.1",
+                        "resolved": "https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.13.1/junit-bom-5.13.1.pom",
+                        "repositoryId": "central",
+                        "checksumAlgorithm": "SHA-256",
+                        "checksum": "fa68451ea830572ed43ffe51d75b6a05f7a5e665a602a51f49d6be02063a65f3"
+                      }
+                    ]
+                  },
+                  "boms": [
+                    {
+                      "groupId": "org.junit",
+                      "artifactId": "junit-bom",
+                      "version": "5.13.4",
+                      "resolved": "https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.13.4/junit-bom-5.13.4.pom",
+                      "repositoryId": "central",
+                      "checksumAlgorithm": "SHA-256",
+                      "checksum": "d7a08a99b2502f0bb68cd4e1f984f0bf69324aaa208bd0f73366c03fc3548a42"
+                    },
+                    {
+                      "groupId": "org.mockito",
+                      "artifactId": "mockito-bom",
+                      "version": "5.20.0",
+                      "resolved": "https://repo.maven.apache.org/maven2/org/mockito/mockito-bom/5.20.0/mockito-bom-5.20.0.pom",
+                      "repositoryId": "central",
+                      "checksumAlgorithm": "SHA-256",
+                      "checksum": "626bc0f79f389d2c41543d16d8d9db0b53ad0848cc37a6e0b4ce771a4fe0bc49"
+                    }
+                  ]
+                }
+              },
               "selectedVersion": "4.0.0-rc-5",
               "included": true,
               "id": "org.apache.maven:maven-api-model:4.0.0-rc-5",
@@ -261,6 +635,73 @@
               "scope": "compile",
               "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-api-xml/4.0.0-rc-5/maven-api-xml-4.0.0-rc-5.jar",
               "repositoryId": "central",
+              "parentPom": {
+                "groupId": "org.apache.maven",
+                "artifactId": "maven-api",
+                "version": "4.0.0-rc-5",
+                "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-api/4.0.0-rc-5/maven-api-4.0.0-rc-5.pom",
+                "repositoryId": "central",
+                "checksumAlgorithm": "SHA-256",
+                "checksum": "610c044f0159a6e15c579ed0579403270fbf9e00e83edb276926b1cf77f5aca9",
+                "parent": {
+                  "groupId": "org.apache.maven",
+                  "artifactId": "maven",
+                  "version": "4.0.0-rc-5",
+                  "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven/4.0.0-rc-5/maven-4.0.0-rc-5.pom",
+                  "repositoryId": "central",
+                  "checksumAlgorithm": "SHA-256",
+                  "checksum": "8514a1eb3998f1222d24580909c4576d5cf0df53d4069dbbb4ca6d34313802f5",
+                  "parent": {
+                    "groupId": "org.apache.maven",
+                    "artifactId": "maven-parent",
+                    "version": "45",
+                    "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/45/maven-parent-45.pom",
+                    "repositoryId": "central",
+                    "checksumAlgorithm": "SHA-256",
+                    "checksum": "94fe869eb9b4ce9fce3995d05ea86b168c85d927f9d17beb814a1960c76d7e6f",
+                    "parent": {
+                      "groupId": "org.apache",
+                      "artifactId": "apache",
+                      "version": "35",
+                      "resolved": "https://repo.maven.apache.org/maven2/org/apache/apache/35/apache-35.pom",
+                      "repositoryId": "central",
+                      "checksumAlgorithm": "SHA-256",
+                      "checksum": "ea297dcd114136e8b8e8b630230d52a76c2fc69f6c5db25d672b1857000728b8"
+                    },
+                    "boms": [
+                      {
+                        "groupId": "org.junit",
+                        "artifactId": "junit-bom",
+                        "version": "5.13.1",
+                        "resolved": "https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.13.1/junit-bom-5.13.1.pom",
+                        "repositoryId": "central",
+                        "checksumAlgorithm": "SHA-256",
+                        "checksum": "fa68451ea830572ed43ffe51d75b6a05f7a5e665a602a51f49d6be02063a65f3"
+                      }
+                    ]
+                  },
+                  "boms": [
+                    {
+                      "groupId": "org.junit",
+                      "artifactId": "junit-bom",
+                      "version": "5.13.4",
+                      "resolved": "https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.13.4/junit-bom-5.13.4.pom",
+                      "repositoryId": "central",
+                      "checksumAlgorithm": "SHA-256",
+                      "checksum": "d7a08a99b2502f0bb68cd4e1f984f0bf69324aaa208bd0f73366c03fc3548a42"
+                    },
+                    {
+                      "groupId": "org.mockito",
+                      "artifactId": "mockito-bom",
+                      "version": "5.20.0",
+                      "resolved": "https://repo.maven.apache.org/maven2/org/mockito/mockito-bom/5.20.0/mockito-bom-5.20.0.pom",
+                      "repositoryId": "central",
+                      "checksumAlgorithm": "SHA-256",
+                      "checksum": "626bc0f79f389d2c41543d16d8d9db0b53ad0848cc37a6e0b4ce771a4fe0bc49"
+                    }
+                  ]
+                }
+              },
               "selectedVersion": "4.0.0-rc-5",
               "included": true,
               "id": "org.apache.maven:maven-api-xml:4.0.0-rc-5",
@@ -294,6 +735,73 @@
               "scope": "compile",
               "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-support/4.0.0-rc-5/maven-support-4.0.0-rc-5.jar",
               "repositoryId": "central",
+              "parentPom": {
+                "groupId": "org.apache.maven",
+                "artifactId": "maven-impl-modules",
+                "version": "4.0.0-rc-5",
+                "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-impl-modules/4.0.0-rc-5/maven-impl-modules-4.0.0-rc-5.pom",
+                "repositoryId": "central",
+                "checksumAlgorithm": "SHA-256",
+                "checksum": "9734a4c3338786c6e6aafe7db4376cad0b9f4edea63d9efcc8e9f26f20625f35",
+                "parent": {
+                  "groupId": "org.apache.maven",
+                  "artifactId": "maven",
+                  "version": "4.0.0-rc-5",
+                  "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven/4.0.0-rc-5/maven-4.0.0-rc-5.pom",
+                  "repositoryId": "central",
+                  "checksumAlgorithm": "SHA-256",
+                  "checksum": "8514a1eb3998f1222d24580909c4576d5cf0df53d4069dbbb4ca6d34313802f5",
+                  "parent": {
+                    "groupId": "org.apache.maven",
+                    "artifactId": "maven-parent",
+                    "version": "45",
+                    "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/45/maven-parent-45.pom",
+                    "repositoryId": "central",
+                    "checksumAlgorithm": "SHA-256",
+                    "checksum": "94fe869eb9b4ce9fce3995d05ea86b168c85d927f9d17beb814a1960c76d7e6f",
+                    "parent": {
+                      "groupId": "org.apache",
+                      "artifactId": "apache",
+                      "version": "35",
+                      "resolved": "https://repo.maven.apache.org/maven2/org/apache/apache/35/apache-35.pom",
+                      "repositoryId": "central",
+                      "checksumAlgorithm": "SHA-256",
+                      "checksum": "ea297dcd114136e8b8e8b630230d52a76c2fc69f6c5db25d672b1857000728b8"
+                    },
+                    "boms": [
+                      {
+                        "groupId": "org.junit",
+                        "artifactId": "junit-bom",
+                        "version": "5.13.1",
+                        "resolved": "https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.13.1/junit-bom-5.13.1.pom",
+                        "repositoryId": "central",
+                        "checksumAlgorithm": "SHA-256",
+                        "checksum": "fa68451ea830572ed43ffe51d75b6a05f7a5e665a602a51f49d6be02063a65f3"
+                      }
+                    ]
+                  },
+                  "boms": [
+                    {
+                      "groupId": "org.junit",
+                      "artifactId": "junit-bom",
+                      "version": "5.13.4",
+                      "resolved": "https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.13.4/junit-bom-5.13.4.pom",
+                      "repositoryId": "central",
+                      "checksumAlgorithm": "SHA-256",
+                      "checksum": "d7a08a99b2502f0bb68cd4e1f984f0bf69324aaa208bd0f73366c03fc3548a42"
+                    },
+                    {
+                      "groupId": "org.mockito",
+                      "artifactId": "mockito-bom",
+                      "version": "5.20.0",
+                      "resolved": "https://repo.maven.apache.org/maven2/org/mockito/mockito-bom/5.20.0/mockito-bom-5.20.0.pom",
+                      "repositoryId": "central",
+                      "checksumAlgorithm": "SHA-256",
+                      "checksum": "626bc0f79f389d2c41543d16d8d9db0b53ad0848cc37a6e0b4ce771a4fe0bc49"
+                    }
+                  ]
+                }
+              },
               "selectedVersion": "4.0.0-rc-5",
               "included": true,
               "id": "org.apache.maven:maven-support:4.0.0-rc-5",
@@ -308,6 +816,73 @@
                   "scope": "compile",
                   "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-api-metadata/4.0.0-rc-5/maven-api-metadata-4.0.0-rc-5.jar",
                   "repositoryId": "central",
+                  "parentPom": {
+                    "groupId": "org.apache.maven",
+                    "artifactId": "maven-api",
+                    "version": "4.0.0-rc-5",
+                    "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-api/4.0.0-rc-5/maven-api-4.0.0-rc-5.pom",
+                    "repositoryId": "central",
+                    "checksumAlgorithm": "SHA-256",
+                    "checksum": "610c044f0159a6e15c579ed0579403270fbf9e00e83edb276926b1cf77f5aca9",
+                    "parent": {
+                      "groupId": "org.apache.maven",
+                      "artifactId": "maven",
+                      "version": "4.0.0-rc-5",
+                      "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven/4.0.0-rc-5/maven-4.0.0-rc-5.pom",
+                      "repositoryId": "central",
+                      "checksumAlgorithm": "SHA-256",
+                      "checksum": "8514a1eb3998f1222d24580909c4576d5cf0df53d4069dbbb4ca6d34313802f5",
+                      "parent": {
+                        "groupId": "org.apache.maven",
+                        "artifactId": "maven-parent",
+                        "version": "45",
+                        "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/45/maven-parent-45.pom",
+                        "repositoryId": "central",
+                        "checksumAlgorithm": "SHA-256",
+                        "checksum": "94fe869eb9b4ce9fce3995d05ea86b168c85d927f9d17beb814a1960c76d7e6f",
+                        "parent": {
+                          "groupId": "org.apache",
+                          "artifactId": "apache",
+                          "version": "35",
+                          "resolved": "https://repo.maven.apache.org/maven2/org/apache/apache/35/apache-35.pom",
+                          "repositoryId": "central",
+                          "checksumAlgorithm": "SHA-256",
+                          "checksum": "ea297dcd114136e8b8e8b630230d52a76c2fc69f6c5db25d672b1857000728b8"
+                        },
+                        "boms": [
+                          {
+                            "groupId": "org.junit",
+                            "artifactId": "junit-bom",
+                            "version": "5.13.1",
+                            "resolved": "https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.13.1/junit-bom-5.13.1.pom",
+                            "repositoryId": "central",
+                            "checksumAlgorithm": "SHA-256",
+                            "checksum": "fa68451ea830572ed43ffe51d75b6a05f7a5e665a602a51f49d6be02063a65f3"
+                          }
+                        ]
+                      },
+                      "boms": [
+                        {
+                          "groupId": "org.junit",
+                          "artifactId": "junit-bom",
+                          "version": "5.13.4",
+                          "resolved": "https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.13.4/junit-bom-5.13.4.pom",
+                          "repositoryId": "central",
+                          "checksumAlgorithm": "SHA-256",
+                          "checksum": "d7a08a99b2502f0bb68cd4e1f984f0bf69324aaa208bd0f73366c03fc3548a42"
+                        },
+                        {
+                          "groupId": "org.mockito",
+                          "artifactId": "mockito-bom",
+                          "version": "5.20.0",
+                          "resolved": "https://repo.maven.apache.org/maven2/org/mockito/mockito-bom/5.20.0/mockito-bom-5.20.0.pom",
+                          "repositoryId": "central",
+                          "checksumAlgorithm": "SHA-256",
+                          "checksum": "626bc0f79f389d2c41543d16d8d9db0b53ad0848cc37a6e0b4ce771a4fe0bc49"
+                        }
+                      ]
+                    }
+                  },
                   "selectedVersion": "4.0.0-rc-5",
                   "included": true,
                   "id": "org.apache.maven:maven-api-metadata:4.0.0-rc-5",
@@ -357,6 +932,73 @@
                   "scope": "compile",
                   "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-api-plugin/4.0.0-rc-5/maven-api-plugin-4.0.0-rc-5.jar",
                   "repositoryId": "central",
+                  "parentPom": {
+                    "groupId": "org.apache.maven",
+                    "artifactId": "maven-api",
+                    "version": "4.0.0-rc-5",
+                    "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-api/4.0.0-rc-5/maven-api-4.0.0-rc-5.pom",
+                    "repositoryId": "central",
+                    "checksumAlgorithm": "SHA-256",
+                    "checksum": "610c044f0159a6e15c579ed0579403270fbf9e00e83edb276926b1cf77f5aca9",
+                    "parent": {
+                      "groupId": "org.apache.maven",
+                      "artifactId": "maven",
+                      "version": "4.0.0-rc-5",
+                      "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven/4.0.0-rc-5/maven-4.0.0-rc-5.pom",
+                      "repositoryId": "central",
+                      "checksumAlgorithm": "SHA-256",
+                      "checksum": "8514a1eb3998f1222d24580909c4576d5cf0df53d4069dbbb4ca6d34313802f5",
+                      "parent": {
+                        "groupId": "org.apache.maven",
+                        "artifactId": "maven-parent",
+                        "version": "45",
+                        "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/45/maven-parent-45.pom",
+                        "repositoryId": "central",
+                        "checksumAlgorithm": "SHA-256",
+                        "checksum": "94fe869eb9b4ce9fce3995d05ea86b168c85d927f9d17beb814a1960c76d7e6f",
+                        "parent": {
+                          "groupId": "org.apache",
+                          "artifactId": "apache",
+                          "version": "35",
+                          "resolved": "https://repo.maven.apache.org/maven2/org/apache/apache/35/apache-35.pom",
+                          "repositoryId": "central",
+                          "checksumAlgorithm": "SHA-256",
+                          "checksum": "ea297dcd114136e8b8e8b630230d52a76c2fc69f6c5db25d672b1857000728b8"
+                        },
+                        "boms": [
+                          {
+                            "groupId": "org.junit",
+                            "artifactId": "junit-bom",
+                            "version": "5.13.1",
+                            "resolved": "https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.13.1/junit-bom-5.13.1.pom",
+                            "repositoryId": "central",
+                            "checksumAlgorithm": "SHA-256",
+                            "checksum": "fa68451ea830572ed43ffe51d75b6a05f7a5e665a602a51f49d6be02063a65f3"
+                          }
+                        ]
+                      },
+                      "boms": [
+                        {
+                          "groupId": "org.junit",
+                          "artifactId": "junit-bom",
+                          "version": "5.13.4",
+                          "resolved": "https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.13.4/junit-bom-5.13.4.pom",
+                          "repositoryId": "central",
+                          "checksumAlgorithm": "SHA-256",
+                          "checksum": "d7a08a99b2502f0bb68cd4e1f984f0bf69324aaa208bd0f73366c03fc3548a42"
+                        },
+                        {
+                          "groupId": "org.mockito",
+                          "artifactId": "mockito-bom",
+                          "version": "5.20.0",
+                          "resolved": "https://repo.maven.apache.org/maven2/org/mockito/mockito-bom/5.20.0/mockito-bom-5.20.0.pom",
+                          "repositoryId": "central",
+                          "checksumAlgorithm": "SHA-256",
+                          "checksum": "626bc0f79f389d2c41543d16d8d9db0b53ad0848cc37a6e0b4ce771a4fe0bc49"
+                        }
+                      ]
+                    }
+                  },
                   "selectedVersion": "4.0.0-rc-5",
                   "included": true,
                   "id": "org.apache.maven:maven-api-plugin:4.0.0-rc-5",
@@ -406,6 +1048,73 @@
                   "scope": "compile",
                   "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-api-settings/4.0.0-rc-5/maven-api-settings-4.0.0-rc-5.jar",
                   "repositoryId": "central",
+                  "parentPom": {
+                    "groupId": "org.apache.maven",
+                    "artifactId": "maven-api",
+                    "version": "4.0.0-rc-5",
+                    "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-api/4.0.0-rc-5/maven-api-4.0.0-rc-5.pom",
+                    "repositoryId": "central",
+                    "checksumAlgorithm": "SHA-256",
+                    "checksum": "610c044f0159a6e15c579ed0579403270fbf9e00e83edb276926b1cf77f5aca9",
+                    "parent": {
+                      "groupId": "org.apache.maven",
+                      "artifactId": "maven",
+                      "version": "4.0.0-rc-5",
+                      "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven/4.0.0-rc-5/maven-4.0.0-rc-5.pom",
+                      "repositoryId": "central",
+                      "checksumAlgorithm": "SHA-256",
+                      "checksum": "8514a1eb3998f1222d24580909c4576d5cf0df53d4069dbbb4ca6d34313802f5",
+                      "parent": {
+                        "groupId": "org.apache.maven",
+                        "artifactId": "maven-parent",
+                        "version": "45",
+                        "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/45/maven-parent-45.pom",
+                        "repositoryId": "central",
+                        "checksumAlgorithm": "SHA-256",
+                        "checksum": "94fe869eb9b4ce9fce3995d05ea86b168c85d927f9d17beb814a1960c76d7e6f",
+                        "parent": {
+                          "groupId": "org.apache",
+                          "artifactId": "apache",
+                          "version": "35",
+                          "resolved": "https://repo.maven.apache.org/maven2/org/apache/apache/35/apache-35.pom",
+                          "repositoryId": "central",
+                          "checksumAlgorithm": "SHA-256",
+                          "checksum": "ea297dcd114136e8b8e8b630230d52a76c2fc69f6c5db25d672b1857000728b8"
+                        },
+                        "boms": [
+                          {
+                            "groupId": "org.junit",
+                            "artifactId": "junit-bom",
+                            "version": "5.13.1",
+                            "resolved": "https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.13.1/junit-bom-5.13.1.pom",
+                            "repositoryId": "central",
+                            "checksumAlgorithm": "SHA-256",
+                            "checksum": "fa68451ea830572ed43ffe51d75b6a05f7a5e665a602a51f49d6be02063a65f3"
+                          }
+                        ]
+                      },
+                      "boms": [
+                        {
+                          "groupId": "org.junit",
+                          "artifactId": "junit-bom",
+                          "version": "5.13.4",
+                          "resolved": "https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.13.4/junit-bom-5.13.4.pom",
+                          "repositoryId": "central",
+                          "checksumAlgorithm": "SHA-256",
+                          "checksum": "d7a08a99b2502f0bb68cd4e1f984f0bf69324aaa208bd0f73366c03fc3548a42"
+                        },
+                        {
+                          "groupId": "org.mockito",
+                          "artifactId": "mockito-bom",
+                          "version": "5.20.0",
+                          "resolved": "https://repo.maven.apache.org/maven2/org/mockito/mockito-bom/5.20.0/mockito-bom-5.20.0.pom",
+                          "repositoryId": "central",
+                          "checksumAlgorithm": "SHA-256",
+                          "checksum": "626bc0f79f389d2c41543d16d8d9db0b53ad0848cc37a6e0b4ce771a4fe0bc49"
+                        }
+                      ]
+                    }
+                  },
                   "selectedVersion": "4.0.0-rc-5",
                   "included": true,
                   "id": "org.apache.maven:maven-api-settings:4.0.0-rc-5",
@@ -455,6 +1164,73 @@
                   "scope": "compile",
                   "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-api-toolchain/4.0.0-rc-5/maven-api-toolchain-4.0.0-rc-5.jar",
                   "repositoryId": "central",
+                  "parentPom": {
+                    "groupId": "org.apache.maven",
+                    "artifactId": "maven-api",
+                    "version": "4.0.0-rc-5",
+                    "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-api/4.0.0-rc-5/maven-api-4.0.0-rc-5.pom",
+                    "repositoryId": "central",
+                    "checksumAlgorithm": "SHA-256",
+                    "checksum": "610c044f0159a6e15c579ed0579403270fbf9e00e83edb276926b1cf77f5aca9",
+                    "parent": {
+                      "groupId": "org.apache.maven",
+                      "artifactId": "maven",
+                      "version": "4.0.0-rc-5",
+                      "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven/4.0.0-rc-5/maven-4.0.0-rc-5.pom",
+                      "repositoryId": "central",
+                      "checksumAlgorithm": "SHA-256",
+                      "checksum": "8514a1eb3998f1222d24580909c4576d5cf0df53d4069dbbb4ca6d34313802f5",
+                      "parent": {
+                        "groupId": "org.apache.maven",
+                        "artifactId": "maven-parent",
+                        "version": "45",
+                        "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/45/maven-parent-45.pom",
+                        "repositoryId": "central",
+                        "checksumAlgorithm": "SHA-256",
+                        "checksum": "94fe869eb9b4ce9fce3995d05ea86b168c85d927f9d17beb814a1960c76d7e6f",
+                        "parent": {
+                          "groupId": "org.apache",
+                          "artifactId": "apache",
+                          "version": "35",
+                          "resolved": "https://repo.maven.apache.org/maven2/org/apache/apache/35/apache-35.pom",
+                          "repositoryId": "central",
+                          "checksumAlgorithm": "SHA-256",
+                          "checksum": "ea297dcd114136e8b8e8b630230d52a76c2fc69f6c5db25d672b1857000728b8"
+                        },
+                        "boms": [
+                          {
+                            "groupId": "org.junit",
+                            "artifactId": "junit-bom",
+                            "version": "5.13.1",
+                            "resolved": "https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.13.1/junit-bom-5.13.1.pom",
+                            "repositoryId": "central",
+                            "checksumAlgorithm": "SHA-256",
+                            "checksum": "fa68451ea830572ed43ffe51d75b6a05f7a5e665a602a51f49d6be02063a65f3"
+                          }
+                        ]
+                      },
+                      "boms": [
+                        {
+                          "groupId": "org.junit",
+                          "artifactId": "junit-bom",
+                          "version": "5.13.4",
+                          "resolved": "https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.13.4/junit-bom-5.13.4.pom",
+                          "repositoryId": "central",
+                          "checksumAlgorithm": "SHA-256",
+                          "checksum": "d7a08a99b2502f0bb68cd4e1f984f0bf69324aaa208bd0f73366c03fc3548a42"
+                        },
+                        {
+                          "groupId": "org.mockito",
+                          "artifactId": "mockito-bom",
+                          "version": "5.20.0",
+                          "resolved": "https://repo.maven.apache.org/maven2/org/mockito/mockito-bom/5.20.0/mockito-bom-5.20.0.pom",
+                          "repositoryId": "central",
+                          "checksumAlgorithm": "SHA-256",
+                          "checksum": "626bc0f79f389d2c41543d16d8d9db0b53ad0848cc37a6e0b4ce771a4fe0bc49"
+                        }
+                      ]
+                    }
+                  },
                   "selectedVersion": "4.0.0-rc-5",
                   "included": true,
                   "id": "org.apache.maven:maven-api-toolchain:4.0.0-rc-5",
@@ -504,6 +1280,73 @@
                   "scope": "compile",
                   "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-xml/4.0.0-rc-5/maven-xml-4.0.0-rc-5.jar",
                   "repositoryId": "central",
+                  "parentPom": {
+                    "groupId": "org.apache.maven",
+                    "artifactId": "maven-impl-modules",
+                    "version": "4.0.0-rc-5",
+                    "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-impl-modules/4.0.0-rc-5/maven-impl-modules-4.0.0-rc-5.pom",
+                    "repositoryId": "central",
+                    "checksumAlgorithm": "SHA-256",
+                    "checksum": "9734a4c3338786c6e6aafe7db4376cad0b9f4edea63d9efcc8e9f26f20625f35",
+                    "parent": {
+                      "groupId": "org.apache.maven",
+                      "artifactId": "maven",
+                      "version": "4.0.0-rc-5",
+                      "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven/4.0.0-rc-5/maven-4.0.0-rc-5.pom",
+                      "repositoryId": "central",
+                      "checksumAlgorithm": "SHA-256",
+                      "checksum": "8514a1eb3998f1222d24580909c4576d5cf0df53d4069dbbb4ca6d34313802f5",
+                      "parent": {
+                        "groupId": "org.apache.maven",
+                        "artifactId": "maven-parent",
+                        "version": "45",
+                        "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/45/maven-parent-45.pom",
+                        "repositoryId": "central",
+                        "checksumAlgorithm": "SHA-256",
+                        "checksum": "94fe869eb9b4ce9fce3995d05ea86b168c85d927f9d17beb814a1960c76d7e6f",
+                        "parent": {
+                          "groupId": "org.apache",
+                          "artifactId": "apache",
+                          "version": "35",
+                          "resolved": "https://repo.maven.apache.org/maven2/org/apache/apache/35/apache-35.pom",
+                          "repositoryId": "central",
+                          "checksumAlgorithm": "SHA-256",
+                          "checksum": "ea297dcd114136e8b8e8b630230d52a76c2fc69f6c5db25d672b1857000728b8"
+                        },
+                        "boms": [
+                          {
+                            "groupId": "org.junit",
+                            "artifactId": "junit-bom",
+                            "version": "5.13.1",
+                            "resolved": "https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.13.1/junit-bom-5.13.1.pom",
+                            "repositoryId": "central",
+                            "checksumAlgorithm": "SHA-256",
+                            "checksum": "fa68451ea830572ed43ffe51d75b6a05f7a5e665a602a51f49d6be02063a65f3"
+                          }
+                        ]
+                      },
+                      "boms": [
+                        {
+                          "groupId": "org.junit",
+                          "artifactId": "junit-bom",
+                          "version": "5.13.4",
+                          "resolved": "https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.13.4/junit-bom-5.13.4.pom",
+                          "repositoryId": "central",
+                          "checksumAlgorithm": "SHA-256",
+                          "checksum": "d7a08a99b2502f0bb68cd4e1f984f0bf69324aaa208bd0f73366c03fc3548a42"
+                        },
+                        {
+                          "groupId": "org.mockito",
+                          "artifactId": "mockito-bom",
+                          "version": "5.20.0",
+                          "resolved": "https://repo.maven.apache.org/maven2/org/mockito/mockito-bom/5.20.0/mockito-bom-5.20.0.pom",
+                          "repositoryId": "central",
+                          "checksumAlgorithm": "SHA-256",
+                          "checksum": "626bc0f79f389d2c41543d16d8d9db0b53ad0848cc37a6e0b4ce771a4fe0bc49"
+                        }
+                      ]
+                    }
+                  },
                   "selectedVersion": "4.0.0-rc-5",
                   "included": true,
                   "id": "org.apache.maven:maven-xml:4.0.0-rc-5",
@@ -518,6 +1361,15 @@
                       "scope": "compile",
                       "resolved": "https://repo.maven.apache.org/maven2/com/fasterxml/woodstox/woodstox-core/7.1.1/woodstox-core-7.1.1.jar",
                       "repositoryId": "central",
+                      "parentPom": {
+                        "groupId": "com.fasterxml",
+                        "artifactId": "oss-parent",
+                        "version": "68",
+                        "resolved": "https://repo.maven.apache.org/maven2/com/fasterxml/oss-parent/68/oss-parent-68.pom",
+                        "repositoryId": "central",
+                        "checksumAlgorithm": "SHA-256",
+                        "checksum": "25eafd96dae242b6b5a7108f55b2c14015b828daa5abe234289fd6e774a1ce57"
+                      },
                       "selectedVersion": "7.1.1",
                       "included": true,
                       "id": "com.fasterxml.woodstox:woodstox-core:7.1.1",
@@ -567,6 +1419,15 @@
                       "scope": "compile",
                       "resolved": "https://repo.maven.apache.org/maven2/org/codehaus/woodstox/stax2-api/4.2.2/stax2-api-4.2.2.jar",
                       "repositoryId": "central",
+                      "parentPom": {
+                        "groupId": "com.fasterxml",
+                        "artifactId": "oss-parent",
+                        "version": "55",
+                        "resolved": "https://repo.maven.apache.org/maven2/com/fasterxml/oss-parent/55/oss-parent-55.pom",
+                        "repositoryId": "central",
+                        "checksumAlgorithm": "SHA-256",
+                        "checksum": "0f5e18f2b35ebf6d839f7fd549972883f696c210f9ae3230afd2c20ba886c04d"
+                      },
                       "selectedVersion": "4.2.2",
                       "included": true,
                       "id": "org.codehaus.woodstox:stax2-api:4.2.2",
@@ -589,6 +1450,26 @@
               "scope": "compile",
               "resolved": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-xml/4.1.0/plexus-xml-4.1.0.jar",
               "repositoryId": "central",
+              "parentPom": {
+                "groupId": "org.codehaus.plexus",
+                "artifactId": "plexus",
+                "version": "20",
+                "resolved": "https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus/20/plexus-20.pom",
+                "repositoryId": "central",
+                "checksumAlgorithm": "SHA-256",
+                "checksum": "a7b594b002fc791733c8e94470d09045f4fd69a93ad5c375752f2057f84633b4",
+                "boms": [
+                  {
+                    "groupId": "org.junit",
+                    "artifactId": "junit-bom",
+                    "version": "5.11.4",
+                    "resolved": "https://repo.maven.apache.org/maven2/org/junit/junit-bom/5.11.4/junit-bom-5.11.4.pom",
+                    "repositoryId": "central",
+                    "checksumAlgorithm": "SHA-256",
+                    "checksum": "19d4b747b204805325b6334553296f986562277a4ac1cb5e593a5e4c4f5e4115"
+                  }
+                ]
+              },
               "selectedVersion": "4.1.0",
               "included": true,
               "id": "org.codehaus.plexus:plexus-xml:4.1.0",
@@ -625,6 +1506,33 @@
           "scope": "compile",
           "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-invoker/3.2.0/maven-invoker-3.2.0.jar",
           "repositoryId": "central",
+          "parentPom": {
+            "groupId": "org.apache.maven.shared",
+            "artifactId": "maven-shared-components",
+            "version": "35",
+            "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/35/maven-shared-components-35.pom",
+            "repositoryId": "central",
+            "checksumAlgorithm": "SHA-256",
+            "checksum": "9751496ceb9f585901f979e8f11693d8b39c34563b2524d0e38c855bb6f52c59",
+            "parent": {
+              "groupId": "org.apache.maven",
+              "artifactId": "maven-parent",
+              "version": "35",
+              "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/35/maven-parent-35.pom",
+              "repositoryId": "central",
+              "checksumAlgorithm": "SHA-256",
+              "checksum": "d2edd4077c0abc9cc8202883c459503180424636cb39a83031ec1112394b2576",
+              "parent": {
+                "groupId": "org.apache",
+                "artifactId": "apache",
+                "version": "25",
+                "resolved": "https://repo.maven.apache.org/maven2/org/apache/apache/25/apache-25.pom",
+                "repositoryId": "central",
+                "checksumAlgorithm": "SHA-256",
+                "checksum": "e68fc19a48cec582a6732fd0b10dbfe9feca25060963def89e547f8a3759d379"
+              }
+            }
+          },
           "selectedVersion": "3.2.0",
           "included": true,
           "id": "org.apache.maven.shared:maven-invoker:3.2.0",
@@ -655,6 +1563,33 @@
               "scope": "compile",
               "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-utils/3.3.4/maven-shared-utils-3.3.4.jar",
               "repositoryId": "central",
+              "parentPom": {
+                "groupId": "org.apache.maven.shared",
+                "artifactId": "maven-shared-components",
+                "version": "34",
+                "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/shared/maven-shared-components/34/maven-shared-components-34.pom",
+                "repositoryId": "central",
+                "checksumAlgorithm": "SHA-256",
+                "checksum": "64d0edb5f21cfff600b1c3ab7d45f9754cd18ba5fbf83b3d1bb7c4849437d8e3",
+                "parent": {
+                  "groupId": "org.apache.maven",
+                  "artifactId": "maven-parent",
+                  "version": "34",
+                  "resolved": "https://repo.maven.apache.org/maven2/org/apache/maven/maven-parent/34/maven-parent-34.pom",
+                  "repositoryId": "central",
+                  "checksumAlgorithm": "SHA-256",
+                  "checksum": "1a8faf7a6a2b848acb26a959954ee115c0d79dbe75a6206fb3b8c7c2f45a237f",
+                  "parent": {
+                    "groupId": "org.apache",
+                    "artifactId": "apache",
+                    "version": "23",
+                    "resolved": "https://repo.maven.apache.org/maven2/org/apache/apache/23/apache-23.pom",
+                    "repositoryId": "central",
+                    "checksumAlgorithm": "SHA-256",
+                    "checksum": "bc10624e0623f36577fac5639ca2936d3240ed152fb6d8d533ab4d270543491c"
+                  }
+                }
+              },
               "selectedVersion": "3.3.4",
               "included": true,
               "id": "org.apache.maven.shared:maven-shared-utils:3.3.4",
@@ -669,6 +1604,24 @@
                   "scope": "compile",
                   "resolved": "https://repo.maven.apache.org/maven2/commons-io/commons-io/2.6/commons-io-2.6.jar",
                   "repositoryId": "central",
+                  "parentPom": {
+                    "groupId": "org.apache.commons",
+                    "artifactId": "commons-parent",
+                    "version": "42",
+                    "resolved": "https://repo.maven.apache.org/maven2/org/apache/commons/commons-parent/42/commons-parent-42.pom",
+                    "repositoryId": "central",
+                    "checksumAlgorithm": "SHA-256",
+                    "checksum": "cd313494c670b483ec256972af1698b330e598f807002354eb765479f604b09c",
+                    "parent": {
+                      "groupId": "org.apache",
+                      "artifactId": "apache",
+                      "version": "18",
+                      "resolved": "https://repo.maven.apache.org/maven2/org/apache/apache/18/apache-18.pom",
+                      "repositoryId": "central",
+                      "checksumAlgorithm": "SHA-256",
+                      "checksum": "7831307285fd475bbc36b20ae38e7882f11c3153b1d5930f852d44eda8f33c17"
+                    }
+                  },
                   "selectedVersion": "2.11.0",
                   "included": false,
                   "id": "commons-io:commons-io:2.6",
@@ -707,6 +1660,15 @@
           "scope": "compile",
           "resolved": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36.jar",
           "repositoryId": "central",
+          "parentPom": {
+            "groupId": "org.slf4j",
+            "artifactId": "slf4j-parent",
+            "version": "1.7.36",
+            "resolved": "https://repo.maven.apache.org/maven2/org/slf4j/slf4j-parent/1.7.36/slf4j-parent-1.7.36.pom",
+            "repositoryId": "central",
+            "checksumAlgorithm": "SHA-256",
+            "checksum": "bb388d37fbcdd3cde64c3cede21838693218dc451f04040c5df360a78ed7e812"
+          },
           "selectedVersion": "1.7.36",
           "included": true,
           "id": "org.slf4j:slf4j-api:1.7.36",
@@ -719,11 +1681,12 @@
     }
   ],
   "mavenPlugins": [],
+  "mavenExtensions": [],
   "metaData": {
     "environment": {
       "osName": "Linux",
-      "mavenVersion": "3.9.9",
-      "javaVersion": "21.0.9"
+      "mavenVersion": "3.9.14",
+      "javaVersion": "25.0.2"
     },
     "config": {
       "includeMavenPlugins": false,
@@ -732,9 +1695,10 @@
       "allowEnvironmentalValidationFailure": true,
       "includeEnvironment": true,
       "reduced": false,
-      "mavenLockfileVersion": "5.14.3-SNAPSHOT",
+      "mavenLockfileVersion": "5.15.1-SNAPSHOT",
       "checksumMode": "local",
       "checksumAlgorithm": "SHA-256"
     }
-  }
+  },
+  "boms": []
 }


### PR DESCRIPTION
This functionality enables to have resolved all BOM POMs and parent POM within a plugin or a dependency artifacts.

All artifacts (plugins, dependencies and their dependencies) which are needed for building simple Spring application are documented in the lockfile. It is usable for basic hermetic builds in this shape.

On the other hand some dependencies might be documented more times under different top tier dependencies. (some duplicates are prevented, but not all)