### PR TITLE
fix: normalize lockfiles for Windows

### DIFF
--- a/.github/workflows/code-qualitiy.yml
+++ b/.github/workflows/code-qualitiy.yml
@@ -8,7 +8,7 @@ permissions:
   contents: read
 jobs:
   maven-quality:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/code-qualitiy.yml
+++ b/.github/workflows/code-qualitiy.yml
@@ -8,7 +8,7 @@ permissions:
   contents: read
 jobs:
   maven-quality:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
       - name: Harden Runner

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/LockFileFacade.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/LockFileFacade.java
@@ -12,6 +12,7 @@ import io.github.chains_project.maven_lockfile.resolvers.ProjectBuilder;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DefaultArtifact;
 import org.apache.maven.artifact.handler.DefaultArtifactHandler;
@@ -517,11 +518,16 @@ public class LockFileFacade {
 
             String relativePath = isExternalPom
                     ? null
-                    : initialProject
-                            .getBasedir()
-                            .toPath()
-                            .relativize(project.getFile().toPath())
-                            .toString();
+                    : StreamSupport.stream(
+                                    initialProject
+                                            .getBasedir()
+                                            .toPath()
+                                            .relativize(project.getFile().toPath())
+                                            .spliterator(),
+                                    false)
+                            .map(Path::toString)
+                            .collect(Collectors.joining("/"));
+
             String checksum;
             ResolvedUrl resolved = null;
             RepositoryId repoId = null;

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/checksum/AbstractChecksumCalculator.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/checksum/AbstractChecksumCalculator.java
@@ -8,6 +8,7 @@ import java.security.MessageDigest;
 import java.util.Collection;
 import java.util.Locale;
 import org.apache.maven.artifact.Artifact;
+import java.nio.charset.StandardCharsets;
 
 public abstract class AbstractChecksumCalculator {
 
@@ -49,8 +50,14 @@ public abstract class AbstractChecksumCalculator {
     public String calculatePomChecksum(Path path) {
         try {
             MessageDigest messageDigest = MessageDigest.getInstance(checksumAlgorithm);
-            byte[] fileBuffer = Files.readAllBytes(path);
-            byte[] artifactHash = messageDigest.digest(fileBuffer);
+
+            //normalize line endings to prevent false-positives on checksum mismatch
+            byte[] normalizedBytes = Files.readString(path)
+                                            .replace("\r\n", "\n")
+                                            .replace("\r", "\n")
+                                            .getBytes(StandardCharsets.UTF_8);
+            
+            byte[] artifactHash = messageDigest.digest(normalizedBytes);
             BaseEncoding baseEncoding = BaseEncoding.base16();
             return baseEncoding.encode(artifactHash).toLowerCase(Locale.ROOT);
         } catch (Exception e) {

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/checksum/AbstractChecksumCalculator.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/checksum/AbstractChecksumCalculator.java
@@ -2,13 +2,13 @@ package io.github.chains_project.maven_lockfile.checksum;
 
 import com.google.common.io.BaseEncoding;
 import io.github.chains_project.maven_lockfile.reporting.PluginLogManager;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.util.Collection;
 import java.util.Locale;
 import org.apache.maven.artifact.Artifact;
-import java.nio.charset.StandardCharsets;
 
 public abstract class AbstractChecksumCalculator {
 
@@ -51,12 +51,12 @@ public abstract class AbstractChecksumCalculator {
         try {
             MessageDigest messageDigest = MessageDigest.getInstance(checksumAlgorithm);
 
-            //normalize line endings to prevent false-positives on checksum mismatch
+            // normalize line endings to prevent false-positives on checksum mismatch
             byte[] normalizedBytes = Files.readString(path)
-                                            .replace("\r\n", "\n")
-                                            .replace("\r", "\n")
-                                            .getBytes(StandardCharsets.UTF_8);
-            
+                    .replace("\r\n", "\n")
+                    .replace("\r", "\n")
+                    .getBytes(StandardCharsets.UTF_8);
+
             byte[] artifactHash = messageDigest.digest(normalizedBytes);
             BaseEncoding baseEncoding = BaseEncoding.base16();
             return baseEncoding.encode(artifactHash).toLowerCase(Locale.ROOT);


### PR DESCRIPTION
Normalize line endings before calculating checksum. Prevents false-positive mismatches on checksum validation.

Context:
My team at work and I are incorporating maven-lockfile. We have a mixed environment, with some of us on windows/mac/linux and we have been facing issues with the pom.xml checksum validation. My lead actually pointed this out to me so quickly made a patch. 