### PR TITLE
fix: override config value in lockfile with CLI args

### DIFF
--- a/lockfile.json
+++ b/lockfile.json
@@ -41445,7 +41445,7 @@
   "metaData": {
     "environment": {
       "osName": "Linux",
-      "mavenVersion": "3.9.15",
+      "mavenVersion": "3.9.16",
       "javaVersion": "17.0.19"
     },
     "config": {

--- a/maven_plugin/lockfile.json
+++ b/maven_plugin/lockfile.json
@@ -56499,7 +56499,7 @@
   "metaData": {
     "environment": {
       "osName": "Linux",
-      "mavenVersion": "3.9.15",
+      "mavenVersion": "3.9.16",
       "javaVersion": "17.0.19"
     },
     "config": {

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/AbstractLockfileMojo.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/AbstractLockfileMojo.java
@@ -174,4 +174,34 @@ public abstract class AbstractLockfileMojo extends AbstractMojo {
         buildingRequest.setRemoteRepositories(project.getPluginArtifactRepositories());
         return buildingRequest;
     }
+
+    /**
+     * Returns a Config that starts from {@code base} (typically the stored lockfile config) and overrides
+     * only the fields for which a boolean flag was explicitly set to {@code true}. When a flag is
+     * {@code false} (the default), the stored value is preserved so that existing lockfile configs are
+     * not silently tightened by plugin defaults.
+     */
+    protected Config mergeConfigWithCliArgs(Config base) {
+        Config.MavenPluginsInclusion pluginsInclusion =
+                includeMavenPlugins ? Config.MavenPluginsInclusion.Include : base.getMavenPluginsInclusion();
+        Config.OnValidationFailure onValidationFailure =
+                allowValidationFailure ? Config.OnValidationFailure.Warn : base.getOnValidationFailure();
+        Config.OnPomValidationFailure onPomValidationFailure =
+                allowPomValidationFailure ? Config.OnPomValidationFailure.Warn : base.getOnPomValidationFailure();
+        Config.OnEnvironmentalValidationFailure onEnvFailure = allowEnvironmentalValidationFailure
+                ? Config.OnEnvironmentalValidationFailure.Warn
+                : base.getOnEnvironmentalValidationFailure();
+        Config.EnvironmentInclusion environmentInclusion =
+                includeEnvironment ? Config.EnvironmentInclusion.Include : base.getEnvironmentInclusion();
+        return new Config(
+                pluginsInclusion,
+                onValidationFailure,
+                onPomValidationFailure,
+                onEnvFailure,
+                environmentInclusion,
+                base.getReductionState(),
+                base.getMavenLockfileVersion(),
+                base.getChecksumMode(),
+                base.getChecksumAlgorithm());
+    }
 }

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/AbstractLockfileMojo.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/AbstractLockfileMojo.java
@@ -43,19 +43,19 @@ public abstract class AbstractLockfileMojo extends AbstractMojo {
     @Component
     protected RepositorySystem repositorySystem;
 
-    @Parameter(property = "includeMavenPlugins", defaultValue = "false")
+    @Parameter(property = "includeMavenPlugins")
     protected String includeMavenPlugins;
 
-    @Parameter(property = "allowValidationFailure", defaultValue = "false")
+    @Parameter(property = "allowValidationFailure")
     protected String allowValidationFailure;
 
-    @Parameter(property = "allowPomValidationFailure", defaultValue = "false")
+    @Parameter(property = "allowPomValidationFailure")
     protected String allowPomValidationFailure;
 
-    @Parameter(property = "allowEnvironmentalValidationFailure", defaultValue = "false")
+    @Parameter(property = "allowEnvironmentalValidationFailure")
     protected String allowEnvironmentalValidationFailure;
 
-    @Parameter(property = "includeEnvironment", defaultValue = "true")
+    @Parameter(property = "includeEnvironment")
     protected String includeEnvironment;
 
     @Parameter(defaultValue = "${maven.version}")
@@ -150,9 +150,11 @@ public abstract class AbstractLockfileMojo extends AbstractMojo {
                 Boolean.parseBoolean(allowEnvironmentalValidationFailure)
                         ? Config.OnEnvironmentalValidationFailure.Warn
                         : Config.OnEnvironmentalValidationFailure.Error;
-        Config.EnvironmentInclusion environmentInclusion = Boolean.parseBoolean(includeEnvironment)
-                ? Config.EnvironmentInclusion.Include
-                : Config.EnvironmentInclusion.Exclude;
+        // null means "not set" — default for includeEnvironment is Include (true), not Exclude
+        Config.EnvironmentInclusion environmentInclusion =
+                Strings.isNullOrEmpty(includeEnvironment) || Boolean.parseBoolean(includeEnvironment)
+                        ? Config.EnvironmentInclusion.Include
+                        : Config.EnvironmentInclusion.Exclude;
         Config.ReductionState reductionState =
                 Boolean.parseBoolean(reduced) ? Config.ReductionState.Reduced : Config.ReductionState.NonReduced;
 
@@ -178,5 +180,50 @@ public abstract class AbstractLockfileMojo extends AbstractMojo {
         ProjectBuildingRequest buildingRequest = new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
         buildingRequest.setRemoteRepositories(project.getPluginArtifactRepositories());
         return buildingRequest;
+    }
+
+    /**
+     * Returns a Config that starts from {@code base} (typically the stored lockfile config) and overrides
+     * only the fields for which a CLI argument was explicitly provided (non-null / non-empty).
+     * Fields that were not supplied on the command line keep their stored value, ensuring backward
+     * compatibility when new arguments are added after a lockfile was generated.
+     */
+    protected Config mergeConfigWithCliArgs(Config base) {
+        Config.MavenPluginsInclusion pluginsInclusion = Strings.isNullOrEmpty(includeMavenPlugins)
+                ? base.getMavenPluginsInclusion()
+                : (Boolean.parseBoolean(includeMavenPlugins)
+                        ? Config.MavenPluginsInclusion.Include
+                        : Config.MavenPluginsInclusion.Exclude);
+        Config.OnValidationFailure onValidationFailure = Strings.isNullOrEmpty(allowValidationFailure)
+                ? base.getOnValidationFailure()
+                : (Boolean.parseBoolean(allowValidationFailure)
+                        ? Config.OnValidationFailure.Warn
+                        : Config.OnValidationFailure.Error);
+        Config.OnPomValidationFailure onPomValidationFailure = Strings.isNullOrEmpty(allowPomValidationFailure)
+                ? base.getOnPomValidationFailure()
+                : (Boolean.parseBoolean(allowPomValidationFailure)
+                        ? Config.OnPomValidationFailure.Warn
+                        : Config.OnPomValidationFailure.Error);
+        Config.OnEnvironmentalValidationFailure onEnvFailure =
+                Strings.isNullOrEmpty(allowEnvironmentalValidationFailure)
+                        ? base.getOnEnvironmentalValidationFailure()
+                        : (Boolean.parseBoolean(allowEnvironmentalValidationFailure)
+                                ? Config.OnEnvironmentalValidationFailure.Warn
+                                : Config.OnEnvironmentalValidationFailure.Error);
+        Config.EnvironmentInclusion environmentInclusion = Strings.isNullOrEmpty(includeEnvironment)
+                ? base.getEnvironmentInclusion()
+                : (Boolean.parseBoolean(includeEnvironment)
+                        ? Config.EnvironmentInclusion.Include
+                        : Config.EnvironmentInclusion.Exclude);
+        return new Config(
+                pluginsInclusion,
+                onValidationFailure,
+                onPomValidationFailure,
+                onEnvFailure,
+                environmentInclusion,
+                base.getReductionState(),
+                base.getMavenLockfileVersion(),
+                base.getChecksumMode(),
+                base.getChecksumAlgorithm());
     }
 }

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/ValidateChecksumMojo.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/ValidateChecksumMojo.java
@@ -40,10 +40,12 @@ public class ValidateChecksumMojo extends AbstractLockfileMojo {
         try {
             getLog().info("Validating lock file ...");
             LockFile lockFileFromFile = LockFile.readLockFile(getLockFilePath(project, lockfileName));
-            Config config = lockFileFromFile.getConfig() == null ? getConfig() : lockFileFromFile.getConfig();
-            if (lockFileFromFile.getConfig() == null) {
+            Config baseConfig = lockFileFromFile.getConfig();
+            if (baseConfig == null) {
                 getLog().warn("No config was found in the lock file. Using default config.");
+                baseConfig = getConfig();
             }
+            Config config = mergeConfigWithCliArgs(baseConfig);
             Environment environment = null;
             if (config.isIncludeEnvironment()) {
                 environment = generateMetaInformation();

--- a/maven_plugin/src/test/java/io/github/chains_project/maven_lockfile/AbstractLockfileMojoTest.java
+++ b/maven_plugin/src/test/java/io/github/chains_project/maven_lockfile/AbstractLockfileMojoTest.java
@@ -1,0 +1,55 @@
+package io.github.chains_project.maven_lockfile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.chains_project.maven_lockfile.checksum.ChecksumModes;
+import io.github.chains_project.maven_lockfile.data.Config;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.junit.jupiter.api.Test;
+
+class AbstractLockfileMojoTest {
+
+    private static AbstractLockfileMojo mojo() {
+        return new AbstractLockfileMojo() {
+            @Override
+            public void execute() throws MojoExecutionException {}
+        };
+    }
+
+    private static Config storedConfig() {
+        return new Config(
+                Config.MavenPluginsInclusion.Exclude,
+                Config.OnValidationFailure.Error,
+                Config.OnPomValidationFailure.Warn,
+                Config.OnEnvironmentalValidationFailure.Error,
+                Config.EnvironmentInclusion.Include,
+                Config.ReductionState.NonReduced,
+                "5.16.0",
+                ChecksumModes.LOCAL,
+                "SHA-256");
+    }
+
+    @Test
+    void cliArgOverridesStoredConfig() {
+        var m = mojo();
+        m.allowEnvironmentalValidationFailure = "true";
+
+        Config merged = m.mergeConfigWithCliArgs(storedConfig());
+
+        assertThat(merged.getOnEnvironmentalValidationFailure())
+                .isEqualTo(Config.OnEnvironmentalValidationFailure.Warn);
+        // Unset CLI args preserve stored values
+        assertThat(merged.getOnValidationFailure()).isEqualTo(Config.OnValidationFailure.Error);
+        assertThat(merged.getOnPomValidationFailure()).isEqualTo(Config.OnPomValidationFailure.Warn);
+    }
+
+    @Test
+    void storedConfigUsedWhenCliArgNotSet() {
+        var m = mojo();
+        assertThat(m.allowEnvironmentalValidationFailure).isNull();
+
+        Config merged = m.mergeConfigWithCliArgs(storedConfig());
+        assertThat(merged.getOnEnvironmentalValidationFailure())
+                .isEqualTo(Config.OnEnvironmentalValidationFailure.Error);
+    }
+}

--- a/maven_plugin/src/test/java/io/github/chains_project/maven_lockfile/ValidateMojoTest.java
+++ b/maven_plugin/src/test/java/io/github/chains_project/maven_lockfile/ValidateMojoTest.java
@@ -1,0 +1,55 @@
+package io.github.chains_project.maven_lockfile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.chains_project.maven_lockfile.checksum.ChecksumModes;
+import io.github.chains_project.maven_lockfile.data.Config;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.junit.jupiter.api.Test;
+
+class ValidateMojoTest {
+
+    private static AbstractLockfileMojo mojo() {
+        return new AbstractLockfileMojo() {
+            @Override
+            public void execute() throws MojoExecutionException {}
+        };
+    }
+
+    private static Config storedConfig() {
+        return new Config(
+                Config.MavenPluginsInclusion.Exclude,
+                Config.OnValidationFailure.Error,
+                Config.OnPomValidationFailure.Warn,
+                Config.OnEnvironmentalValidationFailure.Error,
+                Config.EnvironmentInclusion.Include,
+                Config.ReductionState.NonReduced,
+                "5.16.0",
+                ChecksumModes.LOCAL,
+                "SHA-256");
+    }
+
+    @Test
+    void cliArgOverridesStoredConfig() {
+        var m = mojo();
+        m.allowEnvironmentalValidationFailure = true;
+
+        Config merged = m.mergeConfigWithCliArgs(storedConfig());
+
+        assertThat(merged.getOnEnvironmentalValidationFailure())
+                .isEqualTo(Config.OnEnvironmentalValidationFailure.Warn);
+        // Unset CLI args preserve stored values
+        assertThat(merged.getOnValidationFailure()).isEqualTo(Config.OnValidationFailure.Error);
+        assertThat(merged.getOnPomValidationFailure()).isEqualTo(Config.OnPomValidationFailure.Warn);
+    }
+
+    @Test
+    void storedConfigUsedWhenCliArgNotSet() {
+        var m = mojo();
+        assertThat(m.allowEnvironmentalValidationFailure).isFalse();
+
+        Config merged = m.mergeConfigWithCliArgs(storedConfig());
+        assertThat(merged.getOnEnvironmentalValidationFailure())
+                .isEqualTo(Config.OnEnvironmentalValidationFailure.Error);
+    }
+}

--- a/maven_plugin/src/test/java/it/IntegrationTestsIT.java
+++ b/maven_plugin/src/test/java/it/IntegrationTestsIT.java
@@ -620,6 +620,17 @@ public class IntegrationTestsIT {
     }
 
     @MavenTest
+    public void environmentalCheckCliOverride(MavenExecutionResult result) throws Exception {
+        // contract: a CLI arg (allowEnvironmentalValidationFailure=true) overrides the stored lockfile
+        // config (allowEnvironmentalValidationFailure=false), so validation succeeds even when the
+        // environment recorded in the lockfile does not match the current environment.
+        System.out.println("Running 'environmentalCheckCliOverride' integration test.");
+        assertThat(result).isSuccessful();
+        String stdout = Files.readString(result.getMavenLog().getStdout());
+        assertThat(stdout.contains("Failed verifying environment.")).isFalse();
+    }
+
+    @MavenTest
     public void externalParentPom(MavenExecutionResult result) throws Exception {
         // contract: a project with an external parent POM (e.g., Spring Boot) should generate
         // a lockfile containing the full parent pom hierarchy with checksums

--- a/maven_plugin/src/test/resources-its/it/IntegrationTestsIT/environmentalCheckCliOverride/lockfile.json
+++ b/maven_plugin/src/test/resources-its/it/IntegrationTestsIT/environmentalCheckCliOverride/lockfile.json
@@ -1,0 +1,35 @@
+{
+  "artifactId": "environmental-check-cli-override",
+  "groupId": "com.mycompany.app",
+  "version": "1",
+  "pom": {
+    "groupId": "com.mycompany.app",
+    "artifactId": "environmental-check-cli-override",
+    "version": "1",
+    "relativePath": "pom.xml",
+    "checksumAlgorithm": "SHA-256",
+    "checksum": "0000000000000000000000000000000000000000000000000000000000000000"
+  },
+  "lockFileVersion": 1,
+  "dependencies": [],
+  "mavenPlugins": [],
+  "metaData": {
+    "environment": {
+      "osName": "TamperedOS",
+      "mavenVersion": "0.0.0",
+      "javaVersion": "0.0.0"
+    },
+    "config": {
+      "includeMavenPlugins": false,
+      "allowValidationFailure": false,
+      "allowPomValidationFailure": true,
+      "allowEnvironmentalValidationFailure": false,
+      "includeEnvironment": true,
+      "reduced": false,
+      "mavenLockfileVersion": "5.16.0",
+      "checksumMode": "local",
+      "checksumAlgorithm": "SHA-256"
+    }
+  },
+  "boms": []
+}

--- a/maven_plugin/src/test/resources-its/it/IntegrationTestsIT/environmentalCheckCliOverride/pom.xml
+++ b/maven_plugin/src/test/resources-its/it/IntegrationTestsIT/environmentalCheckCliOverride/pom.xml
@@ -1,0 +1,34 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.mycompany.app</groupId>
+  <artifactId>environmental-check-cli-override</artifactId>
+  <packaging>jar</packaging>
+  <version>1</version>
+  <properties>
+    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <dependencies>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.github.chains-project</groupId>
+        <artifactId>maven-lockfile</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>validate</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <checksumMode>local</checksumMode>
+          <allowEnvironmentalValidationFailure>true</allowEnvironmentalValidationFailure>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
This is beneficial, especially when we introduce new configuration options and want to apply them to older lockfiles with newer plugins. For example, I would want to exclude `parentPom` from being validated in older versions of lockfile `<=5.15.0`.

Also, just to make it explicit, `CLI args with -D` is equivalent to args in pom configuration.

One can try to validate the lockfile file with this patch with a different environment and it works.
```
mvn io.github.chains-project:maven-lockfile:5.16.1-SNAPSHOT:validate  -DincludeMavenPlugins=true -DallowEnvironmentalValidationFailure=true

[WARNING] Lock file environment does not match project environment.
Lockfile environment: Metadata [osName=Linux, mavenVersion=3.9.15, javaVersion=17.0.19]
Project environment:  Metadata [osName=Linux, mavenVersion=3.9.14, javaVersion=25]
```