### PR TITLE
fix: clear negative prewarm cache entries to allow sequential retry

### DIFF
--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/checksum/RemoteChecksumCalculator.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/checksum/RemoteChecksumCalculator.java
@@ -260,6 +260,13 @@ public class RemoteChecksumCalculator extends AbstractChecksumCalculator {
         } finally {
             executor.shutdown();
         }
+        // Parallel pre-warm requests can fail transiently (e.g. rate-limiting, connection
+        // exhaustion) and cache empty/Unresolved sentinels as negative results. Clear those
+        // so the sequential node-creation phase can retry each artifact individually.
+        for (Artifact artifact : artifacts) {
+            checksumCache.remove(getCacheKey(artifact) + ":" + checksumAlgorithm, "");
+            resolvedCache.remove(getCacheKey(artifact), RepositoryInformation.Unresolved());
+        }
     }
 
     @Override


### PR DESCRIPTION
Parallel HTTP requests in prewarmArtifactCache can fail transiently
(rate-limiting, connection exhaustion under high concurrency) and write
empty/Unresolved sentinels into the shared caches. The subsequent
sequential node-creation phase then reads those poisoned entries and
emits empty checksum and resolved fields in the lockfile.

After the executor finishes, remove any "" checksum entries and
RepositoryInformation.Unresolved() resolved entries for pre-warmed
artifacts so that calculateArtifactChecksum / getArtifactResolvedField
can retry each artifact individually with a fresh network request.

Fixes #1561

https://claude.ai/code/session_013bcMjEmzXCLidHEdNRKKs1