### PR TITLE
style: switch jreleaser changelog preset to conventional-commits

### DIFF
--- a/.github/workflows/jreleaser-beta.yml
+++ b/.github/workflows/jreleaser-beta.yml
@@ -96,7 +96,7 @@ jobs:
       - name: commit changes
         run: |
           git checkout -b ${{ env.BRANCH_NAME }}
-          git commit -am "🔖 Releasing version ${{ env.NEXT_BETA_VERSION }}"
+          git commit -am "chore: release version ${{ env.NEXT_BETA_VERSION }}"
           git push --set-upstream origin ${{ env.BRANCH_NAME }}
 
       - name: generate buildinfo file
@@ -130,7 +130,7 @@ jobs:
 
       - name: Commit & Push changes
         run: |
-          git commit -am ":memo: Appending CHANGELOG for ${{ env.NEXT_BETA_VERSION }}"
+          git commit -am "chore: append changelog for ${{ env.NEXT_BETA_VERSION }}"
           git push --set-upstream origin ${{ env.BRANCH_NAME }}
 
       # Log failure:

--- a/.github/workflows/jreleaser.yml
+++ b/.github/workflows/jreleaser.yml
@@ -107,7 +107,7 @@ jobs:
       - name: commit changes
         run: |
           git checkout -b ${{ env.BRANCH_NAME }}
-          git commit -am "🔖 Releasing version ${{ env.NEXT_VERSION }}"
+          git commit -am "chore: release version ${{ env.NEXT_VERSION }}"
           git push --set-upstream origin ${{ env.BRANCH_NAME }}
 
 
@@ -162,7 +162,7 @@ jobs:
 
       - name: Commit & Push changes
         run: |
-          git commit -am "🔖 Setting SNAPSHOT version ${{ env.NEXT_RELEASE_VERSION }}"
+          git commit -am "chore: set snapshot version ${{ env.NEXT_RELEASE_VERSION }}"
           git push --set-upstream origin ${{ env.BRANCH_NAME }}
 
       - name: Create Pull Request for Release

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -24,7 +24,7 @@ release:
       pattern: .*beta.*
     changelog:
       formatted: ALWAYS
-      preset: 'gitmoji'
+      preset: 'conventional-commits'
       format: '- {{commitShortHash}} {{commitTitle}}'
       contributors:
         format: '- {{contributorName}} ({{contributorUsernameAsLink}})'


### PR DESCRIPTION
I don't know how to automate gitmoji selection and [conventional commit](https://jreleaser.org/guide/latest/reference/release/changelog.html#_conventional_commits) [prefixes](https://www.conventionalcommits.org/en/v1.0.0/) feel more natural.