### PR TITLE
Improved/aggressive checksum caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ mvn -f pom.lockfile.xml
 ## Command line Flags
 
 - `reduced` (`-Dreduced=false`) will reduce the lockfile only containing the dependencies after dependency resolution conflicts are resolved. This format is smaller, and easier to review and read. Only use this if you do not need the full dependency tree.
+- `incrementalGenerate` (`-DincrementalGenerate=true`, default=`false`) will generate the lockfile incrementally, re-calculating checksums only for artifacts that have changed since the last generation.
 - `includeMavenPlugins` (`-DincludeMavenPlugins=true`) will include the maven plugins in the lockfile. This is useful if you want to validate the Maven plugins as well.
 - `allowValidationFailure` (`-DallowValidationFailure=true`, default=false) allow validation failures, printing a warning instead of an error. This is useful if you want to only validate the Maven lockfile, but do not need to fail the build in case the lockfile is not valid. Use with caution, you loose all guarantees.
 - `allowPomValidationFailure` (`-DallowPomValidationFailure=true`, default=false) allow validation failure of the pom specifically, dependency validation still occurs (assuming `allowValidationFailure` is `false`). In case of checksum mismatch of pom prints a warning instead of default exception.

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/AbstractLockfileMojo.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/AbstractLockfileMojo.java
@@ -74,6 +74,9 @@ public abstract class AbstractLockfileMojo extends AbstractMojo {
     @Parameter(defaultValue = "false", property = "reduced")
     protected String reduced;
 
+    @Parameter(defaultValue = "false", property = "incrementalGenerate")
+    protected String incrementalGenerate;
+
     @Parameter(defaultValue = "false", property = "skip")
     protected String skip;
 
@@ -160,6 +163,8 @@ public abstract class AbstractLockfileMojo extends AbstractMojo {
                 : Config.EnvironmentInclusion.Exclude;
         Config.ReductionState reductionState =
                 Boolean.parseBoolean(reduced) ? Config.ReductionState.Reduced : Config.ReductionState.NonReduced;
+        Config.GenerationMode generationMode =
+                Boolean.parseBoolean(incrementalGenerate) ? Config.GenerationMode.Incremental : Config.GenerationMode.Full;
 
         return new Config(
                 mavenPluginsInclusion,
@@ -168,6 +173,7 @@ public abstract class AbstractLockfileMojo extends AbstractMojo {
                 onEnvironmentalValidationFailure,
                 environmentInclusion,
                 reductionState,
+                generationMode,
                 mojo.getPlugin().getVersion(),
                 chosenChecksumMode,
                 chosenChecksumAlgorithm);

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/AbstractLockfileMojo.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/AbstractLockfileMojo.java
@@ -2,6 +2,7 @@ package io.github.chains_project.maven_lockfile;
 
 import com.google.common.base.Strings;
 import io.github.chains_project.maven_lockfile.checksum.AbstractChecksumCalculator;
+import io.github.chains_project.maven_lockfile.checksum.CachingChecksumCalculator;
 import io.github.chains_project.maven_lockfile.checksum.ChecksumModes;
 import io.github.chains_project.maven_lockfile.checksum.FileSystemChecksumCalculator;
 import io.github.chains_project.maven_lockfile.checksum.RemoteChecksumCalculator;
@@ -118,19 +119,23 @@ public abstract class AbstractLockfileMojo extends AbstractMojo {
             checksumModeEnum = ChecksumModes.LOCAL;
         }
 
+        final AbstractChecksumCalculator checksumCalculator;
         switch (checksumModeEnum) {
             case LOCAL:
-                return new FileSystemChecksumCalculator(
+                checksumCalculator = new FileSystemChecksumCalculator(
                         dependencyResolver,
                         artifactBuildingRequest,
                         pluginBuildingRequest,
                         config.getChecksumAlgorithm());
+                break;
             case REMOTE:
-                return new RemoteChecksumCalculator(
+                checksumCalculator = new RemoteChecksumCalculator(
                         config.getChecksumAlgorithm(), artifactBuildingRequest, pluginBuildingRequest);
+                break;
             default:
                 throw new MojoExecutionException("Invalid checksum mode: " + checksumModeEnum);
         }
+        return CachingChecksumCalculator.getCachingChecksumCalculator(checksumCalculator, project, session);
     }
 
     protected Config getConfig() {

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/GenerateLockFileMojo.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/GenerateLockFileMojo.java
@@ -61,6 +61,7 @@ public class GenerateLockFileMojo extends AbstractLockfileMojo {
             LockFile lockFile = LockFileFacade.generateLockFileFromProject(
                     session, project, dependencyCollectorBuilder, checksumCalculator, metaData, repositorySystem);
 
+            checksumCalculator.report();
             Path lockFilePath = LockFileFacade.getLockFilePath(project, lockfileName);
             Files.writeString(lockFilePath, JsonUtils.toJson(lockFile));
             getLog().info("Lockfile written to " + lockFilePath);

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/GenerateLockFileMojo.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/GenerateLockFileMojo.java
@@ -54,10 +54,13 @@ public class GenerateLockFileMojo extends AbstractLockfileMojo {
             }
             MetaData metaData = new MetaData(environment, config);
 
+            AbstractChecksumCalculator checksumCalculator = getChecksumCalculator(config);
             if (lockFileFromFile == null) {
                 getLog().info("No lockfile found. Generating new lockfile.");
+            } else if (config.isIncrementalGenerate()) {
+                checksumCalculator.prepopulateCache(lockFileFromFile);
             }
-            AbstractChecksumCalculator checksumCalculator = getChecksumCalculator(config);
+
             LockFile lockFile = LockFileFacade.generateLockFileFromProject(
                     session, project, dependencyCollectorBuilder, checksumCalculator, metaData, repositorySystem);
 
@@ -84,6 +87,7 @@ public class GenerateLockFileMojo extends AbstractLockfileMojo {
                 config.getOnEnvironmentalValidationFailure(),
                 config.getEnvironmentInclusion(),
                 config.getReductionState(),
+                config.getGenerationMode(),
                 mojo.getPlugin().getVersion(),
                 config.getChecksumMode(),
                 config.getChecksumAlgorithm());

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/ValidateChecksumMojo.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/ValidateChecksumMojo.java
@@ -115,6 +115,7 @@ public class ValidateChecksumMojo extends AbstractLockfileMojo {
                         throw new MojoExecutionException("Failed verifying lock file. " + sb);
                 }
             }
+            checksumCalculator.report();
         } catch (IOException e) {
             throw new MojoExecutionException("Could not read lock file", e);
         }

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/checksum/AbstractChecksumCalculator.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/checksum/AbstractChecksumCalculator.java
@@ -43,7 +43,7 @@ public abstract class AbstractChecksumCalculator {
      * to fetch checksums and repository information in parallel. The default is a no-op.
      */
     public void prewarmArtifactCache(Collection<Artifact> artifacts) {
-        // No-op by default; overridden by RemoteChecksumCalculator
+        // No-op by default.
     }
 
     public String calculatePomChecksum(Path path) {
@@ -57,5 +57,13 @@ public abstract class AbstractChecksumCalculator {
             PluginLogManager.getLog().warn("Could not calculate checksum for pom " + path, e);
             return "";
         }
+    }
+
+    /**
+     * Reports on checksum calculation progress. Implementations may use this
+     * to provide debug information in the log. The default is a no-op.
+     */
+    public void report() {
+        // No-op by default.
     }
 }

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/checksum/AbstractChecksumCalculator.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/checksum/AbstractChecksumCalculator.java
@@ -1,6 +1,7 @@
 package io.github.chains_project.maven_lockfile.checksum;
 
 import com.google.common.io.BaseEncoding;
+import io.github.chains_project.maven_lockfile.data.LockFile;
 import io.github.chains_project.maven_lockfile.reporting.PluginLogManager;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -43,6 +44,15 @@ public abstract class AbstractChecksumCalculator {
      * to fetch checksums and repository information in parallel. The default is a no-op.
      */
     public void prewarmArtifactCache(Collection<Artifact> artifacts) {
+        // No-op by default.
+    }
+
+    /**
+     * Pre-populates the cache with information from a previously generated lockfile.
+     * Implementations may use this to prime the cache for an incremental generation.
+     * The default is a no-op.
+     */
+    public void prepopulateCache(LockFile lockFile) {
         // No-op by default.
     }
 

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/checksum/CachingChecksumCalculator.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/checksum/CachingChecksumCalculator.java
@@ -92,6 +92,42 @@ public class CachingChecksumCalculator extends AbstractChecksumCalculator {
     }
 
     @Override
+    public void prepopulateCache(LockFile lockFile) {
+        prepopulateDeps(lockFile.getDependencies());
+        prepopulatePlugins(lockFile.getMavenPlugins());
+        prepopulatePlugins(lockFile.getMavenExtensions());
+        prepopulatePom(lockFile.getPom());
+        lockFile.getBoms().forEach(this::prepopulatePom);
+    }
+
+    private void prepopulate(Artifact artifact, String checksum, RepositoryInformation repositoryInformation) {
+        checksumCache.put(checksumCacheKey(artifact), checksum);
+        resolveCache.put(cacheKey(artifact), repositoryInformation);
+    }
+
+    private void prepopulatePom(Pom pom) {
+        prepopulate(pom.toArtifact(), pom.getChecksum(), pom.getRepositoryInformation());
+        if (pom.getParent() != null) {
+            prepopulatePom(pom.getParent());
+        }
+    }
+
+    private void prepopulatePlugins(Collection<? extends AbstractMavenComponent> plugins) {
+        for (AbstractMavenComponent plugin : plugins) {
+            prepopulate(plugin.toArtifact(), plugin.getChecksum(), plugin.getRepositoryInformation());
+            prepopulateDeps(plugin.getDependencies());
+        }
+    }
+
+    private void prepopulateDeps(Collection<DependencyNode> dependencies) {
+        for (DependencyNode node : dependencies) {
+            prepopulate(node.toArtifact(), node.getChecksum(), node.getRepositoryInformation());
+            prepopulateDeps(node.getChildren());
+            node.getBoms().forEach(this::prepopulatePom);
+        }
+    }
+
+    @Override
     public void report() {
         var checksumStats = checksumCache.stats();
         var resolveStats = resolveCache.stats();

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/checksum/CachingChecksumCalculator.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/checksum/CachingChecksumCalculator.java
@@ -1,0 +1,212 @@
+package io.github.chains_project.maven_lockfile.checksum;
+
+import com.google.common.base.Strings;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import io.github.chains_project.maven_lockfile.data.AbstractMavenComponent;
+import io.github.chains_project.maven_lockfile.data.LockFile;
+import io.github.chains_project.maven_lockfile.data.Pom;
+import io.github.chains_project.maven_lockfile.graph.DependencyNode;
+import io.github.chains_project.maven_lockfile.reporting.PluginLogManager;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.project.MavenProject;
+
+public class CachingChecksumCalculator extends AbstractChecksumCalculator {
+
+    private static final String CHECKSUM_CACHE_SESSION_KEY = "generate-lock-file-checksum-cache";
+    private static final String RESOLVE_CACHE_SESSION_KEY = "generate-lock-file-resolve-cache";
+    private static final int CACHE_SIZE = 2000;
+
+    private final AbstractChecksumCalculator delegate;
+    private final Cache<String, String> checksumCache;
+    private final Cache<String, RepositoryInformation> resolveCache;
+
+    public CachingChecksumCalculator(
+            final AbstractChecksumCalculator delegate,
+            final Cache<String, String> checksumCache,
+            Cache<String, RepositoryInformation> resolveCache) {
+        super(delegate.getChecksumAlgorithm());
+        this.delegate = delegate;
+        this.checksumCache = checksumCache;
+        this.resolveCache = resolveCache;
+    }
+
+    @Override
+    public String getChecksumAlgorithm() {
+        return delegate.getChecksumAlgorithm();
+    }
+
+    @Override
+    public void prewarmArtifactCache(Collection<Artifact> artifacts) {
+        if (artifacts.isEmpty()) {
+            return;
+        }
+        int poolSize = Math.min(16, Math.max(4, Runtime.getRuntime().availableProcessors() * 2));
+        PluginLogManager.getLog()
+                .info(String.format(
+                        "Pre-warming checksum cache for %d unique artifacts with %d threads",
+                        artifacts.size(), poolSize));
+        ExecutorService executor = Executors.newFixedThreadPool(poolSize);
+        try {
+            List<Future<?>> futures = new ArrayList<>();
+            for (var artifact : artifacts) {
+                futures.add(executor.submit(() -> {
+                    calculateArtifactChecksum(artifact);
+                    getArtifactResolvedField(artifact);
+                }));
+            }
+            for (var future : futures) {
+                try {
+                    future.get();
+                } catch (Exception e) {
+                    PluginLogManager.getLog().debug("Pre-warm task failed: " + e.getMessage());
+                }
+            }
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+    private static String cacheKey(Artifact artifact) {
+        var classifier = Strings.nullToEmpty(artifact.getClassifier());
+        return artifact.getGroupId() + ":" + artifact.getArtifactId() + ":" + artifact.getVersion() + ":" + classifier
+                + ":" + artifact.getType();
+    }
+
+    private String checksumCacheKey(Artifact artifact) {
+        return checksumCacheKey(cacheKey(artifact));
+    }
+
+    private String checksumCacheKey(String cacheKey) {
+        return cacheKey + ":" + getChecksumAlgorithm();
+    }
+
+    @Override
+    public void report() {
+        var checksumStats = checksumCache.stats();
+        var resolveStats = resolveCache.stats();
+        PluginLogManager.getLog()
+                .debug("Checksum cache stats: " + checksumStats + ", average load = "
+                        + TimeUnit.NANOSECONDS.toMicros((long) checksumStats.averageLoadPenalty()) + "us");
+        PluginLogManager.getLog()
+                .debug("Resolve cache stats: " + resolveStats + ", average load = "
+                        + TimeUnit.NANOSECONDS.toMicros((long) resolveStats.averageLoadPenalty()) + "us");
+    }
+
+    @Override
+    public String calculateArtifactChecksum(final Artifact artifact) {
+        try {
+            return checksumCache.get(checksumCacheKey(artifact), () -> delegate.calculateArtifactChecksum(artifact));
+        } catch (ExecutionException e) {
+            throw new RuntimeException(e.getCause());
+        }
+    }
+
+    @Override
+    public String calculatePluginChecksum(final Artifact artifact) {
+        try {
+            return checksumCache.get(checksumCacheKey(artifact), () -> delegate.calculatePluginChecksum(artifact));
+        } catch (ExecutionException e) {
+            throw new RuntimeException(e.getCause());
+        }
+    }
+
+    @Override
+    public String calculatePomChecksum(Path path) {
+        try {
+            return checksumCache.get(checksumCacheKey(path.toString()), () -> delegate.calculatePomChecksum(path));
+        } catch (ExecutionException e) {
+            throw new RuntimeException(e.getCause());
+        }
+    }
+
+    @Override
+    public String getDefaultChecksumAlgorithm() {
+        return delegate.getDefaultChecksumAlgorithm();
+    }
+
+    @Override
+    public RepositoryInformation getArtifactResolvedField(final Artifact artifact) {
+        try {
+            return resolveCache.get(cacheKey(artifact), () -> delegate.getArtifactResolvedField(artifact));
+        } catch (ExecutionException e) {
+            throw new RuntimeException(e.getCause());
+        }
+    }
+
+    @Override
+    public RepositoryInformation getPluginResolvedField(final Artifact artifact) {
+        try {
+            return resolveCache.get(cacheKey(artifact), () -> delegate.getPluginResolvedField(artifact));
+        } catch (ExecutionException e) {
+            throw new RuntimeException(e.getCause());
+        }
+    }
+
+    /**
+     * Constructs a caching decorator over an existing checksum calculator.
+     * The internal details of the cache will be stored in the Maven session, allowing the cache to be used across
+     * multiple project builds in a reactor (there are limitations to this, as not all projects in a reactor will
+     * share a classloader, so the caching will fall back in those instances to a project scoped cache).
+     *
+     * @param checksumCalculator the calculator to addd caching to.
+     * @param project the Maven project being built.
+     * @param session the Maven session for cross-project builds.
+     */
+    public static CachingChecksumCalculator getCachingChecksumCalculator(
+            AbstractChecksumCalculator checksumCalculator, MavenProject project, MavenSession session) {
+        Cache<String, String> sessionChecksumCache = null;
+        Cache<String, RepositoryInformation> sessionResolveCache = null;
+        try {
+            sessionChecksumCache =
+                    (Cache<String, String>) session.getSystemProperties().get(CHECKSUM_CACHE_SESSION_KEY);
+        } catch (ClassCastException ignored) {
+            PluginLogManager.getLog()
+                    .warn("Could not obtain session checksum cache. "
+                            + project.getParent().getId() + " / " + System.identityHashCode(project.getParent()));
+            sessionChecksumCache =
+                    CacheBuilder.newBuilder().maximumSize(CACHE_SIZE).build();
+        }
+        try {
+            sessionResolveCache = (Cache<String, RepositoryInformation>)
+                    session.getSystemProperties().get(RESOLVE_CACHE_SESSION_KEY);
+        } catch (ClassCastException ignored) {
+            PluginLogManager.getLog()
+                    .warn("Could not obtain session resolve cache. "
+                            + project.getParent().getId() + " / " + System.identityHashCode(project.getParent()));
+            sessionResolveCache =
+                    CacheBuilder.newBuilder().maximumSize(CACHE_SIZE).build();
+        }
+        if (sessionChecksumCache == null) {
+            sessionChecksumCache = CacheBuilder.newBuilder()
+                    .recordStats()
+                    .maximumSize(CACHE_SIZE)
+                    .build();
+            PluginLogManager.getLog()
+                    .debug("Setting checksum cache in " + project.getName() + " / " + project.getId() + " / "
+                            + System.identityHashCode(project.getParent()));
+            session.getSystemProperties().put(CHECKSUM_CACHE_SESSION_KEY, sessionChecksumCache);
+        }
+        if (sessionResolveCache == null) {
+            sessionResolveCache = CacheBuilder.newBuilder()
+                    .recordStats()
+                    .maximumSize(CACHE_SIZE)
+                    .build();
+            PluginLogManager.getLog()
+                    .debug("Setting resolve cache in " + project.getName() + " / " + project.getId() + " / "
+                            + System.identityHashCode(project.getParent()));
+            session.getSystemProperties().put(RESOLVE_CACHE_SESSION_KEY, sessionResolveCache);
+        }
+        return new CachingChecksumCalculator(checksumCalculator, sessionChecksumCache, sessionResolveCache);
+    }
+}

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/checksum/RemoteChecksumCalculator.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/checksum/RemoteChecksumCalculator.java
@@ -9,16 +9,8 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.security.MessageDigest;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.project.ProjectBuildingRequest;
@@ -28,8 +20,6 @@ public class RemoteChecksumCalculator extends AbstractChecksumCalculator {
     private final ProjectBuildingRequest artifactBuildingRequest;
     private final ProjectBuildingRequest pluginBuildingRequest;
     private final HttpClient httpClient;
-    private final Map<String, String> checksumCache = new ConcurrentHashMap<>();
-    private final Map<String, RepositoryInformation> resolvedCache = new ConcurrentHashMap<>();
 
     public RemoteChecksumCalculator(
             String checksumAlgorithm,
@@ -51,22 +41,7 @@ public class RemoteChecksumCalculator extends AbstractChecksumCalculator {
                 .build();
     }
 
-    private String getCacheKey(Artifact artifact) {
-        String classifier = artifact.getClassifier();
-        if (classifier == null) {
-            classifier = "";
-        }
-        return artifact.getGroupId() + ":" + artifact.getArtifactId() + ":" + artifact.getVersion() + ":" + classifier
-                + ":" + artifact.getType();
-    }
-
     private Optional<String> calculateChecksumInternal(Artifact artifact, ProjectBuildingRequest buildingRequest) {
-        String cacheKey = getCacheKey(artifact) + ":" + checksumAlgorithm;
-        String cached = checksumCache.get(cacheKey);
-        if (cached != null) {
-            return cached.isEmpty() ? Optional.empty() : Optional.of(cached);
-        }
-
         try {
             String groupId = artifact.getGroupId().replace(".", "/");
             String artifactId = artifact.getArtifactId();
@@ -98,7 +73,6 @@ public class RemoteChecksumCalculator extends AbstractChecksumCalculator {
 
                 if (checksumResponse.statusCode() >= 200 && checksumResponse.statusCode() < 300) {
                     String checksum = checksumResponse.body().strip();
-                    checksumCache.put(cacheKey, checksum);
                     return Optional.of(checksum);
                 }
 
@@ -159,33 +133,24 @@ public class RemoteChecksumCalculator extends AbstractChecksumCalculator {
                     String checksum = baseEncoding
                             .encode(messageDigest.digest(artifactResponse.body()))
                             .toLowerCase(Locale.ROOT);
-                    checksumCache.put(cacheKey, checksum);
                     return Optional.of(checksum);
                 }
             }
 
             PluginLogManager.getLog()
                     .warn(String.format(
-                            "Artifact checksum `%s.%s` not found among remote repositories.",
-                            artifact, checksumAlgorithm));
-            checksumCache.put(cacheKey, "");
+                            "Artifact checksum `%s.%s` not found among remote repositories %s.",
+                            artifact, checksumAlgorithm, buildingRequest.getRemoteRepositories()));
             return Optional.empty();
         } catch (Exception e) {
             PluginLogManager.getLog()
                     .warn(String.format("Could not resolve artifact: %s", artifact.getArtifactId()), e);
-            checksumCache.put(cacheKey, "");
             return Optional.empty();
         }
     }
 
     private Optional<RepositoryInformation> getResolvedFieldInternal(
             Artifact artifact, ProjectBuildingRequest buildingRequest) {
-        String cacheKey = getCacheKey(artifact);
-        RepositoryInformation cached = resolvedCache.get(cacheKey);
-        if (cached != null) {
-            return cached.equals(RepositoryInformation.Unresolved()) ? Optional.empty() : Optional.of(cached);
-        }
-
         try {
             String groupId = artifact.getGroupId().replace(".", "/");
             String artifactId = artifact.getArtifactId();
@@ -215,50 +180,16 @@ public class RemoteChecksumCalculator extends AbstractChecksumCalculator {
                 if (response.statusCode() >= 200 && response.statusCode() < 300) {
                     RepositoryInformation result =
                             new RepositoryInformation(ResolvedUrl.of(url), RepositoryId.of(repository.getId()));
-                    resolvedCache.put(cacheKey, result);
                     return Optional.of(result);
                 }
             }
 
             PluginLogManager.getLog().warn(String.format("Artifact resolved url `%s` not found.", artifact));
-            resolvedCache.put(cacheKey, RepositoryInformation.Unresolved());
             return Optional.empty();
         } catch (Exception e) {
             PluginLogManager.getLog()
                     .warn(String.format("Could not resolve url for artifact: %s", artifact.getArtifactId()), e);
-            resolvedCache.put(cacheKey, RepositoryInformation.Unresolved());
             return Optional.empty();
-        }
-    }
-
-    @Override
-    public void prewarmArtifactCache(Collection<Artifact> artifacts) {
-        if (artifacts.isEmpty()) {
-            return;
-        }
-        int poolSize = Math.min(16, Math.max(4, Runtime.getRuntime().availableProcessors() * 2));
-        PluginLogManager.getLog()
-                .info(String.format(
-                        "Pre-warming checksum cache for %d unique artifacts with %d threads",
-                        artifacts.size(), poolSize));
-        ExecutorService executor = Executors.newFixedThreadPool(poolSize);
-        try {
-            List<Future<?>> futures = new ArrayList<>();
-            for (var artifact : artifacts) {
-                futures.add(executor.submit(() -> {
-                    calculateArtifactChecksum(artifact);
-                    getArtifactResolvedField(artifact);
-                }));
-            }
-            for (var future : futures) {
-                try {
-                    future.get();
-                } catch (Exception e) {
-                    PluginLogManager.getLog().debug("Pre-warm task failed: " + e.getMessage());
-                }
-            }
-        } finally {
-            executor.shutdown();
         }
     }
 

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/AbstractMavenComponent.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/AbstractMavenComponent.java
@@ -1,9 +1,13 @@
 package io.github.chains_project.maven_lockfile.data;
 
+import io.github.chains_project.maven_lockfile.checksum.RepositoryInformation;
 import io.github.chains_project.maven_lockfile.graph.DependencyNode;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
 
 /**
  * Base class for Maven components (plugins, extensions) that share common metadata structure.
@@ -73,6 +77,27 @@ public abstract class AbstractMavenComponent implements Comparable<AbstractMaven
 
     public Set<DependencyNode> getDependencies() {
         return dependencies;
+    }
+
+    public Artifact toArtifact() {
+        final String scopeValue = null;
+        final String typeValue = "maven-plugin";
+        final String classifierValue = null;
+        return new DefaultArtifact(
+                groupId.getValue(),
+                artifactId.getValue(),
+                version.getValue(),
+                scopeValue,
+                typeValue,
+                classifierValue,
+                new DefaultArtifactHandler(typeValue));
+    }
+
+    public RepositoryInformation getRepositoryInformation() {
+        if (resolved != null && repositoryId != null) {
+            return new RepositoryInformation(resolved, repositoryId);
+        }
+        return RepositoryInformation.Unresolved();
     }
 
     @Override

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/Config.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/Config.java
@@ -11,6 +11,7 @@ public class Config {
     private final boolean allowEnvironmentalValidationFailure;
     private final boolean includeEnvironment;
     private final boolean reduced;
+    private final boolean incrementalGenerate;
     private final String mavenLockfileVersion;
     private final ChecksumModes checksumMode;
     private final String checksumAlgorithm;
@@ -22,6 +23,7 @@ public class Config {
             OnEnvironmentalValidationFailure allowEnvironmentalValidationFailure,
             EnvironmentInclusion includeEnvironment,
             ReductionState reduced,
+            GenerationMode generationMode,
             String mavenLockfileVersion,
             ChecksumModes checksumMode,
             String checksumAlgorithm) {
@@ -32,6 +34,7 @@ public class Config {
                 allowEnvironmentalValidationFailure.equals(OnEnvironmentalValidationFailure.Warn);
         this.includeEnvironment = includeEnvironment.equals(EnvironmentInclusion.Include);
         this.reduced = reduced.equals(ReductionState.Reduced);
+        this.incrementalGenerate = generationMode.equals(GenerationMode.Incremental);
         this.mavenLockfileVersion = mavenLockfileVersion;
         this.checksumMode = checksumMode;
         this.checksumAlgorithm = checksumAlgorithm;
@@ -44,6 +47,7 @@ public class Config {
         this.allowEnvironmentalValidationFailure = false;
         this.includeEnvironment = true;
         this.reduced = false;
+        this.incrementalGenerate = false;
         this.mavenLockfileVersion = "1";
         this.checksumMode = ChecksumModes.LOCAL;
         this.checksumAlgorithm = new FileSystemChecksumCalculator(null, null, null, null).getDefaultChecksumAlgorithm();
@@ -123,6 +127,18 @@ public class Config {
         return reduced ? ReductionState.Reduced : ReductionState.NonReduced;
     }
     /**
+     * @return whether generation should be incremental.
+     */
+    public boolean isIncrementalGenerate() {
+        return incrementalGenerate;
+    }
+    /**
+     * @return the generation mode.
+     */
+    public GenerationMode getGenerationMode() {
+        return incrementalGenerate ? GenerationMode.Incremental : GenerationMode.Full;
+    }
+    /**
      * @return the mavenLockfileVersion
      */
     public String getMavenLockfileVersion() {
@@ -169,5 +185,10 @@ public class Config {
     public enum ReductionState {
         Reduced,
         NonReduced
+    }
+
+    public enum GenerationMode {
+        Incremental,
+        Full
     }
 }

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/Pom.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/Pom.java
@@ -1,5 +1,10 @@
 package io.github.chains_project.maven_lockfile.data;
 
+import io.github.chains_project.maven_lockfile.checksum.RepositoryInformation;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+
 import java.util.Objects;
 
 public class Pom implements Comparable<Pom> {
@@ -69,6 +74,27 @@ public class Pom implements Comparable<Pom> {
 
     public Pom getParent() {
         return parent;
+    }
+
+    public Artifact toArtifact() {
+        final String scopeValue = null;
+        final String typeValue = "pom";
+        final String classifierValue = null;
+        return new DefaultArtifact(
+                groupId.getValue(),
+                artifactId.getValue(),
+                version.getValue(),
+                scopeValue,
+                typeValue,
+                classifierValue,
+                new DefaultArtifactHandler(typeValue));
+    }
+
+    public RepositoryInformation getRepositoryInformation() {
+        if (resolved != null && repositoryId != null) {
+            return new RepositoryInformation(resolved, repositoryId);
+        }
+        return RepositoryInformation.Unresolved();
     }
 
     @Override

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/graph/DependencyNode.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/graph/DependencyNode.java
@@ -1,6 +1,7 @@
 package io.github.chains_project.maven_lockfile.graph;
 
 import com.google.gson.annotations.Expose;
+import io.github.chains_project.maven_lockfile.checksum.RepositoryInformation;
 import io.github.chains_project.maven_lockfile.data.ArtifactId;
 import io.github.chains_project.maven_lockfile.data.ArtifactType;
 import io.github.chains_project.maven_lockfile.data.Classifier;
@@ -11,6 +12,9 @@ import io.github.chains_project.maven_lockfile.data.RepositoryId;
 import io.github.chains_project.maven_lockfile.data.ResolvedUrl;
 import io.github.chains_project.maven_lockfile.data.VersionNumber;
 import java.util.*;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
 
 /**
  * This class represents a node in the dependency graph. It contains the artifactId, groupId and version  of the dependency.
@@ -188,6 +192,33 @@ public class DependencyNode implements Comparable<DependencyNode> {
      */
     public boolean isIncluded() {
         return included;
+    }
+
+    /**
+     * @return the artifact representation of the dependency node
+     */
+    public Artifact toArtifact() {
+        var scopeValue = (scope == null) ? null : scope.getValue();
+        var typeValue = (type == null) ? "jar" : type.getValue();
+        var classifierValue = (classifier == null) ? null : classifier.getValue();
+        return new DefaultArtifact(
+                groupId.getValue(),
+                artifactId.getValue(),
+                version.getValue(),
+                scopeValue,
+                typeValue,
+                classifierValue,
+                new DefaultArtifactHandler(typeValue));
+    }
+
+    /**
+     * @return the combined repository information.
+     */
+    public RepositoryInformation getRepositoryInformation() {
+        if (resolved != null && repositoryId != null) {
+            return new RepositoryInformation(resolved, repositoryId);
+        }
+        return RepositoryInformation.Unresolved();
     }
 
     @Override

--- a/maven_plugin/src/test/java/io/github/chains_project/maven_lockfile/graph/LockfileTest.java
+++ b/maven_plugin/src/test/java/io/github/chains_project/maven_lockfile/graph/LockfileTest.java
@@ -32,6 +32,7 @@ public class LockfileTest {
                         Config.OnEnvironmentalValidationFailure.Error,
                         Config.EnvironmentInclusion.Include,
                         Config.ReductionState.NonReduced,
+                        Config.GenerationMode.Full,
                         "1",
                         ChecksumModes.LOCAL,
                         "SHA-1"));


### PR DESCRIPTION
This PR proposes two related changes:

## Improved/cross project caching
Applying caching (similar to that implemented for the remote checksum calculator) to all cache calculator, and applying a single cache across all projects in a multi project/reactor build - achieved by stashing the underlying caches in the Maven session.
This has a significant impact on performance of `:generate`, as deep transitive dependencies are evaluated repeatedly and increasingly as a reactor build progresses through the project dependency tree.
There are limitations to the cross-project caching - i.e. if the reactor creates project sets with distinct classloaders from the initiating/parent project. In this case the caching falls back to a project scoped cache.

In my test project, this results in 58,000 checksum calculation total requests (including plugin dependencies) only making 1070 requests to the underlying remote checksum calculator. There's a more modest gain with the local calculator (about 3 seconds on my large test project), with a bit of the benefit coming from having the multi-threaded prewarm code applied to all calculator now.

## Incremental generation mode
An opt-in feature (i.e. with config flag) that avoids re-calculating checksums on subsequent `:generate`calls.
This is achieved by simply pre-loading the checksums in the lockfile into the checksum calculator cache (which is now known to decorate all checksum calculators).
In my test project, this reduces the remaining 1070 remote calculator calls to ~30 (there are a bunch of glitches in the dependency tree like missing/relocated poms etc. that still seem to cause calculations).
Removing the lockfile and re-generating (or changing the config flag) provides for forcing re-generation where a checksum changes for valid reasons.

I think that this doesn't change the security guarantees of the lockfile...
We 'trust' the checksums in the lockfile, so re-calculating them has two possible outcomes:
1. The checksum is unchanged, and we could have avoided recalculating it.
2. The checksum is changed, which can be detected by a `:validate` run either before or after the incremental `:generate`.
The only difference in behaviour with a full regeneration would be generating a new checksum for an artifact that wasn't expected to change - I think the incremental behaviour is actually more desirable TBH (should this even be an opt-in feature>?). 

Happy to discuss/split/rework, since this landed without an initial discussion issue (the bulk of the implementation was in a stash from a year ago that I'd forgotten about and noticed while doing other patches).