### PR TITLE
feat: add SpecialPluginResolver framework for dynamically-loaded plug…

### DIFF
--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/LockFileFacade.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/LockFileFacade.java
@@ -9,6 +9,8 @@ import io.github.chains_project.maven_lockfile.graph.DependencyGraph;
 import io.github.chains_project.maven_lockfile.reporting.PluginLogManager;
 import io.github.chains_project.maven_lockfile.resolvers.BomResolver;
 import io.github.chains_project.maven_lockfile.resolvers.ProjectBuilder;
+import io.github.chains_project.maven_lockfile.resolvers.SpecialPluginResolver;
+import io.github.chains_project.maven_lockfile.resolvers.SurefirePluginResolver;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -42,6 +44,14 @@ import org.eclipse.aether.util.artifact.JavaScopes;
  *
  */
 public class LockFileFacade {
+
+    /**
+     * Registry of special plugin resolvers that discover dynamically-loaded plugin artifacts.
+     * Add new implementations here to extend lockfile generation to new build plugins.
+     */
+    private static final List<SpecialPluginResolver> PLUGIN_RESOLVERS = List.of(
+            new SurefirePluginResolver());
+
     /**
      * This visitor is used to traverse the dependency graph and add the edges to the graph.
      */
@@ -299,7 +309,7 @@ public class LockFileFacade {
             AbstractChecksumCalculator checksumCalculator) {
         Set<MavenPlugin> plugins = new TreeSet<>();
 
-        // Build a map of user-declared plugin dependencies
+        // Build a map of user-declared plugin dependencies (mutable lists so resolvers can inject)
         // Key: groupId:artifactId, Value: list of user-declared dependencies
         Map<String, List<Dependency>> userPluginDependencies = new HashMap<>();
         if (project.getBuild() != null && project.getBuild().getPlugins() != null) {
@@ -307,10 +317,20 @@ public class LockFileFacade {
                 String key = plugin.getGroupId() + ":" + plugin.getArtifactId();
                 if (plugin.getDependencies() != null
                         && !plugin.getDependencies().isEmpty()) {
-                    userPluginDependencies.put(key, plugin.getDependencies());
+                    userPluginDependencies.put(key, new ArrayList<>(plugin.getDependencies()));
                 }
             }
         }
+
+        for (SpecialPluginResolver resolver : PLUGIN_RESOLVERS) {
+            if (!resolver.isApplicable(project)) continue;
+            PluginLogManager.getLog()
+                    .info(resolver.getDisplayName() + " detected — running special plugin resolver");
+            SpecialPluginResolver.DiscoveryResult result = resolver.discover(project, session);
+            result.getPluginDependencies().forEach((pluginKey, deps) ->
+                    userPluginDependencies.computeIfAbsent(pluginKey, k -> new ArrayList<>()).addAll(deps));
+        }
+
         ProjectBuilder projectBuilder = new ProjectBuilder(session, project.getPluginArtifactRepositories());
 
         for (Artifact pluginArtifact : project.getPluginArtifacts()) {

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/resolvers/SpecialPluginResolver.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/resolvers/SpecialPluginResolver.java
@@ -1,0 +1,97 @@
+package io.github.chains_project.maven_lockfile.resolvers;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.project.MavenProject;
+
+/**
+ * Base class for resolvers that discover artifacts dynamically loaded by specific Maven build
+ * plugins — artifacts that are not declared in the project's {@code pom.xml} but are required
+ * for a hermetic offline build.
+ *
+ * <p>Implement this class to add support for a new plugin. Discovered artifacts are returned as
+ * a {@link DiscoveryResult} containing plugin dependencies keyed by the target plugin's
+ * {@code groupId:artifactId}.
+ *
+ * <p>Register new implementations in {@code LockFileFacade#PLUGIN_RESOLVERS}.
+ */
+public abstract class SpecialPluginResolver {
+
+    /**
+     * Returns {@code true} if this resolver applies to the given project (i.e. the plugin it
+     * handles is present in the project's build plugins).
+     */
+    public abstract boolean isApplicable(MavenProject project);
+
+    /**
+     * A short human-readable name for log messages (e.g. {@code "Surefire"}).
+     */
+    public abstract String getDisplayName();
+
+    /**
+     * Discovers artifacts that the plugin loads dynamically and returns them as a
+     * {@link DiscoveryResult}.
+     *
+     * @param project the Maven project
+     * @param session the Maven session
+     * @return discovery result (may be {@link DiscoveryResult#empty()})
+     */
+    public abstract DiscoveryResult discover(MavenProject project, MavenSession session);
+
+    /**
+     * Returns the first build plugin matching the given {@code artifactId}, or empty.
+     */
+    protected static Optional<Plugin> findPlugin(MavenProject project, String artifactId) {
+        return project.getBuildPlugins().stream()
+                .filter(p -> artifactId.equals(p.getArtifactId()))
+                .findFirst();
+    }
+
+    /**
+     * Holds the artifacts discovered by a {@link SpecialPluginResolver}.
+     *
+     * <p>{@link #pluginDependencies} are mapped by plugin key ({@code groupId:artifactId});
+     * they are injected as user-declared dependencies for the target plugin's resolution in
+     * {@code LockFileFacade}.
+     */
+    public static final class DiscoveryResult {
+
+        private final Map<String, List<Dependency>> pluginDependencies;
+
+        private DiscoveryResult(Map<String, List<Dependency>> pluginDependencies) {
+            this.pluginDependencies = pluginDependencies;
+        }
+
+        /** Result with no discovered artifacts. */
+        public static DiscoveryResult empty() {
+            return new DiscoveryResult(Collections.emptyMap());
+        }
+
+        /**
+         * Result carrying dependencies to inject into a specific plugin's resolution.
+         *
+         * @param pluginKey  {@code groupId:artifactId} of the target plugin
+         * @param deps       dependencies to inject
+         */
+        public static DiscoveryResult ofPluginDependencies(
+                String pluginKey, List<Dependency> deps) {
+            return new DiscoveryResult(Map.of(pluginKey, deps));
+        }
+
+        /**
+         * Returns dependencies to inject, keyed by plugin {@code groupId:artifactId}.
+         */
+        public Map<String, List<Dependency>> getPluginDependencies() {
+            return pluginDependencies;
+        }
+
+        public boolean isEmpty() {
+            return pluginDependencies.isEmpty();
+        }
+    }
+}

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/resolvers/SurefirePluginResolver.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/resolvers/SurefirePluginResolver.java
@@ -1,0 +1,99 @@
+package io.github.chains_project.maven_lockfile.resolvers;
+
+import io.github.chains_project.maven_lockfile.reporting.PluginLogManager;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.project.MavenProject;
+
+/**
+ * Discovers the test framework provider that {@code maven-surefire-plugin} loads dynamically at
+ * runtime based on which testing library is declared in the project's test dependencies.
+ *
+ * <p>Surefire selects a provider jar at test-execution time by inspecting the test classpath for
+ * known framework marker groupIds, then resolves the matching provider at its own version. None of
+ * these provider jars appear in the project's declared dependencies, so they would be missing from
+ * the lockfile without this resolver.
+ *
+ * <p>The mapping from test-framework marker groupId to provider artifactId is defined in
+ * {@link #FRAMEWORK_PROVIDER_TABLE}. Adding support for a new provider requires only a new entry
+ * in that table.
+ */
+public class SurefirePluginResolver extends SpecialPluginResolver {
+
+    private static final String SUREFIRE_GROUP_ID = "org.apache.maven.surefire";
+    private static final String SUREFIRE_ARTIFACT_ID = "maven-surefire-plugin";
+    private static final String SUREFIRE_PLUGIN_KEY =
+            "org.apache.maven.plugins:" + SUREFIRE_ARTIFACT_ID;
+
+    /**
+     * Maps test-framework marker groupIds to the Surefire provider artifactId that handles them.
+     * Entries are evaluated in order; the first match wins.
+     */
+    private static final List<Map.Entry<List<String>, String>> FRAMEWORK_PROVIDER_TABLE = List.of(
+            Map.entry(List.of("org.junit.jupiter", "org.junit.platform"), "surefire-junit-platform"),
+            Map.entry(List.of("org.testng"), "surefire-testng"),
+            Map.entry(List.of("junit"), "surefire-junit47"),
+            Map.entry(List.of("junit-addons"), "surefire-junit3"));
+
+    public SurefirePluginResolver() {}
+
+    @Override
+    public boolean isApplicable(MavenProject project) {
+        return findPlugin(project, SUREFIRE_ARTIFACT_ID).isPresent()
+                && detectProvider(project) != null;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "maven-surefire-plugin (provider auto-detection)";
+    }
+
+    @Override
+    public DiscoveryResult discover(MavenProject project, MavenSession session) {
+        String surefireVersion = findPlugin(project, SUREFIRE_ARTIFACT_ID)
+                .map(p -> p.getVersion())
+                .orElse(null);
+
+        if (surefireVersion == null || surefireVersion.startsWith("${")) {
+            PluginLogManager.getLog().warn(
+                    "SurefirePluginResolver: could not resolve surefire version — skipping");
+            return DiscoveryResult.empty();
+        }
+
+        String providerArtifactId = detectProvider(project);
+        if (providerArtifactId == null) {
+            return DiscoveryResult.empty();
+        }
+
+        Dependency provider = new Dependency();
+        provider.setGroupId(SUREFIRE_GROUP_ID);
+        provider.setArtifactId(providerArtifactId);
+        provider.setVersion(surefireVersion);
+
+        PluginLogManager.getLog().info(String.format(
+                "SurefirePluginResolver: injecting %s:%s:%s into %s",
+                SUREFIRE_GROUP_ID, providerArtifactId, surefireVersion, SUREFIRE_PLUGIN_KEY));
+
+        List<Dependency> deps = new ArrayList<>();
+        deps.add(provider);
+        return DiscoveryResult.ofPluginDependencies(SUREFIRE_PLUGIN_KEY, deps);
+    }
+
+    private static String detectProvider(MavenProject project) {
+        List<String> testGroupIds = project.getDependencies().stream()
+                .filter(d -> "test".equals(d.getScope()))
+                .map(d -> d.getGroupId())
+                .collect(Collectors.toList());
+
+        for (Map.Entry<List<String>, String> entry : FRAMEWORK_PROVIDER_TABLE) {
+            if (testGroupIds.stream().anyMatch(entry.getKey()::contains)) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+}

--- a/maven_plugin/src/test/java/io/github/chains_project/maven_lockfile/resolvers/SurefirePluginResolverTest.java
+++ b/maven_plugin/src/test/java/io/github/chains_project/maven_lockfile/resolvers/SurefirePluginResolverTest.java
@@ -1,0 +1,107 @@
+package io.github.chains_project.maven_lockfile.resolvers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.maven.model.Build;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SurefirePluginResolverTest {
+
+    private SurefirePluginResolver resolver;
+
+    @BeforeEach
+    void setUp() {
+        resolver = new SurefirePluginResolver();
+    }
+
+    @Test
+    void isNotApplicableWhenSurefirePluginAbsent() {
+        MavenProject project = new MavenProject(new Model());
+        assertThat(resolver.isApplicable(project)).isFalse();
+    }
+
+    @Test
+    void isNotApplicableWhenSurefirePresentButNoTestFramework() {
+        Model model = new Model();
+        Build build = new Build();
+        Plugin surefire = new Plugin();
+        surefire.setGroupId("org.apache.maven.plugins");
+        surefire.setArtifactId("maven-surefire-plugin");
+        surefire.setVersion("3.2.5");
+        build.addPlugin(surefire);
+        model.setBuild(build);
+
+        MavenProject project = new MavenProject(model);
+        assertThat(resolver.isApplicable(project)).isFalse();
+    }
+
+    @Test
+    void isApplicableWhenSurefireAndJUnit5Present() {
+        MavenProject project = projectWithSurefireAndTestDep("org.junit.jupiter", "junit-jupiter", "5.10.2");
+        assertThat(resolver.isApplicable(project)).isTrue();
+    }
+
+    @Test
+    void isApplicableWhenSurefireAndTestNGPresent() {
+        MavenProject project = projectWithSurefireAndTestDep("org.testng", "testng", "7.9.0");
+        assertThat(resolver.isApplicable(project)).isTrue();
+    }
+
+    @Test
+    void isApplicableWhenSurefireAndJUnit4Present() {
+        MavenProject project = projectWithSurefireAndTestDep("junit", "junit", "4.13.2");
+        assertThat(resolver.isApplicable(project)).isTrue();
+    }
+
+    @Test
+    void isNotApplicableWhenOnlyCompileScopeDeps() {
+        Model model = new Model();
+        Build build = new Build();
+        Plugin surefire = new Plugin();
+        surefire.setGroupId("org.apache.maven.plugins");
+        surefire.setArtifactId("maven-surefire-plugin");
+        surefire.setVersion("3.2.5");
+        build.addPlugin(surefire);
+        model.setBuild(build);
+
+        Dependency guava = new Dependency();
+        guava.setGroupId("com.google.guava");
+        guava.setArtifactId("guava");
+        guava.setVersion("33.0.0-jre");
+        guava.setScope("compile");
+        model.addDependency(guava);
+
+        MavenProject project = new MavenProject(model);
+        assertThat(resolver.isApplicable(project)).isFalse();
+    }
+
+    @Test
+    void displayNameContainsSurefire() {
+        assertThat(resolver.getDisplayName()).contains("surefire");
+    }
+
+    private static MavenProject projectWithSurefireAndTestDep(String groupId, String artifactId, String version) {
+        Model model = new Model();
+        Build build = new Build();
+        Plugin surefire = new Plugin();
+        surefire.setGroupId("org.apache.maven.plugins");
+        surefire.setArtifactId("maven-surefire-plugin");
+        surefire.setVersion("3.2.5");
+        build.addPlugin(surefire);
+        model.setBuild(build);
+
+        Dependency dep = new Dependency();
+        dep.setGroupId(groupId);
+        dep.setArtifactId(artifactId);
+        dep.setVersion(version);
+        dep.setScope("test");
+        model.addDependency(dep);
+
+        return new MavenProject(model);
+    }
+}

--- a/maven_plugin/src/test/java/it/IntegrationTestsIT.java
+++ b/maven_plugin/src/test/java/it/IntegrationTestsIT.java
@@ -877,4 +877,42 @@ public class IntegrationTestsIT {
         assertThat(parent.getArtifactId().equals("oss-parent"));
         assertThat(parent.getVersion().equals("7"));
     }
+
+    @MavenTest
+    public void surefirePluginResolver(MavenExecutionResult result) throws Exception {
+        // contract: when maven-surefire-plugin is present and junit-jupiter is declared as a test
+        // dependency, SurefirePluginResolver must inject surefire-junit-platform into the
+        // surefire plugin's recorded dependencies so the JUnit Platform provider is available
+        // for offline builds.
+        System.out.println("Running 'surefirePluginResolver' integration test.");
+        assertThat(result).isSuccessful();
+        Path lockFilePath = findFile(result, "lockfile.json");
+        assertThat(lockFilePath).exists();
+        var lockFile = LockFile.readLockFile(lockFilePath);
+
+        var surefirePlugin = lockFile.getMavenPlugins().stream()
+                .filter(p -> "maven-surefire-plugin".equals(p.getArtifactId().getValue()))
+                .findFirst();
+        assertThat(surefirePlugin).isPresent();
+
+        // surefire-junit-platform must be injected by SurefirePluginResolver
+        assertThat(surefirePlugin.get().getDependencies())
+                .as("maven-surefire-plugin should contain surefire-junit-platform injected by SurefirePluginResolver")
+                .anyMatch(dep -> "surefire-junit-platform".equals(dep.getArtifactId().getValue())
+                        && "org.apache.maven.surefire".equals(dep.getGroupId().getValue()));
+
+        // The injected provider must have its transitive dependencies resolved
+        var provider = surefirePlugin.get().getDependencies().stream()
+                .filter(dep -> "surefire-junit-platform".equals(dep.getArtifactId().getValue()))
+                .findFirst();
+        assertThat(provider).isPresent();
+        assertThat(provider.get().getChildren())
+                .as("surefire-junit-platform must have transitive dependencies resolved")
+                .isNotEmpty();
+
+        // junit-platform-launcher must be in the transitive closure
+        assertThat(flattenDependencies(provider.get()))
+                .as("injected subtree must contain junit-platform-launcher for offline JUnit 5 execution")
+                .anyMatch(dep -> "junit-platform-launcher".equals(dep.getArtifactId().getValue()));
+    }
 }

--- a/maven_plugin/src/test/resources-its/it/IntegrationTestsIT/surefirePluginResolver/pom.xml
+++ b/maven_plugin/src/test/resources-its/it/IntegrationTestsIT/surefirePluginResolver/pom.xml
@@ -1,0 +1,49 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.mycompany.app</groupId>
+  <artifactId>surefire-resolver-test</artifactId>
+  <packaging>jar</packaging>
+  <version>1</version>
+
+  <properties>
+    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.10.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.5</version>
+      </plugin>
+      <plugin>
+        <groupId>io.github.chains-project</groupId>
+        <artifactId>maven-lockfile</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <checksumMode>local</checksumMode>
+          <includeMavenPlugins>true</includeMavenPlugins>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/maven_plugin/src/test/resources-its/it/IntegrationTestsIT/surefirePluginResolver/src/main/java/HelloWorld.java
+++ b/maven_plugin/src/test/resources-its/it/IntegrationTestsIT/surefirePluginResolver/src/main/java/HelloWorld.java
@@ -1,0 +1,5 @@
+public class HelloWorld {
+    public static void main(String[] args) {
+        System.out.println("Hello World!");
+    }
+}


### PR DESCRIPTION
…in artifacts

Some Maven build plugins (e.g. maven-surefire-plugin) resolve additional artifacts at runtime that are not declared in the POM. These artifacts are invisible to the lockfile even with includeMavenPlugins=true.

This adds a SpecialPluginResolver abstract class and a SurefirePluginResolver implementation that detects the test framework and injects the corresponding Surefire provider into the lockfile.