### PR TITLE
fix: backward-compatible validation for old lockfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ mvn -f pom.lockfile.xml
 - `allowPomValidationFailure` (`-DallowPomValidationFailure=true`, default=false) allow validation failure of the pom specifically, dependency validation still occurs (assuming `allowValidationFailure` is `false`). In case of checksum mismatch of pom prints a warning instead of default exception.
 - `allowEnvironmentalValidationFailure` (`-DallowEnvironmentalValidationFailure=true`, default=false) allow validation failure of the environment. In case of environment mismatch prints a warning instead of default exception.
 - `includeEnvironment` (`-DincludeEnvironment=true`) will include the environment metadata in the lockfile. This is useful if you want to have warnings when the environment changes.
+- `includeBoms` (`-DincludeBoms=true`, default=true) controls whether BOM (bill of materials) POMs are included in the lockfile.
+- `allowBomValidationFailure` (`-DallowBomValidationFailure=true`, default=false) allow BOM validation failures, printing a warning instead of an error.
+- `includeParentPom` (`-DincludeParentPom=true`, default=true) controls whether parent POM data is included in the lockfile for dependencies and plugins.
+- `allowParentPomValidationFailure` (`-DallowParentPomValidationFailure=true`, default=false) allow parent POM validation failures, printing a warning instead of an error.
+- `includeMavenExtensions` (`-DincludeMavenExtensions=true`, default=true) controls whether Maven build extensions are included in the lockfile.
+- `allowMavenExtensionsValidationFailure` (`-DallowMavenExtensionsValidationFailure=true`, default=false) allow Maven extensions validation failures, printing a warning instead of an error.
 - `checksumAlgorithm` (`-DchecksumAlgorithm=SHA-256`) will set the checksum algorithm used to generate the lockfile. If not explicitly provided it will use SHA-256.
 - `checksumMode` will set the checksum mode used to generate the lockfile. See [Checksum Modes](/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/checksum/ChecksumModes.java) for more information.
 - `skip` (`-Dskip=true`) will skip the execution of the plugin. This is useful if you would like to disable the plugin for a specific module.

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/AbstractLockfileMojo.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/AbstractLockfileMojo.java
@@ -58,6 +58,24 @@ public abstract class AbstractLockfileMojo extends AbstractMojo {
     @Parameter(property = "includeEnvironment")
     protected Boolean includeEnvironment;
 
+    @Parameter(property = "includeBoms")
+    protected Boolean includeBoms;
+
+    @Parameter(property = "allowBomValidationFailure")
+    protected Boolean allowBomValidationFailure;
+
+    @Parameter(property = "includeParentPom")
+    protected Boolean includeParentPom;
+
+    @Parameter(property = "allowParentPomValidationFailure")
+    protected Boolean allowParentPomValidationFailure;
+
+    @Parameter(property = "includeMavenExtensions")
+    protected Boolean includeMavenExtensions;
+
+    @Parameter(property = "allowMavenExtensionsValidationFailure")
+    protected Boolean allowMavenExtensionsValidationFailure;
+
     @Parameter(defaultValue = "${maven.version}")
     protected String mavenVersion;
 
@@ -157,6 +175,26 @@ public abstract class AbstractLockfileMojo extends AbstractMojo {
                 : Config.EnvironmentInclusion.Include;
         Config.ReductionState reductionState =
                 reduced ? Config.ReductionState.Reduced : Config.ReductionState.NonReduced;
+        // include* flags default to true when not explicitly set
+        Config.BomsInclusion bomsInclusion =
+                Boolean.FALSE.equals(includeBoms) ? Config.BomsInclusion.Exclude : Config.BomsInclusion.Include;
+        Config.OnBomValidationFailure onBomValidationFailure = Boolean.TRUE.equals(allowBomValidationFailure)
+                ? Config.OnBomValidationFailure.Warn
+                : Config.OnBomValidationFailure.Error;
+        Config.ParentPomInclusion parentPomInclusion = Boolean.FALSE.equals(includeParentPom)
+                ? Config.ParentPomInclusion.Exclude
+                : Config.ParentPomInclusion.Include;
+        Config.OnParentPomValidationFailure onParentPomValidationFailure =
+                Boolean.TRUE.equals(allowParentPomValidationFailure)
+                        ? Config.OnParentPomValidationFailure.Warn
+                        : Config.OnParentPomValidationFailure.Error;
+        Config.MavenExtensionsInclusion mavenExtensionsInclusion = Boolean.FALSE.equals(includeMavenExtensions)
+                ? Config.MavenExtensionsInclusion.Exclude
+                : Config.MavenExtensionsInclusion.Include;
+        Config.OnMavenExtensionsValidationFailure onMavenExtensionsValidationFailure =
+                Boolean.TRUE.equals(allowMavenExtensionsValidationFailure)
+                        ? Config.OnMavenExtensionsValidationFailure.Warn
+                        : Config.OnMavenExtensionsValidationFailure.Error;
 
         return new Config(
                 mavenPluginsInclusion,
@@ -167,7 +205,13 @@ public abstract class AbstractLockfileMojo extends AbstractMojo {
                 reductionState,
                 mojo.getPlugin().getVersion(),
                 chosenChecksumMode,
-                chosenChecksumAlgorithm);
+                chosenChecksumAlgorithm,
+                bomsInclusion,
+                onBomValidationFailure,
+                parentPomInclusion,
+                onParentPomValidationFailure,
+                mavenExtensionsInclusion,
+                onMavenExtensionsValidationFailure);
     }
 
     protected ProjectBuildingRequest newResolveArtifactProjectBuildingRequest() throws MojoExecutionException {
@@ -205,6 +249,31 @@ public abstract class AbstractLockfileMojo extends AbstractMojo {
         Config.EnvironmentInclusion environmentInclusion = includeEnvironment != null
                 ? (includeEnvironment ? Config.EnvironmentInclusion.Include : Config.EnvironmentInclusion.Exclude)
                 : base.getEnvironmentInclusion();
+        Config.BomsInclusion bomsInclusion = includeBoms != null
+                ? (includeBoms ? Config.BomsInclusion.Include : Config.BomsInclusion.Exclude)
+                : base.getBomsInclusion();
+        Config.OnBomValidationFailure onBomValidationFailure = allowBomValidationFailure != null
+                ? (allowBomValidationFailure ? Config.OnBomValidationFailure.Warn : Config.OnBomValidationFailure.Error)
+                : base.getOnBomValidationFailure();
+        Config.ParentPomInclusion parentPomInclusion = includeParentPom != null
+                ? (includeParentPom ? Config.ParentPomInclusion.Include : Config.ParentPomInclusion.Exclude)
+                : base.getParentPomInclusion();
+        Config.OnParentPomValidationFailure onParentPomValidationFailure = allowParentPomValidationFailure != null
+                ? (allowParentPomValidationFailure
+                        ? Config.OnParentPomValidationFailure.Warn
+                        : Config.OnParentPomValidationFailure.Error)
+                : base.getOnParentPomValidationFailure();
+        Config.MavenExtensionsInclusion mavenExtensionsInclusion = includeMavenExtensions != null
+                ? (includeMavenExtensions
+                        ? Config.MavenExtensionsInclusion.Include
+                        : Config.MavenExtensionsInclusion.Exclude)
+                : base.getMavenExtensionsInclusion();
+        Config.OnMavenExtensionsValidationFailure onMavenExtensionsValidationFailure =
+                allowMavenExtensionsValidationFailure != null
+                        ? (allowMavenExtensionsValidationFailure
+                                ? Config.OnMavenExtensionsValidationFailure.Warn
+                                : Config.OnMavenExtensionsValidationFailure.Error)
+                        : base.getOnMavenExtensionsValidationFailure();
         return new Config(
                 pluginsInclusion,
                 onValidationFailure,
@@ -214,6 +283,12 @@ public abstract class AbstractLockfileMojo extends AbstractMojo {
                 base.getReductionState(),
                 base.getMavenLockfileVersion(),
                 base.getChecksumMode(),
-                base.getChecksumAlgorithm());
+                base.getChecksumAlgorithm(),
+                bomsInclusion,
+                onBomValidationFailure,
+                parentPomInclusion,
+                onParentPomValidationFailure,
+                mavenExtensionsInclusion,
+                onMavenExtensionsValidationFailure);
     }
 }

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/AbstractLockfileMojo.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/AbstractLockfileMojo.java
@@ -176,10 +176,9 @@ public abstract class AbstractLockfileMojo extends AbstractMojo {
         Config.ReductionState reductionState =
                 Boolean.parseBoolean(reduced) ? Config.ReductionState.Reduced : Config.ReductionState.NonReduced;
         // include* flags default to Include when unset — same pattern as includeEnvironment
-        Config.BomsInclusion bomsInclusion =
-                Strings.isNullOrEmpty(includeBoms) || Boolean.parseBoolean(includeBoms)
-                        ? Config.BomsInclusion.Include
-                        : Config.BomsInclusion.Exclude;
+        Config.BomsInclusion bomsInclusion = Strings.isNullOrEmpty(includeBoms) || Boolean.parseBoolean(includeBoms)
+                ? Config.BomsInclusion.Include
+                : Config.BomsInclusion.Exclude;
         Config.OnBomValidationFailure onBomValidationFailure = Boolean.parseBoolean(allowBomValidationFailure)
                 ? Config.OnBomValidationFailure.Warn
                 : Config.OnBomValidationFailure.Error;

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/AbstractLockfileMojo.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/AbstractLockfileMojo.java
@@ -58,6 +58,24 @@ public abstract class AbstractLockfileMojo extends AbstractMojo {
     @Parameter(property = "includeEnvironment")
     protected String includeEnvironment;
 
+    @Parameter(property = "includeBoms")
+    protected String includeBoms;
+
+    @Parameter(property = "allowBomValidationFailure")
+    protected String allowBomValidationFailure;
+
+    @Parameter(property = "includeParentPom")
+    protected String includeParentPom;
+
+    @Parameter(property = "allowParentPomValidationFailure")
+    protected String allowParentPomValidationFailure;
+
+    @Parameter(property = "includeMavenExtensions")
+    protected String includeMavenExtensions;
+
+    @Parameter(property = "allowMavenExtensionsValidationFailure")
+    protected String allowMavenExtensionsValidationFailure;
+
     @Parameter(defaultValue = "${maven.version}")
     protected String mavenVersion;
 
@@ -157,6 +175,30 @@ public abstract class AbstractLockfileMojo extends AbstractMojo {
                         : Config.EnvironmentInclusion.Exclude;
         Config.ReductionState reductionState =
                 Boolean.parseBoolean(reduced) ? Config.ReductionState.Reduced : Config.ReductionState.NonReduced;
+        // include* flags default to Include when unset — same pattern as includeEnvironment
+        Config.BomsInclusion bomsInclusion =
+                Strings.isNullOrEmpty(includeBoms) || Boolean.parseBoolean(includeBoms)
+                        ? Config.BomsInclusion.Include
+                        : Config.BomsInclusion.Exclude;
+        Config.OnBomValidationFailure onBomValidationFailure = Boolean.parseBoolean(allowBomValidationFailure)
+                ? Config.OnBomValidationFailure.Warn
+                : Config.OnBomValidationFailure.Error;
+        Config.ParentPomInclusion parentPomInclusion =
+                Strings.isNullOrEmpty(includeParentPom) || Boolean.parseBoolean(includeParentPom)
+                        ? Config.ParentPomInclusion.Include
+                        : Config.ParentPomInclusion.Exclude;
+        Config.OnParentPomValidationFailure onParentPomValidationFailure =
+                Boolean.parseBoolean(allowParentPomValidationFailure)
+                        ? Config.OnParentPomValidationFailure.Warn
+                        : Config.OnParentPomValidationFailure.Error;
+        Config.MavenExtensionsInclusion mavenExtensionsInclusion =
+                Strings.isNullOrEmpty(includeMavenExtensions) || Boolean.parseBoolean(includeMavenExtensions)
+                        ? Config.MavenExtensionsInclusion.Include
+                        : Config.MavenExtensionsInclusion.Exclude;
+        Config.OnMavenExtensionsValidationFailure onMavenExtensionsValidationFailure =
+                Boolean.parseBoolean(allowMavenExtensionsValidationFailure)
+                        ? Config.OnMavenExtensionsValidationFailure.Warn
+                        : Config.OnMavenExtensionsValidationFailure.Error;
 
         return new Config(
                 mavenPluginsInclusion,
@@ -167,7 +209,13 @@ public abstract class AbstractLockfileMojo extends AbstractMojo {
                 reductionState,
                 mojo.getPlugin().getVersion(),
                 chosenChecksumMode,
-                chosenChecksumAlgorithm);
+                chosenChecksumAlgorithm,
+                bomsInclusion,
+                onBomValidationFailure,
+                parentPomInclusion,
+                onParentPomValidationFailure,
+                mavenExtensionsInclusion,
+                onMavenExtensionsValidationFailure);
     }
 
     protected ProjectBuildingRequest newResolveArtifactProjectBuildingRequest() throws MojoExecutionException {
@@ -215,6 +263,36 @@ public abstract class AbstractLockfileMojo extends AbstractMojo {
                 : (Boolean.parseBoolean(includeEnvironment)
                         ? Config.EnvironmentInclusion.Include
                         : Config.EnvironmentInclusion.Exclude);
+        Config.BomsInclusion bomsInclusion = Strings.isNullOrEmpty(includeBoms)
+                ? base.getBomsInclusion()
+                : (Boolean.parseBoolean(includeBoms) ? Config.BomsInclusion.Include : Config.BomsInclusion.Exclude);
+        Config.OnBomValidationFailure onBomValidationFailure = Strings.isNullOrEmpty(allowBomValidationFailure)
+                ? base.getOnBomValidationFailure()
+                : (Boolean.parseBoolean(allowBomValidationFailure)
+                        ? Config.OnBomValidationFailure.Warn
+                        : Config.OnBomValidationFailure.Error);
+        Config.ParentPomInclusion parentPomInclusion = Strings.isNullOrEmpty(includeParentPom)
+                ? base.getParentPomInclusion()
+                : (Boolean.parseBoolean(includeParentPom)
+                        ? Config.ParentPomInclusion.Include
+                        : Config.ParentPomInclusion.Exclude);
+        Config.OnParentPomValidationFailure onParentPomValidationFailure =
+                Strings.isNullOrEmpty(allowParentPomValidationFailure)
+                        ? base.getOnParentPomValidationFailure()
+                        : (Boolean.parseBoolean(allowParentPomValidationFailure)
+                                ? Config.OnParentPomValidationFailure.Warn
+                                : Config.OnParentPomValidationFailure.Error);
+        Config.MavenExtensionsInclusion mavenExtensionsInclusion = Strings.isNullOrEmpty(includeMavenExtensions)
+                ? base.getMavenExtensionsInclusion()
+                : (Boolean.parseBoolean(includeMavenExtensions)
+                        ? Config.MavenExtensionsInclusion.Include
+                        : Config.MavenExtensionsInclusion.Exclude);
+        Config.OnMavenExtensionsValidationFailure onMavenExtensionsValidationFailure =
+                Strings.isNullOrEmpty(allowMavenExtensionsValidationFailure)
+                        ? base.getOnMavenExtensionsValidationFailure()
+                        : (Boolean.parseBoolean(allowMavenExtensionsValidationFailure)
+                                ? Config.OnMavenExtensionsValidationFailure.Warn
+                                : Config.OnMavenExtensionsValidationFailure.Error);
         return new Config(
                 pluginsInclusion,
                 onValidationFailure,
@@ -224,6 +302,12 @@ public abstract class AbstractLockfileMojo extends AbstractMojo {
                 base.getReductionState(),
                 base.getMavenLockfileVersion(),
                 base.getChecksumMode(),
-                base.getChecksumAlgorithm());
+                base.getChecksumAlgorithm(),
+                bomsInclusion,
+                onBomValidationFailure,
+                parentPomInclusion,
+                onParentPomValidationFailure,
+                mavenExtensionsInclusion,
+                onMavenExtensionsValidationFailure);
     }
 }

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/AbstractLockfileMojo.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/AbstractLockfileMojo.java
@@ -43,19 +43,19 @@ public abstract class AbstractLockfileMojo extends AbstractMojo {
     @Component
     protected RepositorySystem repositorySystem;
 
-    @Parameter(property = "includeMavenPlugins", defaultValue = "false")
+    @Parameter(property = "includeMavenPlugins")
     protected String includeMavenPlugins;
 
-    @Parameter(property = "allowValidationFailure", defaultValue = "false")
+    @Parameter(property = "allowValidationFailure")
     protected String allowValidationFailure;
 
-    @Parameter(property = "allowPomValidationFailure", defaultValue = "false")
+    @Parameter(property = "allowPomValidationFailure")
     protected String allowPomValidationFailure;
 
-    @Parameter(property = "allowEnvironmentalValidationFailure", defaultValue = "false")
+    @Parameter(property = "allowEnvironmentalValidationFailure")
     protected String allowEnvironmentalValidationFailure;
 
-    @Parameter(property = "includeEnvironment", defaultValue = "true")
+    @Parameter(property = "includeEnvironment")
     protected String includeEnvironment;
 
     @Parameter(defaultValue = "${maven.version}")
@@ -150,9 +150,11 @@ public abstract class AbstractLockfileMojo extends AbstractMojo {
                 Boolean.parseBoolean(allowEnvironmentalValidationFailure)
                         ? Config.OnEnvironmentalValidationFailure.Warn
                         : Config.OnEnvironmentalValidationFailure.Error;
-        Config.EnvironmentInclusion environmentInclusion = Boolean.parseBoolean(includeEnvironment)
-                ? Config.EnvironmentInclusion.Include
-                : Config.EnvironmentInclusion.Exclude;
+        // null means "not set" — default for includeEnvironment is Include (true), not Exclude
+        Config.EnvironmentInclusion environmentInclusion =
+                Strings.isNullOrEmpty(includeEnvironment) || Boolean.parseBoolean(includeEnvironment)
+                        ? Config.EnvironmentInclusion.Include
+                        : Config.EnvironmentInclusion.Exclude;
         Config.ReductionState reductionState =
                 Boolean.parseBoolean(reduced) ? Config.ReductionState.Reduced : Config.ReductionState.NonReduced;
 
@@ -178,5 +180,50 @@ public abstract class AbstractLockfileMojo extends AbstractMojo {
         ProjectBuildingRequest buildingRequest = new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
         buildingRequest.setRemoteRepositories(project.getPluginArtifactRepositories());
         return buildingRequest;
+    }
+
+    /**
+     * Returns a Config that starts from {@code base} (typically the stored lockfile config) and overrides
+     * only the fields for which a CLI argument was explicitly provided (non-null / non-empty).
+     * Fields that were not supplied on the command line keep their stored value, ensuring backward
+     * compatibility when new arguments are added after a lockfile was generated.
+     */
+    protected Config mergeConfigWithCliArgs(Config base) {
+        Config.MavenPluginsInclusion pluginsInclusion = Strings.isNullOrEmpty(includeMavenPlugins)
+                ? base.getMavenPluginsInclusion()
+                : (Boolean.parseBoolean(includeMavenPlugins)
+                        ? Config.MavenPluginsInclusion.Include
+                        : Config.MavenPluginsInclusion.Exclude);
+        Config.OnValidationFailure onValidationFailure = Strings.isNullOrEmpty(allowValidationFailure)
+                ? base.getOnValidationFailure()
+                : (Boolean.parseBoolean(allowValidationFailure)
+                        ? Config.OnValidationFailure.Warn
+                        : Config.OnValidationFailure.Error);
+        Config.OnPomValidationFailure onPomValidationFailure = Strings.isNullOrEmpty(allowPomValidationFailure)
+                ? base.getOnPomValidationFailure()
+                : (Boolean.parseBoolean(allowPomValidationFailure)
+                        ? Config.OnPomValidationFailure.Warn
+                        : Config.OnPomValidationFailure.Error);
+        Config.OnEnvironmentalValidationFailure onEnvFailure =
+                Strings.isNullOrEmpty(allowEnvironmentalValidationFailure)
+                        ? base.getOnEnvironmentalValidationFailure()
+                        : (Boolean.parseBoolean(allowEnvironmentalValidationFailure)
+                                ? Config.OnEnvironmentalValidationFailure.Warn
+                                : Config.OnEnvironmentalValidationFailure.Error);
+        Config.EnvironmentInclusion environmentInclusion = Strings.isNullOrEmpty(includeEnvironment)
+                ? base.getEnvironmentInclusion()
+                : (Boolean.parseBoolean(includeEnvironment)
+                        ? Config.EnvironmentInclusion.Include
+                        : Config.EnvironmentInclusion.Exclude);
+        return new Config(
+                pluginsInclusion,
+                onValidationFailure,
+                onPomValidationFailure,
+                onEnvFailure,
+                environmentInclusion,
+                base.getReductionState(),
+                base.getMavenLockfileVersion(),
+                base.getChecksumMode(),
+                base.getChecksumAlgorithm());
     }
 }

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/GenerateLockFileMojo.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/GenerateLockFileMojo.java
@@ -85,6 +85,12 @@ public class GenerateLockFileMojo extends AbstractLockfileMojo {
                 config.getReductionState(),
                 mojo.getPlugin().getVersion(),
                 config.getChecksumMode(),
-                config.getChecksumAlgorithm());
+                config.getChecksumAlgorithm(),
+                config.getBomsInclusion(),
+                config.getOnBomValidationFailure(),
+                config.getParentPomInclusion(),
+                config.getOnParentPomValidationFailure(),
+                config.getMavenExtensionsInclusion(),
+                config.getOnMavenExtensionsValidationFailure());
     }
 }

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/LockFileEquality.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/LockFileEquality.java
@@ -1,0 +1,142 @@
+package io.github.chains_project.maven_lockfile;
+
+import io.github.chains_project.maven_lockfile.data.LockFile;
+import io.github.chains_project.maven_lockfile.data.MavenPlugin;
+import io.github.chains_project.maven_lockfile.data.Pom;
+import io.github.chains_project.maven_lockfile.graph.DependencyNode;
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Equality helpers used by {@link io.github.chains_project.maven_lockfile.reporting.ValidationPhases}
+ * to compare an on-disk lockfile against a freshly-generated one.
+ *
+ * <p>Each method covers one independently-testable concern:
+ * <ul>
+ *   <li>{@link #coreEqual}: GAV, dependency nodes, and plugins — the minimum required for a valid lockfile.
+ *   <li>{@link #bomsEqualForAll}: top-level BOMs and per-node BOMs across all dependencies and plugins.
+ *   <li>{@link #parentPomsEqualForAll}: parentPom on every dependency node and plugin.
+ * </ul>
+ *
+ * Maven extensions and environment are compared directly with {@link Objects#equals} in their
+ * respective {@link io.github.chains_project.maven_lockfile.reporting.ValidationPhase} implementations.
+ */
+public final class LockFileEquality {
+
+    private LockFileEquality() {}
+
+    public static boolean coreEqual(LockFile a, LockFile b) {
+        return Objects.equals(a.getName(), b.getName())
+                && Objects.equals(a.getGroupId(), b.getGroupId())
+                && Objects.equals(a.getVersion(), b.getVersion())
+                && dependencySetsEqual(a.getDependencies(), b.getDependencies())
+                && pluginSetsEqual(a.getMavenPlugins(), b.getMavenPlugins());
+    }
+
+    private static boolean dependencySetsEqual(Set<DependencyNode> a, Set<DependencyNode> b) {
+        return a.size() == b.size()
+                && a.stream().allMatch(nA -> b.stream().anyMatch(nB -> dependencyNodeEqual(nA, nB)));
+    }
+
+    private static boolean dependencyNodeEqual(DependencyNode a, DependencyNode b) {
+        return Objects.equals(a.getGroupId(), b.getGroupId())
+                && Objects.equals(a.getArtifactId(), b.getArtifactId())
+                && Objects.equals(a.getVersion(), b.getVersion())
+                && Objects.equals(a.getClassifier(), b.getClassifier())
+                && Objects.equals(a.getType(), b.getType())
+                && Objects.equals(a.getChecksumAlgorithm(), b.getChecksumAlgorithm())
+                && Objects.equals(a.getChecksum(), b.getChecksum())
+                && Objects.equals(a.getScope(), b.getScope())
+                && Objects.equals(a.getSelectedVersion(), b.getSelectedVersion())
+                && Objects.equals(a.getParent(), b.getParent())
+                && dependencySetsEqual(a.getChildren(), b.getChildren());
+    }
+
+    private static boolean pluginSetsEqual(Set<MavenPlugin> a, Set<MavenPlugin> b) {
+        return a.size() == b.size() && a.stream().allMatch(pA -> b.stream().anyMatch(pB -> mavenPluginEqual(pA, pB)));
+    }
+
+    private static boolean mavenPluginEqual(MavenPlugin a, MavenPlugin b) {
+        return Objects.equals(a.getGroupId(), b.getGroupId())
+                && Objects.equals(a.getArtifactId(), b.getArtifactId())
+                && Objects.equals(a.getVersion(), b.getVersion())
+                && Objects.equals(a.getChecksum(), b.getChecksum())
+                && Objects.equals(a.getChecksumAlgorithm(), b.getChecksumAlgorithm())
+                && Objects.equals(a.getResolved(), b.getResolved())
+                && Objects.equals(a.getRepositoryId(), b.getRepositoryId())
+                && dependencySetsEqual(a.getDependencies(), b.getDependencies());
+    }
+
+    public static boolean bomsEqualForAll(LockFile a, LockFile b, boolean compareParentChains) {
+        if (!pomSetsEqual(a.getBoms(), b.getBoms(), compareParentChains)) return false;
+        if (!nodeBomsEqual(a.getDependencies(), b.getDependencies(), compareParentChains)) return false;
+        for (MavenPlugin pA : a.getMavenPlugins()) {
+            Optional<MavenPlugin> pB = findMatchingPlugin(pA, b.getMavenPlugins());
+            if (pB.isEmpty()) return false;
+            if (!nodeBomsEqual(pA.getDependencies(), pB.get().getDependencies(), compareParentChains)) return false;
+        }
+        return true;
+    }
+
+    private static boolean nodeBomsEqual(Set<DependencyNode> a, Set<DependencyNode> b, boolean compareParentChains) {
+        return a.size() == b.size()
+                && a.stream().allMatch(nA -> b.stream()
+                        .anyMatch(nB -> Objects.equals(nA.getGroupId(), nB.getGroupId())
+                                && Objects.equals(nA.getArtifactId(), nB.getArtifactId())
+                                && Objects.equals(nA.getVersion(), nB.getVersion())
+                                && pomSetsEqual(nA.getBoms(), nB.getBoms(), compareParentChains)
+                                && nodeBomsEqual(nA.getChildren(), nB.getChildren(), compareParentChains)));
+    }
+
+    static boolean pomSetsEqual(Set<Pom> a, Set<Pom> b, boolean compareParentChains) {
+        Set<Pom> safeA = a == null ? Collections.emptySet() : a;
+        Set<Pom> safeB = b == null ? Collections.emptySet() : b;
+        return safeA.size() == safeB.size()
+                && safeA.stream().allMatch(pA -> safeB.stream().anyMatch(pB -> pomEqual(pA, pB, compareParentChains)));
+    }
+
+    public static boolean pomEqual(Pom a, Pom b, boolean compareParentChains) {
+        if (a == null && b == null) return true;
+        if (a == null || b == null) return false;
+        return Objects.equals(a.getGroupId(), b.getGroupId())
+                && Objects.equals(a.getArtifactId(), b.getArtifactId())
+                && Objects.equals(a.getVersion(), b.getVersion())
+                && Objects.equals(a.getRelativePath(), b.getRelativePath())
+                && Objects.equals(a.getResolved(), b.getResolved())
+                && Objects.equals(a.getRepositoryId(), b.getRepositoryId())
+                && Objects.equals(a.getChecksumAlgorithm(), b.getChecksumAlgorithm())
+                && Objects.equals(a.getChecksum(), b.getChecksum())
+                && (!compareParentChains || pomEqual(a.getParent(), b.getParent(), true));
+    }
+
+    public static boolean parentPomsEqualForAll(LockFile a, LockFile b) {
+        if (!nodeParentPomsEqual(a.getDependencies(), b.getDependencies())) return false;
+        for (MavenPlugin pA : a.getMavenPlugins()) {
+            Optional<MavenPlugin> pB = findMatchingPlugin(pA, b.getMavenPlugins());
+            if (pB.isEmpty()) return false;
+            if (!Objects.equals(pA.getParentPom(), pB.get().getParentPom())) return false;
+            if (!nodeParentPomsEqual(pA.getDependencies(), pB.get().getDependencies())) return false;
+        }
+        return true;
+    }
+
+    private static boolean nodeParentPomsEqual(Set<DependencyNode> a, Set<DependencyNode> b) {
+        return a.size() == b.size()
+                && a.stream().allMatch(nA -> b.stream()
+                        .anyMatch(nB -> Objects.equals(nA.getGroupId(), nB.getGroupId())
+                                && Objects.equals(nA.getArtifactId(), nB.getArtifactId())
+                                && Objects.equals(nA.getVersion(), nB.getVersion())
+                                && Objects.equals(nA.getParentPom(), nB.getParentPom())
+                                && nodeParentPomsEqual(nA.getChildren(), nB.getChildren())));
+    }
+
+    private static Optional<MavenPlugin> findMatchingPlugin(MavenPlugin target, Set<MavenPlugin> plugins) {
+        return plugins.stream()
+                .filter(p -> Objects.equals(target.getGroupId(), p.getGroupId())
+                        && Objects.equals(target.getArtifactId(), p.getArtifactId())
+                        && Objects.equals(target.getVersion(), p.getVersion()))
+                .findFirst();
+    }
+}

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/ValidateChecksumMojo.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/ValidateChecksumMojo.java
@@ -40,10 +40,12 @@ public class ValidateChecksumMojo extends AbstractLockfileMojo {
         try {
             getLog().info("Validating lock file ...");
             LockFile lockFileFromFile = LockFile.readLockFile(getLockFilePath(project, lockfileName));
-            Config config = lockFileFromFile.getConfig() == null ? getConfig() : lockFileFromFile.getConfig();
-            if (lockFileFromFile.getConfig() == null) {
+            Config baseConfig = lockFileFromFile.getConfig();
+            if (baseConfig == null) {
                 getLog().warn("No config was found in the lock file. Using default config.");
+                baseConfig = getConfig();
             }
+            Config config = mergeConfigWithCliArgs(baseConfig);
             Environment environment = null;
             if (config.isIncludeEnvironment()) {
                 environment = generateMetaInformation();

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/ValidateChecksumMojo.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/ValidateChecksumMojo.java
@@ -7,10 +7,9 @@ import io.github.chains_project.maven_lockfile.data.Config;
 import io.github.chains_project.maven_lockfile.data.Environment;
 import io.github.chains_project.maven_lockfile.data.LockFile;
 import io.github.chains_project.maven_lockfile.data.MetaData;
-import io.github.chains_project.maven_lockfile.reporting.LockFileDifference;
 import io.github.chains_project.maven_lockfile.reporting.PluginLogManager;
+import io.github.chains_project.maven_lockfile.reporting.ValidationPhases;
 import java.io.IOException;
-import java.util.Objects;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -54,69 +53,17 @@ public class ValidateChecksumMojo extends AbstractLockfileMojo {
             AbstractChecksumCalculator checksumCalculator = getChecksumCalculator(config, true);
             LockFile lockFileFromProject = LockFileFacade.generateLockFileFromProject(
                     session, project, dependencyCollectorBuilder, checksumCalculator, metaData, repositorySystem);
-            if (!Objects.equals(lockFileFromFile.getEnvironment(), lockFileFromProject.getEnvironment())) {
-                String sb = "Lock file environment does not match project environment.\n"
-                        + "Lockfile environment: " + lockFileFromFile.getEnvironment() + "\n"
-                        + "Project environment:  " + lockFileFromProject.getEnvironment() + "\n";
+            for (var phase : ValidationPhases.all()) {
+                if (!phase.isEnabled(config)) continue;
+                var failure = phase.validate(lockFileFromFile, lockFileFromProject, config);
+                if (failure.isEmpty()) continue;
+                if (phase.isWarn(config)) {
+                    getLog().warn(failure.get());
+                } else {
+                    throw new MojoExecutionException(failure.get());
+                }
+            }
 
-                switch (config.getOnEnvironmentalValidationFailure()) {
-                    case Warn:
-                        getLog().warn(sb);
-                        break;
-                    case Error:
-                        throw new MojoExecutionException("Failed verifying environment. " + sb);
-                }
-            }
-            if (!Objects.equals(lockFileFromFile.getPom(), lockFileFromProject.getPom())) {
-                String sb = "Pom checksum mismatch. Differences:\nYour lockfile pom:\n"
-                        + JsonUtils.toJson(lockFileFromFile.getPom())
-                        + "\n" + "Your project pom:\n"
-                        + JsonUtils.toJson(lockFileFromProject.getPom())
-                        + "\n";
-
-                switch (config.getOnPomValidationFailure()) {
-                    case Warn:
-                        getLog().warn(sb);
-                        break;
-                    case Error:
-                        throw new MojoExecutionException("Failed verifying lock file. " + sb);
-                }
-            }
-            if (!lockFileFromFile.equals(lockFileFromProject)) {
-                var diff = LockFileDifference.diff(lockFileFromFile, lockFileFromProject);
-                String sb = "Lock file validation failed. Differences:" + "\n"
-                        + "Your lockfile from file is for:"
-                        + lockFileFromFile.getGroupId().getValue()
-                        + ":" + lockFileFromFile.getName().getValue() + ":"
-                        + lockFileFromFile.getVersion().getValue() + "\n" + "Your generated lockfile is for:"
-                        + lockFileFromProject.getGroupId().getValue() + ":"
-                        + lockFileFromProject.getName().getValue() + ":"
-                        + lockFileFromProject.getVersion().getValue() + "\n" + "Missing dependencies in lock file:\n "
-                        + JsonUtils.toJson(diff.getMissingDependenciesInFile())
-                        + "\n"
-                        + "Missing dependencies in project:\n "
-                        + JsonUtils.toJson(diff.getMissingDependenciesInProject())
-                        + "\n"
-                        + "Missing plugins in lockfile:\n "
-                        + JsonUtils.toJson(diff.getMissingPluginsInFile())
-                        + "\n"
-                        + "Missing plugins in project:\n "
-                        + JsonUtils.toJson(diff.getMissingPluginsInProject())
-                        + "\n"
-                        + "Missing extensions in lockfile:\n "
-                        + JsonUtils.toJson(diff.getMissingExtensionsInFile())
-                        + "\n"
-                        + "Missing extensions in project:\n "
-                        + JsonUtils.toJson(diff.getMissingExtensionsInProject())
-                        + "\n";
-                switch (config.getOnValidationFailure()) {
-                    case Warn:
-                        getLog().warn("Failed verifying lock file. " + sb);
-                        break;
-                    case Error:
-                        throw new MojoExecutionException("Failed verifying lock file. " + sb);
-                }
-            }
         } catch (IOException e) {
             throw new MojoExecutionException("Could not read lock file", e);
         }

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/ValidateChecksumMojo.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/ValidateChecksumMojo.java
@@ -6,11 +6,14 @@ import io.github.chains_project.maven_lockfile.checksum.AbstractChecksumCalculat
 import io.github.chains_project.maven_lockfile.data.Config;
 import io.github.chains_project.maven_lockfile.data.Environment;
 import io.github.chains_project.maven_lockfile.data.LockFile;
+import io.github.chains_project.maven_lockfile.data.MavenPlugin;
 import io.github.chains_project.maven_lockfile.data.MetaData;
+import io.github.chains_project.maven_lockfile.graph.DependencyNode;
 import io.github.chains_project.maven_lockfile.reporting.LockFileDifference;
 import io.github.chains_project.maven_lockfile.reporting.PluginLogManager;
 import java.io.IOException;
 import java.util.Objects;
+import java.util.Set;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -82,7 +85,20 @@ public class ValidateChecksumMojo extends AbstractLockfileMojo {
                         throw new MojoExecutionException("Failed verifying lock file. " + sb);
                 }
             }
-            if (!lockFileFromFile.equals(lockFileFromProject)) {
+            boolean skipParentPom = !lockFileHasParentPomData(lockFileFromFile);
+            // Old-format lockfiles also lack parent chains on bom Pom objects; skip bom comparison
+            // whenever parentPom data is absent, since both features were introduced together.
+            boolean skipNodeBoms = skipParentPom || !lockFileHasNodeBomData(lockFileFromFile);
+            boolean skipExtensions = lockFileFromFile.getMavenExtensions().isEmpty();
+            if (skipParentPom || skipNodeBoms || skipExtensions) {
+                getLog().warn("The on-disk lockfile is missing one or more fields introduced in recent"
+                        + " plugin versions (parentPom, dependency BOMs, mavenExtensions)."
+                        + " Those fields will be skipped during validation."
+                        + " Please regenerate the lockfile with the current plugin version to enable full validation.");
+            }
+            boolean equal = lockFilesEqual(
+                    lockFileFromFile, lockFileFromProject, skipParentPom, skipNodeBoms, skipExtensions);
+            if (!equal) {
                 var diff = LockFileDifference.diff(lockFileFromFile, lockFileFromProject);
                 String sb = "Lock file validation failed. Differences:" + "\n"
                         + "Your lockfile from file is for:"
@@ -121,5 +137,95 @@ public class ValidateChecksumMojo extends AbstractLockfileMojo {
             throw new MojoExecutionException("Could not read lock file", e);
         }
         getLog().info("Lockfile successfully validated.");
+    }
+
+    private static boolean lockFilesEqual(
+            LockFile fromFile,
+            LockFile fromProject,
+            boolean skipParentPom,
+            boolean skipNodeBoms,
+            boolean skipExtensions) {
+        if (!Objects.equals(fromFile.getName(), fromProject.getName())
+                || !Objects.equals(fromFile.getGroupId(), fromProject.getGroupId())
+                || !Objects.equals(fromFile.getVersion(), fromProject.getVersion())) {
+            return false;
+        }
+        if (!depSetsEqual(fromFile.getDependencies(), fromProject.getDependencies(), skipParentPom, skipNodeBoms))
+            return false;
+        if (!pluginSetsEqual(fromFile.getMavenPlugins(), fromProject.getMavenPlugins(), skipParentPom, skipNodeBoms))
+            return false;
+        // Extensions: the on-disk lockfile pre-dates extension tracking when the set is empty,
+        // so only compare when the on-disk lockfile already contains extension data.
+        if (!skipExtensions
+                && !Objects.equals(fromFile.getMavenExtensions(), fromProject.getMavenExtensions())) return false;
+        return Objects.equals(fromFile.getBoms(), fromProject.getBoms());
+    }
+
+    private static boolean depSetsEqual(
+            Set<DependencyNode> a, Set<DependencyNode> b, boolean skipParentPom, boolean skipNodeBoms) {
+        if (a.size() != b.size()) return false;
+        return a.stream()
+                .allMatch(nodeA -> b.stream().anyMatch(nodeB -> depNodesEqual(nodeA, nodeB, skipParentPom, skipNodeBoms)));
+    }
+
+    private static boolean depNodesEqual(
+            DependencyNode a, DependencyNode b, boolean skipParentPom, boolean skipNodeBoms) {
+        return Objects.equals(a.getGroupId(), b.getGroupId())
+                && Objects.equals(a.getArtifactId(), b.getArtifactId())
+                && Objects.equals(a.getVersion(), b.getVersion())
+                && Objects.equals(a.getClassifier(), b.getClassifier())
+                && Objects.equals(a.getType(), b.getType())
+                && Objects.equals(a.getChecksumAlgorithm(), b.getChecksumAlgorithm())
+                && Objects.equals(a.getChecksum(), b.getChecksum())
+                && Objects.equals(a.getScope(), b.getScope())
+                && Objects.equals(a.getSelectedVersion(), b.getSelectedVersion())
+                && Objects.equals(a.getParent(), b.getParent())
+                && (skipNodeBoms || Objects.equals(a.getBoms(), b.getBoms()))
+                && depSetsEqual(a.getChildren(), b.getChildren(), skipParentPom, skipNodeBoms);
+    }
+
+    private static boolean pluginSetsEqual(
+            Set<MavenPlugin> a, Set<MavenPlugin> b, boolean skipParentPom, boolean skipNodeBoms) {
+        if (a.size() != b.size()) return false;
+        return a.stream()
+                .allMatch(pA -> b.stream().anyMatch(pB -> pluginEquals(pA, pB, skipParentPom, skipNodeBoms)));
+    }
+
+    private static boolean pluginEquals(
+            MavenPlugin a, MavenPlugin b, boolean skipParentPom, boolean skipNodeBoms) {
+        return Objects.equals(a.getGroupId(), b.getGroupId())
+                && Objects.equals(a.getArtifactId(), b.getArtifactId())
+                && Objects.equals(a.getVersion(), b.getVersion())
+                && Objects.equals(a.getChecksum(), b.getChecksum())
+                && Objects.equals(a.getChecksumAlgorithm(), b.getChecksumAlgorithm())
+                && Objects.equals(a.getResolved(), b.getResolved())
+                && Objects.equals(a.getRepositoryId(), b.getRepositoryId())
+                && (skipParentPom || Objects.equals(a.getParentPom(), b.getParentPom()))
+                && depSetsEqual(a.getDependencies(), b.getDependencies(), skipParentPom, skipNodeBoms);
+    }
+
+    /** Returns true if any dependency node or plugin (transitively) carries a non-null parentPom. */
+    private static boolean lockFileHasParentPomData(LockFile lockFile) {
+        return lockFile.getDependencies().stream().anyMatch(ValidateChecksumMojo::nodeHasParentPom)
+                || lockFile.getMavenPlugins().stream()
+                        .anyMatch(p -> p.getParentPom() != null
+                                || p.getDependencies().stream().anyMatch(ValidateChecksumMojo::nodeHasParentPom));
+    }
+
+    private static boolean nodeHasParentPom(DependencyNode node) {
+        return node.getParentPom() != null
+                || node.getChildren().stream().anyMatch(ValidateChecksumMojo::nodeHasParentPom);
+    }
+
+    /** Returns true if any dependency node (transitively) has a non-empty boms set. */
+    private static boolean lockFileHasNodeBomData(LockFile lockFile) {
+        return lockFile.getDependencies().stream().anyMatch(ValidateChecksumMojo::nodeHasBoms)
+                || lockFile.getMavenPlugins().stream()
+                        .anyMatch(p -> p.getDependencies().stream().anyMatch(ValidateChecksumMojo::nodeHasBoms));
+    }
+
+    private static boolean nodeHasBoms(DependencyNode node) {
+        return !node.getBoms().isEmpty()
+                || node.getChildren().stream().anyMatch(ValidateChecksumMojo::nodeHasBoms);
     }
 }

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/ValidateChecksumMojo.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/ValidateChecksumMojo.java
@@ -8,11 +8,14 @@ import io.github.chains_project.maven_lockfile.data.Environment;
 import io.github.chains_project.maven_lockfile.data.LockFile;
 import io.github.chains_project.maven_lockfile.data.MavenPlugin;
 import io.github.chains_project.maven_lockfile.data.MetaData;
+import io.github.chains_project.maven_lockfile.data.Pom;
 import io.github.chains_project.maven_lockfile.graph.DependencyNode;
 import io.github.chains_project.maven_lockfile.reporting.LockFileDifference;
 import io.github.chains_project.maven_lockfile.reporting.PluginLogManager;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -85,20 +88,10 @@ public class ValidateChecksumMojo extends AbstractLockfileMojo {
                         throw new MojoExecutionException("Failed verifying lock file. " + sb);
                 }
             }
-            boolean skipParentPom = !lockFileHasParentPomData(lockFileFromFile);
-            // Old-format lockfiles also lack parent chains on bom Pom objects; skip bom comparison
-            // whenever parentPom data is absent, since both features were introduced together.
-            boolean skipNodeBoms = skipParentPom || !lockFileHasNodeBomData(lockFileFromFile);
-            boolean skipExtensions = lockFileFromFile.getMavenExtensions().isEmpty();
-            if (skipParentPom || skipNodeBoms || skipExtensions) {
-                getLog().warn("The on-disk lockfile is missing one or more fields introduced in recent"
-                        + " plugin versions (parentPom, dependency BOMs, mavenExtensions)."
-                        + " Those fields will be skipped during validation."
-                        + " Please regenerate the lockfile with the current plugin version to enable full validation.");
-            }
-            boolean equal = lockFilesEqual(
-                    lockFileFromFile, lockFileFromProject, skipParentPom, skipNodeBoms, skipExtensions);
-            if (!equal) {
+
+            // Phase 1: core equality (deps/plugins compared without parentPom, boms, extensions)
+            boolean phase1Equal = coreEqual(lockFileFromFile, lockFileFromProject);
+            if (!phase1Equal) {
                 var diff = LockFileDifference.diff(lockFileFromFile, lockFileFromProject);
                 String sb = "Lock file validation failed. Differences:" + "\n"
                         + "Your lockfile from file is for:"
@@ -107,7 +100,8 @@ public class ValidateChecksumMojo extends AbstractLockfileMojo {
                         + lockFileFromFile.getVersion().getValue() + "\n" + "Your generated lockfile is for:"
                         + lockFileFromProject.getGroupId().getValue() + ":"
                         + lockFileFromProject.getName().getValue() + ":"
-                        + lockFileFromProject.getVersion().getValue() + "\n" + "Missing dependencies in lock file:\n "
+                        + lockFileFromProject.getVersion().getValue() + "\n"
+                        + "Missing dependencies in lock file:\n "
                         + JsonUtils.toJson(diff.getMissingDependenciesInFile())
                         + "\n"
                         + "Missing dependencies in project:\n "
@@ -118,12 +112,6 @@ public class ValidateChecksumMojo extends AbstractLockfileMojo {
                         + "\n"
                         + "Missing plugins in project:\n "
                         + JsonUtils.toJson(diff.getMissingPluginsInProject())
-                        + "\n"
-                        + "Missing extensions in lockfile:\n "
-                        + JsonUtils.toJson(diff.getMissingExtensionsInFile())
-                        + "\n"
-                        + "Missing extensions in project:\n "
-                        + JsonUtils.toJson(diff.getMissingExtensionsInProject())
                         + "\n";
                 switch (config.getOnValidationFailure()) {
                     case Warn:
@@ -133,43 +121,83 @@ public class ValidateChecksumMojo extends AbstractLockfileMojo {
                         throw new MojoExecutionException("Failed verifying lock file. " + sb);
                 }
             }
+
+            // Phase 2: bom membership (independent of Phase 1)
+            if (config.isIncludeBoms()) {
+                if (!bomsEqualForAll(lockFileFromFile, lockFileFromProject, config.isIncludeParentPom())) {
+                    String msg = "Bom validation failed."
+                            + " The BOM membership or BOM POM data of dependencies differs"
+                            + " between the lockfile and the project.";
+                    switch (config.getOnBomValidationFailure()) {
+                        case Warn:
+                            getLog().warn(msg);
+                            break;
+                        case Error:
+                            throw new MojoExecutionException(msg);
+                    }
+                }
+            }
+
+            // Phase 3: parentPom on nodes/plugins (only when Phase 1 passed)
+            if (phase1Equal && config.isIncludeParentPom()) {
+                if (!parentPomsEqualForAll(lockFileFromFile, lockFileFromProject)) {
+                    String msg = "Parent POM validation failed."
+                            + " The parentPom of one or more dependencies or plugins differs"
+                            + " between the lockfile and the project.";
+                    switch (config.getOnParentPomValidationFailure()) {
+                        case Warn:
+                            getLog().warn(msg);
+                            break;
+                        case Error:
+                            throw new MojoExecutionException(msg);
+                    }
+                }
+            }
+
+            // Phase 4: maven extensions (independent)
+            if (config.isIncludeMavenExtensions()) {
+                if (!Objects.equals(lockFileFromFile.getMavenExtensions(), lockFileFromProject.getMavenExtensions())) {
+                    var diff = LockFileDifference.diff(lockFileFromFile, lockFileFromProject);
+                    String msg = "Maven extensions validation failed.\n"
+                            + "Missing extensions in lockfile:\n "
+                            + JsonUtils.toJson(diff.getMissingExtensionsInFile())
+                            + "\n"
+                            + "Missing extensions in project:\n "
+                            + JsonUtils.toJson(diff.getMissingExtensionsInProject())
+                            + "\n";
+                    switch (config.getOnMavenExtensionsValidationFailure()) {
+                        case Warn:
+                            getLog().warn(msg);
+                            break;
+                        case Error:
+                            throw new MojoExecutionException(msg);
+                    }
+                }
+            }
+
         } catch (IOException e) {
             throw new MojoExecutionException("Could not read lock file", e);
         }
         getLog().info("Lockfile successfully validated.");
     }
 
-    private static boolean lockFilesEqual(
-            LockFile fromFile,
-            LockFile fromProject,
-            boolean skipParentPom,
-            boolean skipNodeBoms,
-            boolean skipExtensions) {
-        if (!Objects.equals(fromFile.getName(), fromProject.getName())
-                || !Objects.equals(fromFile.getGroupId(), fromProject.getGroupId())
-                || !Objects.equals(fromFile.getVersion(), fromProject.getVersion())) {
+    // Phase 1: core equality — skips parentPom, per-node boms, top-level boms, and extensions
+    private static boolean coreEqual(LockFile a, LockFile b) {
+        if (!Objects.equals(a.getName(), b.getName())
+                || !Objects.equals(a.getGroupId(), b.getGroupId())
+                || !Objects.equals(a.getVersion(), b.getVersion())) {
             return false;
         }
-        if (!depSetsEqual(fromFile.getDependencies(), fromProject.getDependencies(), skipParentPom, skipNodeBoms))
-            return false;
-        if (!pluginSetsEqual(fromFile.getMavenPlugins(), fromProject.getMavenPlugins(), skipParentPom, skipNodeBoms))
-            return false;
-        // Extensions: the on-disk lockfile pre-dates extension tracking when the set is empty,
-        // so only compare when the on-disk lockfile already contains extension data.
-        if (!skipExtensions
-                && !Objects.equals(fromFile.getMavenExtensions(), fromProject.getMavenExtensions())) return false;
-        return Objects.equals(fromFile.getBoms(), fromProject.getBoms());
+        if (!depsEqualCore(a.getDependencies(), b.getDependencies())) return false;
+        return pluginsEqualCore(a.getMavenPlugins(), b.getMavenPlugins());
     }
 
-    private static boolean depSetsEqual(
-            Set<DependencyNode> a, Set<DependencyNode> b, boolean skipParentPom, boolean skipNodeBoms) {
+    private static boolean depsEqualCore(Set<DependencyNode> a, Set<DependencyNode> b) {
         if (a.size() != b.size()) return false;
-        return a.stream()
-                .allMatch(nodeA -> b.stream().anyMatch(nodeB -> depNodesEqual(nodeA, nodeB, skipParentPom, skipNodeBoms)));
+        return a.stream().allMatch(nodeA -> b.stream().anyMatch(nodeB -> nodeEqualCore(nodeA, nodeB)));
     }
 
-    private static boolean depNodesEqual(
-            DependencyNode a, DependencyNode b, boolean skipParentPom, boolean skipNodeBoms) {
+    private static boolean nodeEqualCore(DependencyNode a, DependencyNode b) {
         return Objects.equals(a.getGroupId(), b.getGroupId())
                 && Objects.equals(a.getArtifactId(), b.getArtifactId())
                 && Objects.equals(a.getVersion(), b.getVersion())
@@ -180,19 +208,15 @@ public class ValidateChecksumMojo extends AbstractLockfileMojo {
                 && Objects.equals(a.getScope(), b.getScope())
                 && Objects.equals(a.getSelectedVersion(), b.getSelectedVersion())
                 && Objects.equals(a.getParent(), b.getParent())
-                && (skipNodeBoms || Objects.equals(a.getBoms(), b.getBoms()))
-                && depSetsEqual(a.getChildren(), b.getChildren(), skipParentPom, skipNodeBoms);
+                && depsEqualCore(a.getChildren(), b.getChildren());
     }
 
-    private static boolean pluginSetsEqual(
-            Set<MavenPlugin> a, Set<MavenPlugin> b, boolean skipParentPom, boolean skipNodeBoms) {
+    private static boolean pluginsEqualCore(Set<MavenPlugin> a, Set<MavenPlugin> b) {
         if (a.size() != b.size()) return false;
-        return a.stream()
-                .allMatch(pA -> b.stream().anyMatch(pB -> pluginEquals(pA, pB, skipParentPom, skipNodeBoms)));
+        return a.stream().allMatch(pA -> b.stream().anyMatch(pB -> pluginEqualCore(pA, pB)));
     }
 
-    private static boolean pluginEquals(
-            MavenPlugin a, MavenPlugin b, boolean skipParentPom, boolean skipNodeBoms) {
+    private static boolean pluginEqualCore(MavenPlugin a, MavenPlugin b) {
         return Objects.equals(a.getGroupId(), b.getGroupId())
                 && Objects.equals(a.getArtifactId(), b.getArtifactId())
                 && Objects.equals(a.getVersion(), b.getVersion())
@@ -200,32 +224,84 @@ public class ValidateChecksumMojo extends AbstractLockfileMojo {
                 && Objects.equals(a.getChecksumAlgorithm(), b.getChecksumAlgorithm())
                 && Objects.equals(a.getResolved(), b.getResolved())
                 && Objects.equals(a.getRepositoryId(), b.getRepositoryId())
-                && (skipParentPom || Objects.equals(a.getParentPom(), b.getParentPom()))
-                && depSetsEqual(a.getDependencies(), b.getDependencies(), skipParentPom, skipNodeBoms);
+                && depsEqualCore(a.getDependencies(), b.getDependencies());
     }
 
-    /** Returns true if any dependency node or plugin (transitively) carries a non-null parentPom. */
-    private static boolean lockFileHasParentPomData(LockFile lockFile) {
-        return lockFile.getDependencies().stream().anyMatch(ValidateChecksumMojo::nodeHasParentPom)
-                || lockFile.getMavenPlugins().stream()
-                        .anyMatch(p -> p.getParentPom() != null
-                                || p.getDependencies().stream().anyMatch(ValidateChecksumMojo::nodeHasParentPom));
+    // Phase 2: bom equality — top-level boms + per-node boms; optionally skip Pom parent chains
+    private static boolean bomsEqualForAll(LockFile a, LockFile b, boolean compareParentChains) {
+        if (!pomSetsEqual(a.getBoms(), b.getBoms(), compareParentChains)) return false;
+        if (!nodeBomsEqual(a.getDependencies(), b.getDependencies(), compareParentChains)) return false;
+        for (MavenPlugin pA : a.getMavenPlugins()) {
+            Optional<MavenPlugin> pBOpt = b.getMavenPlugins().stream()
+                    .filter(pB -> Objects.equals(pA.getGroupId(), pB.getGroupId())
+                            && Objects.equals(pA.getArtifactId(), pB.getArtifactId())
+                            && Objects.equals(pA.getVersion(), pB.getVersion()))
+                    .findFirst();
+            if (!pBOpt.isPresent()) return false;
+            if (!nodeBomsEqual(pA.getDependencies(), pBOpt.get().getDependencies(), compareParentChains))
+                return false;
+        }
+        return true;
     }
 
-    private static boolean nodeHasParentPom(DependencyNode node) {
-        return node.getParentPom() != null
-                || node.getChildren().stream().anyMatch(ValidateChecksumMojo::nodeHasParentPom);
+    private static boolean nodeBomsEqual(
+            Set<DependencyNode> depsA, Set<DependencyNode> depsB, boolean compareParentChains) {
+        if (depsA.size() != depsB.size()) return false;
+        return depsA.stream().allMatch(nA -> depsB.stream().anyMatch(nB ->
+                Objects.equals(nA.getGroupId(), nB.getGroupId())
+                && Objects.equals(nA.getArtifactId(), nB.getArtifactId())
+                && Objects.equals(nA.getVersion(), nB.getVersion())
+                && pomSetsEqual(nA.getBoms(), nB.getBoms(), compareParentChains)
+                && nodeBomsEqual(nA.getChildren(), nB.getChildren(), compareParentChains)));
     }
 
-    /** Returns true if any dependency node (transitively) has a non-empty boms set. */
-    private static boolean lockFileHasNodeBomData(LockFile lockFile) {
-        return lockFile.getDependencies().stream().anyMatch(ValidateChecksumMojo::nodeHasBoms)
-                || lockFile.getMavenPlugins().stream()
-                        .anyMatch(p -> p.getDependencies().stream().anyMatch(ValidateChecksumMojo::nodeHasBoms));
+    private static boolean pomSetsEqual(Set<Pom> a, Set<Pom> b, boolean compareParentChains) {
+        Set<Pom> safeA = a == null ? Collections.emptySet() : a;
+        Set<Pom> safeB = b == null ? Collections.emptySet() : b;
+        if (safeA.size() != safeB.size()) return false;
+        return safeA.stream()
+                .allMatch(pomA -> safeB.stream().anyMatch(pomB -> pomEqual(pomA, pomB, compareParentChains)));
     }
 
-    private static boolean nodeHasBoms(DependencyNode node) {
-        return !node.getBoms().isEmpty()
-                || node.getChildren().stream().anyMatch(ValidateChecksumMojo::nodeHasBoms);
+    private static boolean pomEqual(Pom a, Pom b, boolean compareParentChains) {
+        if (a == null && b == null) return true;
+        if (a == null || b == null) return false;
+        boolean baseEqual = Objects.equals(a.getGroupId(), b.getGroupId())
+                && Objects.equals(a.getArtifactId(), b.getArtifactId())
+                && Objects.equals(a.getVersion(), b.getVersion())
+                && Objects.equals(a.getRelativePath(), b.getRelativePath())
+                && Objects.equals(a.getResolved(), b.getResolved())
+                && Objects.equals(a.getRepositoryId(), b.getRepositoryId())
+                && Objects.equals(a.getChecksumAlgorithm(), b.getChecksumAlgorithm())
+                && Objects.equals(a.getChecksum(), b.getChecksum());
+        if (!baseEqual) return false;
+        return !compareParentChains || pomEqual(a.getParent(), b.getParent(), true);
+    }
+
+    // Phase 3: parentPom equality on all dependency nodes and plugins
+    private static boolean parentPomsEqualForAll(LockFile a, LockFile b) {
+        if (!nodeParentPomsEqual(a.getDependencies(), b.getDependencies())) return false;
+        for (MavenPlugin pA : a.getMavenPlugins()) {
+            Optional<MavenPlugin> pBOpt = b.getMavenPlugins().stream()
+                    .filter(pB -> Objects.equals(pA.getGroupId(), pB.getGroupId())
+                            && Objects.equals(pA.getArtifactId(), pB.getArtifactId())
+                            && Objects.equals(pA.getVersion(), pB.getVersion()))
+                    .findFirst();
+            if (!pBOpt.isPresent()) return false;
+            MavenPlugin pB = pBOpt.get();
+            if (!Objects.equals(pA.getParentPom(), pB.getParentPom())) return false;
+            if (!nodeParentPomsEqual(pA.getDependencies(), pB.getDependencies())) return false;
+        }
+        return true;
+    }
+
+    private static boolean nodeParentPomsEqual(Set<DependencyNode> depsA, Set<DependencyNode> depsB) {
+        if (depsA.size() != depsB.size()) return false;
+        return depsA.stream().allMatch(nA -> depsB.stream().anyMatch(nB ->
+                Objects.equals(nA.getGroupId(), nB.getGroupId())
+                && Objects.equals(nA.getArtifactId(), nB.getArtifactId())
+                && Objects.equals(nA.getVersion(), nB.getVersion())
+                && Objects.equals(nA.getParentPom(), nB.getParentPom())
+                && nodeParentPomsEqual(nA.getChildren(), nB.getChildren())));
     }
 }

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/ValidateChecksumMojo.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/ValidateChecksumMojo.java
@@ -238,8 +238,7 @@ public class ValidateChecksumMojo extends AbstractLockfileMojo {
                             && Objects.equals(pA.getVersion(), pB.getVersion()))
                     .findFirst();
             if (!pBOpt.isPresent()) return false;
-            if (!nodeBomsEqual(pA.getDependencies(), pBOpt.get().getDependencies(), compareParentChains))
-                return false;
+            if (!nodeBomsEqual(pA.getDependencies(), pBOpt.get().getDependencies(), compareParentChains)) return false;
         }
         return true;
     }
@@ -247,12 +246,12 @@ public class ValidateChecksumMojo extends AbstractLockfileMojo {
     private static boolean nodeBomsEqual(
             Set<DependencyNode> depsA, Set<DependencyNode> depsB, boolean compareParentChains) {
         if (depsA.size() != depsB.size()) return false;
-        return depsA.stream().allMatch(nA -> depsB.stream().anyMatch(nB ->
-                Objects.equals(nA.getGroupId(), nB.getGroupId())
-                && Objects.equals(nA.getArtifactId(), nB.getArtifactId())
-                && Objects.equals(nA.getVersion(), nB.getVersion())
-                && pomSetsEqual(nA.getBoms(), nB.getBoms(), compareParentChains)
-                && nodeBomsEqual(nA.getChildren(), nB.getChildren(), compareParentChains)));
+        return depsA.stream().allMatch(nA -> depsB.stream()
+                .anyMatch(nB -> Objects.equals(nA.getGroupId(), nB.getGroupId())
+                        && Objects.equals(nA.getArtifactId(), nB.getArtifactId())
+                        && Objects.equals(nA.getVersion(), nB.getVersion())
+                        && pomSetsEqual(nA.getBoms(), nB.getBoms(), compareParentChains)
+                        && nodeBomsEqual(nA.getChildren(), nB.getChildren(), compareParentChains)));
     }
 
     private static boolean pomSetsEqual(Set<Pom> a, Set<Pom> b, boolean compareParentChains) {
@@ -297,11 +296,11 @@ public class ValidateChecksumMojo extends AbstractLockfileMojo {
 
     private static boolean nodeParentPomsEqual(Set<DependencyNode> depsA, Set<DependencyNode> depsB) {
         if (depsA.size() != depsB.size()) return false;
-        return depsA.stream().allMatch(nA -> depsB.stream().anyMatch(nB ->
-                Objects.equals(nA.getGroupId(), nB.getGroupId())
-                && Objects.equals(nA.getArtifactId(), nB.getArtifactId())
-                && Objects.equals(nA.getVersion(), nB.getVersion())
-                && Objects.equals(nA.getParentPom(), nB.getParentPom())
-                && nodeParentPomsEqual(nA.getChildren(), nB.getChildren())));
+        return depsA.stream().allMatch(nA -> depsB.stream()
+                .anyMatch(nB -> Objects.equals(nA.getGroupId(), nB.getGroupId())
+                        && Objects.equals(nA.getArtifactId(), nB.getArtifactId())
+                        && Objects.equals(nA.getVersion(), nB.getVersion())
+                        && Objects.equals(nA.getParentPom(), nB.getParentPom())
+                        && nodeParentPomsEqual(nA.getChildren(), nB.getChildren())));
     }
 }

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/AbstractMavenComponent.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/AbstractMavenComponent.java
@@ -78,6 +78,10 @@ public abstract class AbstractMavenComponent implements Comparable<AbstractMaven
         return dependencies;
     }
 
+    public Pom getParentPom() {
+        return parentPom;
+    }
+
     @Override
     public int hashCode() {
         return Objects.hash(

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/Config.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/Config.java
@@ -14,6 +14,12 @@ public class Config {
     private final String mavenLockfileVersion;
     private final ChecksumModes checksumMode;
     private final String checksumAlgorithm;
+    private final boolean includeBoms;
+    private final boolean allowBomValidationFailure;
+    private final boolean includeParentPom;
+    private final boolean allowParentPomValidationFailure;
+    private final boolean includeMavenExtensions;
+    private final boolean allowMavenExtensionsValidationFailure;
 
     public Config(
             MavenPluginsInclusion includeMavenPlugins,
@@ -24,7 +30,13 @@ public class Config {
             ReductionState reduced,
             String mavenLockfileVersion,
             ChecksumModes checksumMode,
-            String checksumAlgorithm) {
+            String checksumAlgorithm,
+            BomsInclusion includeBoms,
+            OnBomValidationFailure allowBomValidationFailure,
+            ParentPomInclusion includeParentPom,
+            OnParentPomValidationFailure allowParentPomValidationFailure,
+            MavenExtensionsInclusion includeMavenExtensions,
+            OnMavenExtensionsValidationFailure allowMavenExtensionsValidationFailure) {
         this.includeMavenPlugins = includeMavenPlugins.equals(MavenPluginsInclusion.Include);
         this.allowValidationFailure = allowValidationFailure.equals(OnValidationFailure.Warn);
         this.allowPomValidationFailure = allowPomValidationFailure.equals(OnPomValidationFailure.Warn);
@@ -35,6 +47,14 @@ public class Config {
         this.mavenLockfileVersion = mavenLockfileVersion;
         this.checksumMode = checksumMode;
         this.checksumAlgorithm = checksumAlgorithm;
+        this.includeBoms = includeBoms.equals(BomsInclusion.Include);
+        this.allowBomValidationFailure = allowBomValidationFailure.equals(OnBomValidationFailure.Warn);
+        this.includeParentPom = includeParentPom.equals(ParentPomInclusion.Include);
+        this.allowParentPomValidationFailure =
+                allowParentPomValidationFailure.equals(OnParentPomValidationFailure.Warn);
+        this.includeMavenExtensions = includeMavenExtensions.equals(MavenExtensionsInclusion.Include);
+        this.allowMavenExtensionsValidationFailure =
+                allowMavenExtensionsValidationFailure.equals(OnMavenExtensionsValidationFailure.Warn);
     }
 
     public Config() {
@@ -47,6 +67,12 @@ public class Config {
         this.mavenLockfileVersion = "1";
         this.checksumMode = ChecksumModes.LOCAL;
         this.checksumAlgorithm = new FileSystemChecksumCalculator(null, null, null, null).getDefaultChecksumAlgorithm();
+        this.includeBoms = false;
+        this.allowBomValidationFailure = false;
+        this.includeParentPom = false;
+        this.allowParentPomValidationFailure = false;
+        this.includeMavenExtensions = false;
+        this.allowMavenExtensionsValidationFailure = false;
     }
     /**
      * @return the includeMavenPlugins
@@ -141,6 +167,56 @@ public class Config {
         return checksumAlgorithm;
     }
 
+    public boolean isIncludeBoms() {
+        return includeBoms;
+    }
+
+    public BomsInclusion getBomsInclusion() {
+        return includeBoms ? BomsInclusion.Include : BomsInclusion.Exclude;
+    }
+
+    public boolean isAllowBomValidationFailure() {
+        return allowBomValidationFailure;
+    }
+
+    public OnBomValidationFailure getOnBomValidationFailure() {
+        return allowBomValidationFailure ? OnBomValidationFailure.Warn : OnBomValidationFailure.Error;
+    }
+
+    public boolean isIncludeParentPom() {
+        return includeParentPom;
+    }
+
+    public ParentPomInclusion getParentPomInclusion() {
+        return includeParentPom ? ParentPomInclusion.Include : ParentPomInclusion.Exclude;
+    }
+
+    public boolean isAllowParentPomValidationFailure() {
+        return allowParentPomValidationFailure;
+    }
+
+    public OnParentPomValidationFailure getOnParentPomValidationFailure() {
+        return allowParentPomValidationFailure ? OnParentPomValidationFailure.Warn : OnParentPomValidationFailure.Error;
+    }
+
+    public boolean isIncludeMavenExtensions() {
+        return includeMavenExtensions;
+    }
+
+    public MavenExtensionsInclusion getMavenExtensionsInclusion() {
+        return includeMavenExtensions ? MavenExtensionsInclusion.Include : MavenExtensionsInclusion.Exclude;
+    }
+
+    public boolean isAllowMavenExtensionsValidationFailure() {
+        return allowMavenExtensionsValidationFailure;
+    }
+
+    public OnMavenExtensionsValidationFailure getOnMavenExtensionsValidationFailure() {
+        return allowMavenExtensionsValidationFailure
+                ? OnMavenExtensionsValidationFailure.Warn
+                : OnMavenExtensionsValidationFailure.Error;
+    }
+
     public enum MavenPluginsInclusion {
         Include,
         Exclude
@@ -169,5 +245,35 @@ public class Config {
     public enum ReductionState {
         Reduced,
         NonReduced
+    }
+
+    public enum BomsInclusion {
+        Include,
+        Exclude
+    }
+
+    public enum OnBomValidationFailure {
+        Warn,
+        Error
+    }
+
+    public enum ParentPomInclusion {
+        Include,
+        Exclude
+    }
+
+    public enum OnParentPomValidationFailure {
+        Warn,
+        Error
+    }
+
+    public enum MavenExtensionsInclusion {
+        Include,
+        Exclude
+    }
+
+    public enum OnMavenExtensionsValidationFailure {
+        Warn,
+        Error
     }
 }

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/Config.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/Config.java
@@ -14,6 +14,12 @@ public class Config {
     private final String mavenLockfileVersion;
     private final ChecksumModes checksumMode;
     private final String checksumAlgorithm;
+    private final boolean includeBoms;
+    private final boolean allowBomValidationFailure;
+    private final boolean includeParentPom;
+    private final boolean allowParentPomValidationFailure;
+    private final boolean includeMavenExtensions;
+    private final boolean allowMavenExtensionsValidationFailure;
 
     public Config(
             MavenPluginsInclusion includeMavenPlugins,
@@ -24,7 +30,13 @@ public class Config {
             ReductionState reduced,
             String mavenLockfileVersion,
             ChecksumModes checksumMode,
-            String checksumAlgorithm) {
+            String checksumAlgorithm,
+            BomsInclusion includeBoms,
+            OnBomValidationFailure allowBomValidationFailure,
+            ParentPomInclusion includeParentPom,
+            OnParentPomValidationFailure allowParentPomValidationFailure,
+            MavenExtensionsInclusion includeMavenExtensions,
+            OnMavenExtensionsValidationFailure allowMavenExtensionsValidationFailure) {
         this.includeMavenPlugins = includeMavenPlugins.equals(MavenPluginsInclusion.Include);
         this.allowValidationFailure = allowValidationFailure.equals(OnValidationFailure.Warn);
         this.allowPomValidationFailure = allowPomValidationFailure.equals(OnPomValidationFailure.Warn);
@@ -35,6 +47,14 @@ public class Config {
         this.mavenLockfileVersion = mavenLockfileVersion;
         this.checksumMode = checksumMode;
         this.checksumAlgorithm = checksumAlgorithm;
+        this.includeBoms = includeBoms.equals(BomsInclusion.Include);
+        this.allowBomValidationFailure = allowBomValidationFailure.equals(OnBomValidationFailure.Warn);
+        this.includeParentPom = includeParentPom.equals(ParentPomInclusion.Include);
+        this.allowParentPomValidationFailure =
+                allowParentPomValidationFailure.equals(OnParentPomValidationFailure.Warn);
+        this.includeMavenExtensions = includeMavenExtensions.equals(MavenExtensionsInclusion.Include);
+        this.allowMavenExtensionsValidationFailure =
+                allowMavenExtensionsValidationFailure.equals(OnMavenExtensionsValidationFailure.Warn);
     }
 
     public Config() {
@@ -47,6 +67,12 @@ public class Config {
         this.mavenLockfileVersion = "1";
         this.checksumMode = ChecksumModes.LOCAL;
         this.checksumAlgorithm = new FileSystemChecksumCalculator(null, null, null, null).getDefaultChecksumAlgorithm();
+        this.includeBoms = false;
+        this.allowBomValidationFailure = false;
+        this.includeParentPom = false;
+        this.allowParentPomValidationFailure = false;
+        this.includeMavenExtensions = false;
+        this.allowMavenExtensionsValidationFailure = false;
     }
     /**
      * @return the includeMavenPlugins
@@ -141,6 +167,58 @@ public class Config {
         return checksumAlgorithm;
     }
 
+    public boolean isIncludeBoms() {
+        return includeBoms;
+    }
+
+    public BomsInclusion getBomsInclusion() {
+        return includeBoms ? BomsInclusion.Include : BomsInclusion.Exclude;
+    }
+
+    public boolean isAllowBomValidationFailure() {
+        return allowBomValidationFailure;
+    }
+
+    public OnBomValidationFailure getOnBomValidationFailure() {
+        return allowBomValidationFailure ? OnBomValidationFailure.Warn : OnBomValidationFailure.Error;
+    }
+
+    public boolean isIncludeParentPom() {
+        return includeParentPom;
+    }
+
+    public ParentPomInclusion getParentPomInclusion() {
+        return includeParentPom ? ParentPomInclusion.Include : ParentPomInclusion.Exclude;
+    }
+
+    public boolean isAllowParentPomValidationFailure() {
+        return allowParentPomValidationFailure;
+    }
+
+    public OnParentPomValidationFailure getOnParentPomValidationFailure() {
+        return allowParentPomValidationFailure
+                ? OnParentPomValidationFailure.Warn
+                : OnParentPomValidationFailure.Error;
+    }
+
+    public boolean isIncludeMavenExtensions() {
+        return includeMavenExtensions;
+    }
+
+    public MavenExtensionsInclusion getMavenExtensionsInclusion() {
+        return includeMavenExtensions ? MavenExtensionsInclusion.Include : MavenExtensionsInclusion.Exclude;
+    }
+
+    public boolean isAllowMavenExtensionsValidationFailure() {
+        return allowMavenExtensionsValidationFailure;
+    }
+
+    public OnMavenExtensionsValidationFailure getOnMavenExtensionsValidationFailure() {
+        return allowMavenExtensionsValidationFailure
+                ? OnMavenExtensionsValidationFailure.Warn
+                : OnMavenExtensionsValidationFailure.Error;
+    }
+
     public enum MavenPluginsInclusion {
         Include,
         Exclude
@@ -169,5 +247,35 @@ public class Config {
     public enum ReductionState {
         Reduced,
         NonReduced
+    }
+
+    public enum BomsInclusion {
+        Include,
+        Exclude
+    }
+
+    public enum OnBomValidationFailure {
+        Warn,
+        Error
+    }
+
+    public enum ParentPomInclusion {
+        Include,
+        Exclude
+    }
+
+    public enum OnParentPomValidationFailure {
+        Warn,
+        Error
+    }
+
+    public enum MavenExtensionsInclusion {
+        Include,
+        Exclude
+    }
+
+    public enum OnMavenExtensionsValidationFailure {
+        Warn,
+        Error
     }
 }

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/Config.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/data/Config.java
@@ -196,9 +196,7 @@ public class Config {
     }
 
     public OnParentPomValidationFailure getOnParentPomValidationFailure() {
-        return allowParentPomValidationFailure
-                ? OnParentPomValidationFailure.Warn
-                : OnParentPomValidationFailure.Error;
+        return allowParentPomValidationFailure ? OnParentPomValidationFailure.Warn : OnParentPomValidationFailure.Error;
     }
 
     public boolean isIncludeMavenExtensions() {

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/reporting/ValidationPhase.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/reporting/ValidationPhase.java
@@ -1,0 +1,31 @@
+package io.github.chains_project.maven_lockfile.reporting;
+
+import io.github.chains_project.maven_lockfile.data.Config;
+import io.github.chains_project.maven_lockfile.data.LockFile;
+import java.util.Optional;
+
+/**
+ * Represents one validation concern checked during {@code mvn maven-lockfile:validate}.
+ *
+ * <p>Each implementation is responsible for deciding whether it applies to the current
+ * configuration ({@link #isEnabled}), how to compare the on-disk lockfile against the
+ * freshly-generated one ({@link #validate}), and what to do on mismatch ({@link #isWarn}).
+ *
+ * <p>To add a new field to lockfile validation, implement this interface and register the
+ * implementation in {@link ValidationPhases#all}.
+ */
+public interface ValidationPhase {
+
+    /** Whether this phase should run given the current config. */
+    boolean isEnabled(Config config);
+
+    /**
+     * Compare the two lockfiles for this concern.
+     *
+     * @return {@link Optional#empty()} if they agree, or a non-empty failure message.
+     */
+    Optional<String> validate(LockFile fromFile, LockFile fromProject, Config config);
+
+    /** {@code true} → log a warning on failure; {@code false} → throw a build error. */
+    boolean isWarn(Config config);
+}

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/reporting/ValidationPhases.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/reporting/ValidationPhases.java
@@ -1,0 +1,190 @@
+package io.github.chains_project.maven_lockfile.reporting;
+
+import io.github.chains_project.maven_lockfile.JsonUtils;
+import io.github.chains_project.maven_lockfile.LockFileEquality;
+import io.github.chains_project.maven_lockfile.data.Config;
+import io.github.chains_project.maven_lockfile.data.LockFile;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * All built-in {@link ValidationPhase} implementations, in the order they are run during
+ * {@code mvn maven-lockfile:validate}.
+ */
+public final class ValidationPhases {
+
+    private ValidationPhases() {}
+
+    public static List<ValidationPhase> all() {
+        return List.of(
+                new EnvironmentPhase(),
+                new PomPhase(),
+                new CorePhase(),
+                new BomsPhase(),
+                new ParentPomPhase(),
+                new ExtensionsPhase());
+    }
+
+    private static final class EnvironmentPhase implements ValidationPhase {
+
+        @Override
+        public boolean isEnabled(Config config) {
+            return config.isIncludeEnvironment();
+        }
+
+        @Override
+        public Optional<String> validate(LockFile fromFile, LockFile fromProject, Config config) {
+            if (Objects.equals(fromFile.getEnvironment(), fromProject.getEnvironment())) {
+                return Optional.empty();
+            }
+            String msg = "Lock file environment does not match project environment.\n"
+                    + "Lockfile environment: " + fromFile.getEnvironment() + "\n"
+                    + "Project environment:  " + fromProject.getEnvironment() + "\n";
+            return Optional.of(msg);
+        }
+
+        @Override
+        public boolean isWarn(Config config) {
+            return config.getOnEnvironmentalValidationFailure() == Config.OnEnvironmentalValidationFailure.Warn;
+        }
+    }
+
+    private static final class PomPhase implements ValidationPhase {
+
+        @Override
+        public boolean isEnabled(Config config) {
+            return true;
+        }
+
+        @Override
+        public Optional<String> validate(LockFile fromFile, LockFile fromProject, Config config) {
+            if (LockFileEquality.pomEqual(fromFile.getPom(), fromProject.getPom(), false)) {
+                return Optional.empty();
+            }
+            String msg = "Pom checksum mismatch. Differences:\nYour lockfile pom:\n"
+                    + JsonUtils.toJson(fromFile.getPom())
+                    + "\nYour project pom:\n"
+                    + JsonUtils.toJson(fromProject.getPom())
+                    + "\n";
+            return Optional.of(msg);
+        }
+
+        @Override
+        public boolean isWarn(Config config) {
+            return config.getOnPomValidationFailure() == Config.OnPomValidationFailure.Warn;
+        }
+    }
+
+    private static final class CorePhase implements ValidationPhase {
+
+        @Override
+        public boolean isEnabled(Config config) {
+            return true;
+        }
+
+        @Override
+        public Optional<String> validate(LockFile fromFile, LockFile fromProject, Config config) {
+            if (LockFileEquality.coreEqual(fromFile, fromProject)) {
+                return Optional.empty();
+            }
+            var diff = LockFileDifference.diff(fromFile, fromProject);
+            String msg = "Failed verifying lock file. Lock file validation failed. Differences:\n"
+                    + "Your lockfile from file is for: "
+                    + fromFile.getGroupId().getValue() + ":"
+                    + fromFile.getName().getValue() + ":"
+                    + fromFile.getVersion().getValue() + "\n"
+                    + "Your generated lockfile is for: "
+                    + fromProject.getGroupId().getValue() + ":"
+                    + fromProject.getName().getValue() + ":"
+                    + fromProject.getVersion().getValue() + "\n"
+                    + "Missing dependencies in lock file:\n "
+                    + JsonUtils.toJson(diff.getMissingDependenciesInFile()) + "\n"
+                    + "Missing dependencies in project:\n "
+                    + JsonUtils.toJson(diff.getMissingDependenciesInProject()) + "\n"
+                    + "Missing plugins in lockfile:\n "
+                    + JsonUtils.toJson(diff.getMissingPluginsInFile()) + "\n"
+                    + "Missing plugins in project:\n "
+                    + JsonUtils.toJson(diff.getMissingPluginsInProject()) + "\n";
+            return Optional.of(msg);
+        }
+
+        @Override
+        public boolean isWarn(Config config) {
+            return config.getOnValidationFailure() == Config.OnValidationFailure.Warn;
+        }
+    }
+
+    private static final class BomsPhase implements ValidationPhase {
+
+        @Override
+        public boolean isEnabled(Config config) {
+            return config.isIncludeBoms();
+        }
+
+        @Override
+        public Optional<String> validate(LockFile fromFile, LockFile fromProject, Config config) {
+            if (LockFileEquality.bomsEqualForAll(fromFile, fromProject, config.isIncludeParentPom())) {
+                return Optional.empty();
+            }
+            return Optional.of("Bom validation failed."
+                    + " The BOM membership or BOM POM data of dependencies differs"
+                    + " between the lockfile and the project.");
+        }
+
+        @Override
+        public boolean isWarn(Config config) {
+            return config.getOnBomValidationFailure() == Config.OnBomValidationFailure.Warn;
+        }
+    }
+
+    private static final class ParentPomPhase implements ValidationPhase {
+
+        @Override
+        public boolean isEnabled(Config config) {
+            return config.isIncludeParentPom();
+        }
+
+        @Override
+        public Optional<String> validate(LockFile fromFile, LockFile fromProject, Config config) {
+            if (LockFileEquality.parentPomsEqualForAll(fromFile, fromProject)) {
+                return Optional.empty();
+            }
+            return Optional.of("Parent POM validation failed."
+                    + " The parentPom of one or more dependencies or plugins differs"
+                    + " between the lockfile and the project.");
+        }
+
+        @Override
+        public boolean isWarn(Config config) {
+            return config.getOnParentPomValidationFailure() == Config.OnParentPomValidationFailure.Warn;
+        }
+    }
+
+    private static final class ExtensionsPhase implements ValidationPhase {
+
+        @Override
+        public boolean isEnabled(Config config) {
+            return config.isIncludeMavenExtensions();
+        }
+
+        @Override
+        public Optional<String> validate(LockFile fromFile, LockFile fromProject, Config config) {
+            if (Objects.equals(fromFile.getMavenExtensions(), fromProject.getMavenExtensions())) {
+                return Optional.empty();
+            }
+            var diff = LockFileDifference.diff(fromFile, fromProject);
+            String msg = "Maven extensions validation failed.\n"
+                    + "Missing extensions in lockfile:\n "
+                    + JsonUtils.toJson(diff.getMissingExtensionsInFile()) + "\n"
+                    + "Missing extensions in project:\n "
+                    + JsonUtils.toJson(diff.getMissingExtensionsInProject()) + "\n";
+            return Optional.of(msg);
+        }
+
+        @Override
+        public boolean isWarn(Config config) {
+            return config.getOnMavenExtensionsValidationFailure() == Config.OnMavenExtensionsValidationFailure.Warn;
+        }
+    }
+}

--- a/maven_plugin/src/test/java/io/github/chains_project/maven_lockfile/AbstractLockfileMojoTest.java
+++ b/maven_plugin/src/test/java/io/github/chains_project/maven_lockfile/AbstractLockfileMojoTest.java
@@ -7,7 +7,7 @@ import io.github.chains_project.maven_lockfile.data.Config;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.junit.jupiter.api.Test;
 
-class ValidateMojoTest {
+class AbstractLockfileMojoTest {
 
     private static AbstractLockfileMojo mojo() {
         return new AbstractLockfileMojo() {
@@ -27,11 +27,11 @@ class ValidateMojoTest {
                 "5.16.0",
                 ChecksumModes.LOCAL,
                 "SHA-256",
-                Config.BomsInclusion.Exclude,
+                Config.BomsInclusion.Include,
                 Config.OnBomValidationFailure.Error,
-                Config.ParentPomInclusion.Exclude,
+                Config.ParentPomInclusion.Include,
                 Config.OnParentPomValidationFailure.Error,
-                Config.MavenExtensionsInclusion.Exclude,
+                Config.MavenExtensionsInclusion.Include,
                 Config.OnMavenExtensionsValidationFailure.Error);
     }
 

--- a/maven_plugin/src/test/java/io/github/chains_project/maven_lockfile/AbstractLockfileMojoTest.java
+++ b/maven_plugin/src/test/java/io/github/chains_project/maven_lockfile/AbstractLockfileMojoTest.java
@@ -26,7 +26,13 @@ class AbstractLockfileMojoTest {
                 Config.ReductionState.NonReduced,
                 "5.16.0",
                 ChecksumModes.LOCAL,
-                "SHA-256");
+                "SHA-256",
+                Config.BomsInclusion.Include,
+                Config.OnBomValidationFailure.Error,
+                Config.ParentPomInclusion.Include,
+                Config.OnParentPomValidationFailure.Error,
+                Config.MavenExtensionsInclusion.Include,
+                Config.OnMavenExtensionsValidationFailure.Error);
     }
 
     @Test

--- a/maven_plugin/src/test/java/io/github/chains_project/maven_lockfile/AbstractLockfileMojoTest.java
+++ b/maven_plugin/src/test/java/io/github/chains_project/maven_lockfile/AbstractLockfileMojoTest.java
@@ -1,0 +1,55 @@
+package io.github.chains_project.maven_lockfile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.chains_project.maven_lockfile.checksum.ChecksumModes;
+import io.github.chains_project.maven_lockfile.data.Config;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.junit.jupiter.api.Test;
+
+class AbstractLockfileMojoTest {
+
+    private static AbstractLockfileMojo mojo() {
+        return new AbstractLockfileMojo() {
+            @Override
+            public void execute() throws MojoExecutionException {}
+        };
+    }
+
+    private static Config storedConfig() {
+        return new Config(
+                Config.MavenPluginsInclusion.Exclude,
+                Config.OnValidationFailure.Error,
+                Config.OnPomValidationFailure.Warn,
+                Config.OnEnvironmentalValidationFailure.Error,
+                Config.EnvironmentInclusion.Include,
+                Config.ReductionState.NonReduced,
+                "5.16.0",
+                ChecksumModes.LOCAL,
+                "SHA-256");
+    }
+
+    @Test
+    void cliArgOverridesStoredConfig() {
+        var m = mojo();
+        m.allowEnvironmentalValidationFailure = "true";
+
+        Config merged = m.mergeConfigWithCliArgs(storedConfig());
+
+        assertThat(merged.getOnEnvironmentalValidationFailure())
+                .isEqualTo(Config.OnEnvironmentalValidationFailure.Warn);
+        // Unset CLI args preserve stored values
+        assertThat(merged.getOnValidationFailure()).isEqualTo(Config.OnValidationFailure.Error);
+        assertThat(merged.getOnPomValidationFailure()).isEqualTo(Config.OnPomValidationFailure.Warn);
+    }
+
+    @Test
+    void storedConfigUsedWhenCliArgNotSet() {
+        var m = mojo();
+        assertThat(m.allowEnvironmentalValidationFailure).isNull();
+
+        Config merged = m.mergeConfigWithCliArgs(storedConfig());
+        assertThat(merged.getOnEnvironmentalValidationFailure())
+                .isEqualTo(Config.OnEnvironmentalValidationFailure.Error);
+    }
+}

--- a/maven_plugin/src/test/java/io/github/chains_project/maven_lockfile/graph/LockFileEqualityTest.java
+++ b/maven_plugin/src/test/java/io/github/chains_project/maven_lockfile/graph/LockFileEqualityTest.java
@@ -1,0 +1,257 @@
+package io.github.chains_project.maven_lockfile.graph;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.chains_project.maven_lockfile.LockFileEquality;
+import io.github.chains_project.maven_lockfile.data.ArtifactId;
+import io.github.chains_project.maven_lockfile.data.ArtifactType;
+import io.github.chains_project.maven_lockfile.data.GroupId;
+import io.github.chains_project.maven_lockfile.data.LockFile;
+import io.github.chains_project.maven_lockfile.data.MavenPlugin;
+import io.github.chains_project.maven_lockfile.data.MavenScope;
+import io.github.chains_project.maven_lockfile.data.Pom;
+import io.github.chains_project.maven_lockfile.data.RepositoryId;
+import io.github.chains_project.maven_lockfile.data.ResolvedUrl;
+import io.github.chains_project.maven_lockfile.data.VersionNumber;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link LockFileEquality}. Each test group targets one public method and includes
+ * explicit "ignores" tests to document what each method does NOT compare.
+ */
+class LockFileEqualityTest {
+
+    private static final GroupId G = GroupId.of("com.example");
+    private static final ArtifactId A = ArtifactId.of("artifact");
+    private static final VersionNumber V = VersionNumber.of("1.0");
+
+    private static LockFile lockFile(Set<DependencyNode> deps, Set<MavenPlugin> plugins, Set<Pom> boms) {
+        return new LockFile(G, A, V, projectPom(), deps, plugins, Set.of(), null, boms);
+    }
+
+    private static Pom projectPom() {
+        return new Pom(G, A, V, "pom.xml", null, null, "SHA-256", "abc123", null);
+    }
+
+    private static Pom bomPom(String artifactId, String checksum) {
+        return new Pom(G, ArtifactId.of(artifactId), V, null, null, null, "SHA-256", checksum, null);
+    }
+
+    private static Pom bomPomWithParent(String artifactId, String checksum, Pom parent) {
+        return new Pom(G, ArtifactId.of(artifactId), V, null, null, null, "SHA-256", checksum, parent);
+    }
+
+    /** A minimal node with no children, no boms, no parentPom. */
+    private static DependencyNode node(String artifactId, String checksum) {
+        return new DependencyNode(
+                ArtifactId.of(artifactId),
+                G,
+                V,
+                null,
+                ArtifactType.of("jar"),
+                MavenScope.COMPILE,
+                ResolvedUrl.Unresolved(),
+                RepositoryId.None(),
+                "SHA-256",
+                checksum);
+    }
+
+    /** Same node but with a BOM attached. */
+    private static DependencyNode nodeWithBom(String artifactId, String checksum, Pom bom) {
+        DependencyNode n = node(artifactId, checksum);
+        n.setBoms(Set.of(bom));
+        return n;
+    }
+
+    /** Same node but with a parentPom attached. */
+    private static DependencyNode nodeWithParentPom(String artifactId, String checksum, Pom parentPom) {
+        DependencyNode n = node(artifactId, checksum);
+        n.setParentPom(parentPom);
+        return n;
+    }
+
+    private static MavenPlugin plugin(String artifactId, String checksum) {
+        return new MavenPlugin(
+                G, ArtifactId.of(artifactId), V, ResolvedUrl.Unresolved(), RepositoryId.None(), "SHA-256", checksum);
+    }
+
+    private static MavenPlugin pluginWithParentPom(String artifactId, String checksum, Pom parentPom) {
+        return new MavenPlugin(
+                G,
+                ArtifactId.of(artifactId),
+                V,
+                ResolvedUrl.Unresolved(),
+                RepositoryId.None(),
+                "SHA-256",
+                checksum,
+                null,
+                parentPom);
+    }
+
+    // -------------------------------------------------------------------------
+    // coreEqual — GAV, dependency coordinates + checksums, plugin coordinates + checksums
+    // Ignores: per-node BOMs, per-node parentPom, top-level BOMs, extensions
+    // -------------------------------------------------------------------------
+
+    @Test
+    void coreEqual_trueWhenDepsAndPluginsMatch() {
+        var a = lockFile(Set.of(node("dep", "c1")), Set.of(plugin("p", "pc1")), Set.of());
+        var b = lockFile(Set.of(node("dep", "c1")), Set.of(plugin("p", "pc1")), Set.of());
+        assertThat(LockFileEquality.coreEqual(a, b)).isTrue();
+    }
+
+    @Test
+    void coreEqual_falseWhenDependencyChecksumDiffers() {
+        var a = lockFile(Set.of(node("dep", "c1")), Set.of(), Set.of());
+        var b = lockFile(Set.of(node("dep", "DIFFERENT")), Set.of(), Set.of());
+        assertThat(LockFileEquality.coreEqual(a, b)).isFalse();
+    }
+
+    @Test
+    void coreEqual_falseWhenDependencyMissing() {
+        var a = lockFile(Set.of(node("dep", "c1")), Set.of(), Set.of());
+        var b = lockFile(Set.of(), Set.of(), Set.of());
+        assertThat(LockFileEquality.coreEqual(a, b)).isFalse();
+    }
+
+    @Test
+    void coreEqual_falseWhenPluginChecksumDiffers() {
+        var a = lockFile(Set.of(), Set.of(plugin("p", "pc1")), Set.of());
+        var b = lockFile(Set.of(), Set.of(plugin("p", "DIFFERENT")), Set.of());
+        assertThat(LockFileEquality.coreEqual(a, b)).isFalse();
+    }
+
+    @Test
+    void coreEqual_ignoresPerNodeBoms() {
+        Pom bom = bomPom("bom-artifact", "bomchecksum");
+        var a = lockFile(Set.of(nodeWithBom("dep", "c1", bom)), Set.of(), Set.of());
+        var b = lockFile(Set.of(node("dep", "c1")), Set.of(), Set.of());
+        assertThat(LockFileEquality.coreEqual(a, b)).isTrue();
+    }
+
+    @Test
+    void coreEqual_ignoresPerNodeParentPom() {
+        Pom parent = bomPom("parent", "pchecksum");
+        var a = lockFile(Set.of(nodeWithParentPom("dep", "c1", parent)), Set.of(), Set.of());
+        var b = lockFile(Set.of(node("dep", "c1")), Set.of(), Set.of());
+        assertThat(LockFileEquality.coreEqual(a, b)).isTrue();
+    }
+
+    @Test
+    void coreEqual_ignoresToplevelBoms() {
+        Pom bom = bomPom("bom-artifact", "bomchecksum");
+        var a = lockFile(Set.of(node("dep", "c1")), Set.of(), Set.of(bom));
+        var b = lockFile(Set.of(node("dep", "c1")), Set.of(), Set.of());
+        assertThat(LockFileEquality.coreEqual(a, b)).isTrue();
+    }
+
+    // -------------------------------------------------------------------------
+    // bomsEqualForAll — top-level BOM sets, per-node BOM sets on deps and plugin deps
+    // Optionally compares BOM POM parent chains (compareParentChains flag)
+    // Ignores: node checksums/coordinates (only uses GAV as a matching key)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void bomsEqualForAll_trueWhenBomsMatch() {
+        Pom bom = bomPom("bom", "bc");
+        var a = lockFile(Set.of(nodeWithBom("dep", "c1", bom)), Set.of(), Set.of(bom));
+        var b = lockFile(Set.of(nodeWithBom("dep", "c1", bom)), Set.of(), Set.of(bom));
+        assertThat(LockFileEquality.bomsEqualForAll(a, b, false)).isTrue();
+    }
+
+    @Test
+    void bomsEqualForAll_falseWhenToplevelBomDiffers() {
+        Pom bom1 = bomPom("bom", "bc1");
+        Pom bom2 = bomPom("bom", "DIFFERENT");
+        var a = lockFile(Set.of(), Set.of(), Set.of(bom1));
+        var b = lockFile(Set.of(), Set.of(), Set.of(bom2));
+        assertThat(LockFileEquality.bomsEqualForAll(a, b, false)).isFalse();
+    }
+
+    @Test
+    void bomsEqualForAll_falseWhenPerNodeBomDiffers() {
+        Pom bom1 = bomPom("bom", "bc1");
+        Pom bom2 = bomPom("bom", "DIFFERENT");
+        var a = lockFile(Set.of(nodeWithBom("dep", "c1", bom1)), Set.of(), Set.of());
+        var b = lockFile(Set.of(nodeWithBom("dep", "c1", bom2)), Set.of(), Set.of());
+        assertThat(LockFileEquality.bomsEqualForAll(a, b, false)).isFalse();
+    }
+
+    @Test
+    void bomsEqualForAll_ignoresBomParentChainWhenFlagIsFalse() {
+        Pom parent1 = bomPom("parent", "p1");
+        Pom parent2 = bomPom("parent", "DIFFERENT");
+        Pom bom1 = bomPomWithParent("bom", "bc", parent1);
+        Pom bom2 = bomPomWithParent("bom", "bc", parent2);
+        var a = lockFile(Set.of(), Set.of(), Set.of(bom1));
+        var b = lockFile(Set.of(), Set.of(), Set.of(bom2));
+        assertThat(LockFileEquality.bomsEqualForAll(a, b, false)).isTrue();
+    }
+
+    @Test
+    void bomsEqualForAll_falseWhenBomParentChainDiffersAndFlagIsTrue() {
+        Pom parent1 = bomPom("parent", "p1");
+        Pom parent2 = bomPom("parent", "DIFFERENT");
+        Pom bom1 = bomPomWithParent("bom", "bc", parent1);
+        Pom bom2 = bomPomWithParent("bom", "bc", parent2);
+        var a = lockFile(Set.of(), Set.of(), Set.of(bom1));
+        var b = lockFile(Set.of(), Set.of(), Set.of(bom2));
+        assertThat(LockFileEquality.bomsEqualForAll(a, b, true)).isFalse();
+    }
+
+    // -------------------------------------------------------------------------
+    // parentPomsEqualForAll — parentPom on every dependency node and plugin (recursive)
+    // Ignores: BOMs, node checksums (only uses GAV as a matching key)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void parentPomsEqualForAll_trueWhenParentPomsMatch() {
+        Pom parent = bomPom("parent", "pc");
+        var a = lockFile(Set.of(nodeWithParentPom("dep", "c1", parent)), Set.of(), Set.of());
+        var b = lockFile(Set.of(nodeWithParentPom("dep", "c1", parent)), Set.of(), Set.of());
+        assertThat(LockFileEquality.parentPomsEqualForAll(a, b)).isTrue();
+    }
+
+    @Test
+    void parentPomsEqualForAll_trueWhenBothParentPomsNull() {
+        var a = lockFile(Set.of(node("dep", "c1")), Set.of(), Set.of());
+        var b = lockFile(Set.of(node("dep", "c1")), Set.of(), Set.of());
+        assertThat(LockFileEquality.parentPomsEqualForAll(a, b)).isTrue();
+    }
+
+    @Test
+    void parentPomsEqualForAll_falseWhenNodeParentPomDiffers() {
+        Pom parent1 = bomPom("parent", "pc1");
+        Pom parent2 = bomPom("parent", "DIFFERENT");
+        var a = lockFile(Set.of(nodeWithParentPom("dep", "c1", parent1)), Set.of(), Set.of());
+        var b = lockFile(Set.of(nodeWithParentPom("dep", "c1", parent2)), Set.of(), Set.of());
+        assertThat(LockFileEquality.parentPomsEqualForAll(a, b)).isFalse();
+    }
+
+    @Test
+    void parentPomsEqualForAll_falseWhenPluginParentPomDiffers() {
+        Pom parent1 = bomPom("parent", "pc1");
+        Pom parent2 = bomPom("parent", "DIFFERENT");
+        var a = lockFile(Set.of(), Set.of(pluginWithParentPom("p", "pc", parent1)), Set.of());
+        var b = lockFile(Set.of(), Set.of(pluginWithParentPom("p", "pc", parent2)), Set.of());
+        assertThat(LockFileEquality.parentPomsEqualForAll(a, b)).isFalse();
+    }
+
+    @Test
+    void parentPomsEqualForAll_falseWhenOneNodeHasParentPomAndOtherDoesNot() {
+        Pom parent = bomPom("parent", "pc1");
+        var a = lockFile(Set.of(nodeWithParentPom("dep", "c1", parent)), Set.of(), Set.of());
+        var b = lockFile(Set.of(node("dep", "c1")), Set.of(), Set.of());
+        assertThat(LockFileEquality.parentPomsEqualForAll(a, b)).isFalse();
+    }
+
+    @Test
+    void parentPomsEqualForAll_ignoresPerNodeBoms() {
+        Pom parent = bomPom("parent", "pc");
+        Pom bom = bomPom("bom", "bc");
+        var a = lockFile(Set.of(nodeWithParentPom("dep", "c1", parent)), Set.of(), Set.of());
+        var b = lockFile(Set.of(nodeWithBom("dep", "c1", bom)), Set.of(), Set.of());
+        assertThat(LockFileEquality.parentPomsEqualForAll(a, b)).isFalse();
+    }
+}

--- a/maven_plugin/src/test/java/io/github/chains_project/maven_lockfile/graph/LockfileTest.java
+++ b/maven_plugin/src/test/java/io/github/chains_project/maven_lockfile/graph/LockfileTest.java
@@ -34,7 +34,13 @@ public class LockfileTest {
                         Config.ReductionState.NonReduced,
                         "1",
                         ChecksumModes.LOCAL,
-                        "SHA-1"));
+                        "SHA-1",
+                        Config.BomsInclusion.Include,
+                        Config.OnBomValidationFailure.Error,
+                        Config.ParentPomInclusion.Include,
+                        Config.OnParentPomValidationFailure.Error,
+                        Config.MavenExtensionsInclusion.Include,
+                        Config.OnMavenExtensionsValidationFailure.Error));
         var groupId = GroupId.of("g");
         var artifactId = ArtifactId.of("a");
         var version = VersionNumber.of("a");

--- a/maven_plugin/src/test/java/it/IntegrationTestsIT.java
+++ b/maven_plugin/src/test/java/it/IntegrationTestsIT.java
@@ -620,6 +620,17 @@ public class IntegrationTestsIT {
     }
 
     @MavenTest
+    public void environmentalCheckCliOverride(MavenExecutionResult result) throws Exception {
+        // contract: a CLI arg (allowEnvironmentalValidationFailure=true) overrides the stored lockfile
+        // config (allowEnvironmentalValidationFailure=false), so validation succeeds even when the
+        // environment recorded in the lockfile does not match the current environment.
+        System.out.println("Running 'environmentalCheckCliOverride' integration test.");
+        assertThat(result).isSuccessful();
+        String stdout = Files.readString(result.getMavenLog().getStdout());
+        assertThat(stdout.contains("Failed verifying environment.")).isFalse();
+    }
+
+    @MavenTest
     public void externalParentPom(MavenExecutionResult result) throws Exception {
         // contract: a project with an external parent POM (e.g., Spring Boot) should generate
         // a lockfile containing the full parent pom hierarchy with checksums

--- a/maven_plugin/src/test/java/it/IntegrationTestsIT.java
+++ b/maven_plugin/src/test/java/it/IntegrationTestsIT.java
@@ -649,7 +649,8 @@ public class IntegrationTestsIT {
         System.out.println("Running 'environmentalCheckShouldFail' integration test.");
         assertThat(result).isFailure();
         String stdout = Files.readString(result.getMavenLog().getStdout());
-        assertThat(stdout.contains("Failed verifying environment.")).isTrue();
+        assertThat(stdout.contains("Lock file environment does not match project environment."))
+                .isTrue();
     }
 
     @MavenTest

--- a/maven_plugin/src/test/resources-its/it/IntegrationTestsIT/buildExtensionsValidationFail/lockfile.json
+++ b/maven_plugin/src/test/resources-its/it/IntegrationTestsIT/buildExtensionsValidationFail/lockfile.json
@@ -27,14 +27,15 @@
   ],
   "metaData": {
     "config": {
-      "includeMavenPlugins": true,
+      "includeMavenPlugins": false,
       "allowValidationFailure": false,
       "allowPomValidationFailure": true,
       "allowEnvironmentalValidationFailure": true,
       "includeEnvironment": false,
       "reduced": false,
       "checksumMode": "local",
-      "checksumAlgorithm": "SHA-256"
+      "checksumAlgorithm": "SHA-256",
+      "includeMavenExtensions": true
     }
   }
 }

--- a/maven_plugin/src/test/resources-its/it/IntegrationTestsIT/buildExtensionsValidationFail/pom.xml
+++ b/maven_plugin/src/test/resources-its/it/IntegrationTestsIT/buildExtensionsValidationFail/pom.xml
@@ -34,7 +34,6 @@
         </executions>
         <configuration>
           <checksumMode>local</checksumMode>
-          <includeMavenPlugins>true</includeMavenPlugins>
         </configuration>
       </plugin>
     </plugins>

--- a/maven_plugin/src/test/resources-its/it/IntegrationTestsIT/environmentalCheckCliOverride/lockfile.json
+++ b/maven_plugin/src/test/resources-its/it/IntegrationTestsIT/environmentalCheckCliOverride/lockfile.json
@@ -1,0 +1,35 @@
+{
+  "artifactId": "environmental-check-cli-override",
+  "groupId": "com.mycompany.app",
+  "version": "1",
+  "pom": {
+    "groupId": "com.mycompany.app",
+    "artifactId": "environmental-check-cli-override",
+    "version": "1",
+    "relativePath": "pom.xml",
+    "checksumAlgorithm": "SHA-256",
+    "checksum": "0000000000000000000000000000000000000000000000000000000000000000"
+  },
+  "lockFileVersion": 1,
+  "dependencies": [],
+  "mavenPlugins": [],
+  "metaData": {
+    "environment": {
+      "osName": "TamperedOS",
+      "mavenVersion": "0.0.0",
+      "javaVersion": "0.0.0"
+    },
+    "config": {
+      "includeMavenPlugins": false,
+      "allowValidationFailure": false,
+      "allowPomValidationFailure": true,
+      "allowEnvironmentalValidationFailure": false,
+      "includeEnvironment": true,
+      "reduced": false,
+      "mavenLockfileVersion": "5.16.0",
+      "checksumMode": "local",
+      "checksumAlgorithm": "SHA-256"
+    }
+  },
+  "boms": []
+}

--- a/maven_plugin/src/test/resources-its/it/IntegrationTestsIT/environmentalCheckCliOverride/pom.xml
+++ b/maven_plugin/src/test/resources-its/it/IntegrationTestsIT/environmentalCheckCliOverride/pom.xml
@@ -1,0 +1,34 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.mycompany.app</groupId>
+  <artifactId>environmental-check-cli-override</artifactId>
+  <packaging>jar</packaging>
+  <version>1</version>
+  <properties>
+    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <dependencies>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.github.chains-project</groupId>
+        <artifactId>maven-lockfile</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>validate</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <checksumMode>local</checksumMode>
+          <allowEnvironmentalValidationFailure>true</allowEnvironmentalValidationFailure>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>


### PR DESCRIPTION
The changes fix backward-compatible validation for lockfiles generated by older plugin versions. This will also fix #1562.

### Problem

Validating a lockfile generated by an older plugin version with the current plugin (5.16.0) fails with a validation error, even though the project's dependencies haven't changed. The root cause is that 5.16.0 added three new fields to the lockfile format:
  - parentPom on each dependency node and plugin
  - parentPom chains on BOM Pom objects
  - mavenExtensions on the lockfile root

### Solution

 6 flags are added:

1. `includeBoms`
2. `includeParentPom`
3. `includeMavenExtensions`
4. `allowBomValidationFailure`
5. `allowParentPomValidationFailure`
6. `allowMavenExtensionsValidationFailure`

Now, old lockfiles lack `includeParentPom` so the validation will now skip comparing `parentPom` comparison. `allowParentPomValidationFailure` need not be specified. `allowParentPomValidationFailure` is only needed when `includeParentPom` is true.

ToDo:
- [x] README update
- [x] Integration tests
- [x] For new parameters, adapt to #1574 and #1575
- [x] The new parameters should also be added to github action CI #1591 
- [x] Parameter 1, 2, and 3 should be `true` by default.