### PR TITLE
fix: resolve special maven properties in BOMs

### DIFF
--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/checksum/RemoteChecksumCalculator.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/checksum/RemoteChecksumCalculator.java
@@ -232,10 +232,10 @@ public class RemoteChecksumCalculator extends AbstractChecksumCalculator {
             String version = artifact.getVersion();
             String baseVersion = artifact.getBaseVersion();
             String classifier = artifact.getClassifier();
-            if (classifier == null) {
-                classifier = "";
-            } else {
+            if (classifier != null && !classifier.isEmpty()) {
                 classifier = "-" + classifier;
+            } else {
+                classifier = "";
             }
             String extension = artifact.getArtifactHandler().getExtension();
             String filename = artifactId + "-" + version + classifier + "." + extension;

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/resolvers/BomResolutionException.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/resolvers/BomResolutionException.java
@@ -1,0 +1,13 @@
+package io.github.chains_project.maven_lockfile.resolvers;
+
+import org.apache.maven.model.building.ModelBuildingException;
+
+public class BomResolutionException extends RuntimeException {
+    public BomResolutionException(String message) {
+        super(message);
+    }
+
+    public BomResolutionException(String message, ModelBuildingException e) {
+        super(message, e);
+    }
+}

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/resolvers/BomResolver.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/resolvers/BomResolver.java
@@ -55,13 +55,15 @@ public class BomResolver {
         for (Dependency dependency : dependencyManagement.getDependencies()) {
             // A BOM POM always has type=pom and scope=import
             if ("pom".equals(dependency.getType()) && "import".equals(dependency.getScope())) {
-                var resolvedVersion = resolveVersionFromPlaceholder(dependency.getVersion(), project);
-                var bomProjectOptional = projectBuilder.buildFromGav(
-                        dependency.getGroupId(), dependency.getArtifactId(), resolvedVersion);
+                var resolvedVersion = interpolateProperty(dependency.getVersion(), project);
+                var resolvedGroupId = interpolateProperty(dependency.getGroupId(), project);
+                var resolvedArtifactId = interpolateProperty(dependency.getArtifactId(), project);
+                var bomProjectOptional =
+                        projectBuilder.buildFromGav(resolvedGroupId, resolvedArtifactId, resolvedVersion);
 
                 if (bomProjectOptional.isEmpty()) {
-                    PluginLogManager.getLog().warn(String.format("Could not resolve BOM for %s", dependency));
-                    continue;
+                    PluginLogManager.getLog().error(String.format("Could not resolve BOM for %s", dependency));
+                    throw new BomResolutionException("Error resolving BOM pom, fail fast");
                 }
 
                 var bomProject = bomProjectOptional.get();
@@ -107,19 +109,27 @@ public class BomResolver {
         });
     }
 
-    private String resolveVersionFromPlaceholder(String version, MavenProject project) {
-        if (version != null && version.startsWith("${") && version.endsWith("}")) {
-            String propertyName = version.substring(2, version.length() - 1);
+    /** Limitation
+     *  This does not work when there are multiple placeholders in the text like ${main.version.number}${minor.version.number}
+     *  I am not aware of any project which could use it like that.*/
+    private String interpolateProperty(String textOrPlaceholder, MavenProject project) {
+        if (textOrPlaceholder != null && textOrPlaceholder.startsWith("${") && textOrPlaceholder.endsWith("}")) {
+            String propertyName = textOrPlaceholder.substring(2, textOrPlaceholder.length() - 1);
 
             // Check project properties (interpolated model has all properties resolved)
-            var resolvedVersion = project.getModel().getProperties().getProperty(propertyName);
+            var propertyValue = project.getModel().getProperties().getProperty(propertyName);
 
-            if (resolvedVersion != null) {
-                return resolvedVersion;
+            if (propertyValue != null) {
+                return propertyValue;
+            }
+            if ("project.version".equals(propertyName)) {
+                return project.getVersion();
+            } else if ("project.groupId".equals(propertyName)) {
+                return project.getGroupId();
             }
         }
 
-        return version;
+        return textOrPlaceholder;
     }
 
     private Pom resolveBomParents(MavenProject start) {

--- a/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/resolvers/ProjectBuilder.java
+++ b/maven_plugin/src/main/java/io/github/chains_project/maven_lockfile/resolvers/ProjectBuilder.java
@@ -11,6 +11,7 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.factory.ArtifactFactory;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.building.ModelBuildingRequest;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.*;
 import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolver;
@@ -38,7 +39,7 @@ public class ProjectBuilder {
      * @return an Optional that contains the MavenProject in case it was successfully built.
      */
     public Optional<MavenProject> buildFromGav(String groupId, String artifactId, String version) {
-        log.debug(String.format("Resolving dependencies for%s:%s:%s", groupId, artifactId, version));
+        log.debug(String.format("Resolving dependencies for %s:%s:%s", groupId, artifactId, version));
 
         var pomFileOptional = lookForPomFileInLocalRepository(groupId, artifactId, version);
 
@@ -114,6 +115,7 @@ public class ProjectBuilder {
             @SuppressWarnings("deprecation")
             org.apache.maven.project.ProjectBuilder projectBuilder =
                     session.getContainer().lookup(org.apache.maven.project.ProjectBuilder.class);
+            buildingRequest.setValidationLevel(ModelBuildingRequest.VALIDATION_LEVEL_MINIMAL);
             ProjectBuildingResult result = projectBuilder.build(pomFile, buildingRequest);
 
             if (result.getProject() == null) {

--- a/maven_plugin/src/test/java/io/github/chains_project/maven_lockfile/checksum/RemoteChecksumCalculatorTest.java
+++ b/maven_plugin/src/test/java/io/github/chains_project/maven_lockfile/checksum/RemoteChecksumCalculatorTest.java
@@ -4,6 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.io.BaseEncoding;
 import com.sun.net.httpserver.HttpServer;
+import io.github.chains_project.maven_lockfile.data.RepositoryId;
+import io.github.chains_project.maven_lockfile.data.ResolvedUrl;
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -25,25 +28,14 @@ class RemoteChecksumCalculatorTest {
     private static final byte[] ARTIFACT = "dummy-artifact-content".getBytes(StandardCharsets.UTF_8);
 
     private HttpServer server;
-    private String repositoryUrl;
+    private String serverUrl;
 
     @BeforeEach
-    void startServer() throws Exception {
-        // A missing remote .sha256 (404) forces a download that is verified against the .sha1 file,
-        // which a proxying repository manager may serve in UPPER-CASE hex. See issue #1599.
+    void startServer() throws IOException {
+        // Each test registers its own context on this shared local HTTP server.
         server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
-        server.createContext("/", exchange -> {
-            String path = exchange.getRequestURI().getPath();
-            byte[] body = path.endsWith(".jar.sha1")
-                    ? hex("SHA-1").toUpperCase(Locale.ROOT).getBytes(StandardCharsets.UTF_8)
-                    : path.endsWith(".jar") ? ARTIFACT : new byte[0];
-            exchange.sendResponseHeaders(body.length == 0 ? 404 : 200, body.length == 0 ? -1 : body.length);
-            try (var os = exchange.getResponseBody()) {
-                os.write(body);
-            }
-        });
         server.start();
-        repositoryUrl = "http://127.0.0.1:" + server.getAddress().getPort() + "/";
+        serverUrl = "http://127.0.0.1:" + server.getAddress().getPort();
     }
 
     @AfterEach
@@ -55,9 +47,22 @@ class RemoteChecksumCalculatorTest {
 
     @Test
     void acceptsUpperCaseRemoteSha1() {
+        // A missing remote .sha256 (404) forces a download that is verified against the .sha1 file,
+        // which a proxying repository manager may serve in UPPER-CASE hex. See issue #1599.
+        server.createContext("/", exchange -> {
+            String path = exchange.getRequestURI().getPath();
+            byte[] body = path.endsWith(".jar.sha1")
+                    ? hex("SHA-1").toUpperCase(Locale.ROOT).getBytes(StandardCharsets.UTF_8)
+                    : path.endsWith(".jar") ? ARTIFACT : new byte[0];
+            exchange.sendResponseHeaders(body.length == 0 ? 404 : 200, body.length == 0 ? -1 : body.length);
+            try (var os = exchange.getResponseBody()) {
+                os.write(body);
+            }
+        });
+
         var repository = new MavenArtifactRepository(
                 "test-repo",
-                repositoryUrl,
+                serverUrl + "/",
                 new DefaultRepositoryLayout(),
                 new ArtifactRepositoryPolicy(),
                 new ArtifactRepositoryPolicy());
@@ -77,6 +82,48 @@ class RemoteChecksumCalculatorTest {
         // A case-sensitive comparison rejects the upper-case .sha1 and yields ""; case-insensitive
         // matching accepts the artifact and returns its SHA-256.
         assertThat(calculator.calculateArtifactChecksum(artifact)).isEqualTo(hex("SHA-256"));
+    }
+
+    @Test
+    void getArtifactResolvedField_returnsResolvedUrlForExistingArtifact() {
+        // Arrange: mock a successful HEAD response for an artifact
+        String groupId = "junit";
+        String artifactId = "junit";
+        String version = "4.13.2";
+        String repositoryId = "test-repo";
+
+        String artifactPath = "/junit/junit/4.13.2/junit-4.13.2.jar";
+        server.createContext(artifactPath, exchange -> {
+            // Return 200 OK for HEAD request
+            exchange.sendResponseHeaders(200, -1);
+            exchange.close();
+        });
+
+        DefaultArtifact artifact = new DefaultArtifact(
+                groupId,
+                artifactId,
+                VersionRange.createFromVersion(version),
+                "compile",
+                "jar",
+                "",
+                new DefaultArtifactHandler("jar"));
+
+        DefaultProjectBuildingRequest buildingRequest = new DefaultProjectBuildingRequest();
+        MavenArtifactRepository testRepo = new MavenArtifactRepository();
+        testRepo.setId(repositoryId);
+        testRepo.setUrl(serverUrl);
+        testRepo.setLayout(new DefaultRepositoryLayout());
+        buildingRequest.setRemoteRepositories(List.of(testRepo));
+
+        RemoteChecksumCalculator calculator = new RemoteChecksumCalculator("SHA-256", buildingRequest, buildingRequest);
+
+        // Act
+        RepositoryInformation result = calculator.getArtifactResolvedField(artifact);
+
+        // Assert: existing artifact should return resolved URL and repository ID
+        String expectedUrl = serverUrl + artifactPath;
+        assertThat(result.getResolvedUrl()).isEqualTo(ResolvedUrl.of(expectedUrl));
+        assertThat(result.getRepositoryId()).isEqualTo(RepositoryId.of(repositoryId));
     }
 
     private static String hex(String algorithm) {

--- a/maven_plugin/src/test/java/io/github/chains_project/maven_lockfile/resolvers/BomResolverTest.java
+++ b/maven_plugin/src/test/java/io/github/chains_project/maven_lockfile/resolvers/BomResolverTest.java
@@ -1,0 +1,469 @@
+package io.github.chains_project.maven_lockfile.resolvers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+import io.github.chains_project.maven_lockfile.checksum.AbstractChecksumCalculator;
+import io.github.chains_project.maven_lockfile.checksum.RepositoryInformation;
+import io.github.chains_project.maven_lockfile.data.ArtifactId;
+import io.github.chains_project.maven_lockfile.data.GroupId;
+import io.github.chains_project.maven_lockfile.data.Pom;
+import io.github.chains_project.maven_lockfile.data.VersionNumber;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.building.DefaultModelBuilder;
+import org.apache.maven.model.building.DefaultModelBuilderFactory;
+import org.apache.maven.model.building.DefaultModelBuildingRequest;
+import org.apache.maven.model.building.ModelBuildingException;
+import org.apache.maven.model.building.ModelBuildingRequest;
+import org.apache.maven.model.building.ModelBuildingResult;
+import org.apache.maven.model.building.ModelSource;
+import org.apache.maven.model.building.StringModelSource;
+import org.apache.maven.model.resolution.ModelResolver;
+import org.apache.maven.project.MavenProject;
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class BomResolverTest {
+
+    private MavenSession session;
+    private List<ArtifactRepository> repositories;
+    private AbstractChecksumCalculator checksumCalculator;
+
+    @BeforeEach
+    void setUp() {
+        session = mock(MavenSession.class);
+        repositories = new ArrayList<>();
+        checksumCalculator = mock(AbstractChecksumCalculator.class);
+
+        // Mock checksum calculator to return empty/unresolved values
+        when(checksumCalculator.getArtifactResolvedField(org.mockito.ArgumentMatchers.any(Artifact.class)))
+                .thenReturn(RepositoryInformation.Unresolved());
+        when(checksumCalculator.calculateArtifactChecksum(org.mockito.ArgumentMatchers.any(Artifact.class)))
+                .thenReturn("");
+        when(checksumCalculator.getChecksumAlgorithm()).thenReturn("SHA-256");
+    }
+
+    @Test
+    void resolveForProject_interpolatesCustomProperty() {
+        // Arrange: Create a Maven project with a custom property
+        Model model = new Model();
+        model.setModelVersion("4.0.0");
+        model.setGroupId("com.example");
+        model.setArtifactId("test-project");
+        model.setVersion("1.0.0");
+
+        // Define custom property maven-lockfile-test-version = 1.1.1
+        Properties properties = new Properties();
+        properties.setProperty("maven-lockfile-test-version", "1.1.1");
+        model.setProperties(properties);
+
+        // Create dependencyManagement with a BOM using ${maven-lockfile-test-version}
+        DependencyManagement depMgmt = new DependencyManagement();
+        Dependency bomDep = new Dependency();
+        bomDep.setGroupId("com.example.bom");
+        bomDep.setArtifactId("test-bom");
+        bomDep.setVersion("${maven-lockfile-test-version}");
+        bomDep.setType("pom");
+        bomDep.setScope("import");
+        depMgmt.addDependency(bomDep);
+        model.setDependencyManagement(depMgmt);
+
+        // Build MavenProject with interpolated model
+        MavenProject project = buildMavenProject(model);
+
+        BomResolver resolver = new BomResolver(session, repositories, checksumCalculator);
+
+        // Act: Verify buildFromGav is called with the interpolated version "1.1.1"
+        try (var mockedProjectBuilder = mockConstruction(ProjectBuilder.class, (mock, context) -> {
+            when(mock.buildFromGav(anyString(), anyString(), anyString())).thenAnswer(invocation -> {
+                String version = invocation.getArgument(2);
+                assertThat(version)
+                        .as("Property interpolation should have resolved ${maven-lockfile-test-version} to 1.1.1")
+                        .isEqualTo("1.1.1");
+                return Optional.empty();
+            });
+        })) {
+            assertThatThrownBy(() -> resolver.resolveForProject(project)).isInstanceOf(BomResolutionException.class);
+
+            assertThat(mockedProjectBuilder.constructed()).hasSize(1);
+            verify(mockedProjectBuilder.constructed().get(0)).buildFromGav("com.example.bom", "test-bom", "1.1.1");
+        }
+    }
+
+    @Test
+    void resolveForProject_interpolatesProjectVersion() {
+        // Arrange: Create a Maven project using ${project.version}
+        Model model = new Model();
+        model.setModelVersion("4.0.0");
+        model.setGroupId("com.example");
+        model.setArtifactId("test-project");
+        model.setVersion("2.0.0");
+
+        // Create dependencyManagement with a BOM using ${project.version}
+        DependencyManagement depMgmt = new DependencyManagement();
+        Dependency bomDep = new Dependency();
+        bomDep.setGroupId("com.example.bom");
+        bomDep.setArtifactId("test-bom");
+        bomDep.setVersion("${project.version}");
+        bomDep.setType("pom");
+        bomDep.setScope("import");
+        depMgmt.addDependency(bomDep);
+        model.setDependencyManagement(depMgmt);
+
+        // Build MavenProject with interpolated model
+        MavenProject project = buildMavenProject(model);
+
+        BomResolver resolver = new BomResolver(session, repositories, checksumCalculator);
+
+        // Act: Verify buildFromGav is called with the interpolated version "2.0.0"
+        try (var mockedProjectBuilder = mockConstruction(ProjectBuilder.class, (mock, context) -> {
+            when(mock.buildFromGav(anyString(), anyString(), anyString())).thenAnswer(invocation -> {
+                String version = invocation.getArgument(2);
+                assertThat(version)
+                        .as("Property interpolation should have resolved ${project.version} to 2.0.0")
+                        .isEqualTo("2.0.0");
+                return Optional.empty();
+            });
+        })) {
+            assertThatThrownBy(() -> resolver.resolveForProject(project)).isInstanceOf(BomResolutionException.class);
+
+            assertThat(mockedProjectBuilder.constructed()).hasSize(1);
+            verify(mockedProjectBuilder.constructed().get(0)).buildFromGav("com.example.bom", "test-bom", "2.0.0");
+        }
+    }
+
+    @Test
+    void resolveForProject_interpolatesProjectGroupId() {
+        // Arrange: Create a Maven project using ${project.groupId}
+        Model model = new Model();
+        model.setModelVersion("4.0.0");
+        model.setGroupId("io.github.test");
+        model.setArtifactId("test-project");
+        model.setVersion("1.0.0");
+
+        // Create dependencyManagement with a BOM using ${project.groupId}
+        DependencyManagement depMgmt = new DependencyManagement();
+        Dependency bomDep = new Dependency();
+        bomDep.setGroupId("${project.groupId}");
+        bomDep.setArtifactId("test-bom");
+        bomDep.setVersion("1.0.0");
+        bomDep.setType("pom");
+        bomDep.setScope("import");
+        depMgmt.addDependency(bomDep);
+        model.setDependencyManagement(depMgmt);
+
+        // Build MavenProject with interpolated model
+        MavenProject project = buildMavenProject(model);
+
+        BomResolver resolver = new BomResolver(session, repositories, checksumCalculator);
+
+        // Act: Verify buildFromGav is called with the interpolated groupId "io.github.test"
+        try (var mockedProjectBuilder = mockConstruction(ProjectBuilder.class, (mock, context) -> {
+            when(mock.buildFromGav(anyString(), anyString(), anyString())).thenAnswer(invocation -> {
+                String groupId = invocation.getArgument(0);
+                assertThat(groupId)
+                        .as("Property interpolation should have resolved ${project.groupId} to io.github.test")
+                        .isEqualTo("io.github.test");
+                return Optional.empty();
+            });
+        })) {
+            assertThatThrownBy(() -> resolver.resolveForProject(project)).isInstanceOf(BomResolutionException.class);
+
+            assertThat(mockedProjectBuilder.constructed()).hasSize(1);
+            verify(mockedProjectBuilder.constructed().get(0)).buildFromGav("io.github.test", "test-bom", "1.0.0");
+        }
+    }
+
+    @Test
+    void resolveForProject_returnsEmptySetWhenNoDependencyManagement() {
+        // Arrange: Create a Maven project without dependencyManagement
+        Model model = new Model();
+        model.setGroupId("com.example");
+        model.setArtifactId("test-project");
+        model.setVersion("1.0.0");
+
+        MavenProject project = new MavenProject(model);
+        project.setOriginalModel(model);
+        BomResolver resolver = new BomResolver(session, repositories, checksumCalculator);
+
+        // Act
+        Set<Pom> result = resolver.resolveForProject(project);
+
+        // Assert
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void resolveForProject_interpolatesPropertiesInNestedTransitiveBom() {
+        // Arrange: Create a parent project with properties
+        Model parentModel = new Model();
+        parentModel.setModelVersion("4.0.0");
+        parentModel.setGroupId("com.example");
+        parentModel.setArtifactId("parent-project");
+        parentModel.setVersion("1.0.0");
+
+        Properties parentProperties = new Properties();
+        parentProperties.setProperty("bom.version", "2.0.0");
+        parentProperties.setProperty("transitive.bom.version", "3.0.0");
+        parentModel.setProperties(parentProperties);
+        // Parent BOM imports another BOM using ${bom.version}
+        DependencyManagement parentDepMgmt = new DependencyManagement();
+        Dependency parentBomDep = new Dependency();
+        parentBomDep.setGroupId("com.example");
+        parentBomDep.setArtifactId("parent-bom");
+        parentBomDep.setVersion("${bom.version}");
+        parentBomDep.setType("pom");
+        parentBomDep.setScope("import");
+        parentDepMgmt.addDependency(parentBomDep);
+        parentModel.setDependencyManagement(parentDepMgmt);
+
+        // Create the nested BOM that imports a transitive BOM
+        Model nestedBomModel = new Model();
+        nestedBomModel.setModelVersion("4.0.0");
+        nestedBomModel.setGroupId("com.example");
+        nestedBomModel.setArtifactId("parent-bom");
+        nestedBomModel.setVersion("2.0.0");
+
+        Properties nestedBomProperties = new Properties();
+        nestedBomProperties.setProperty("transitive.artifact", "transitive-bom");
+        nestedBomModel.setProperties(nestedBomProperties);
+
+        DependencyManagement nestedDepMgmt = new DependencyManagement();
+        Dependency transitiveBomDep = new Dependency();
+        transitiveBomDep.setGroupId("com.example");
+        transitiveBomDep.setArtifactId("${transitive.artifact}");
+        transitiveBomDep.setVersion("${project.version}"); // Uses project.version from nested BOM
+        transitiveBomDep.setType("pom");
+        transitiveBomDep.setScope("import");
+        nestedDepMgmt.addDependency(transitiveBomDep);
+        nestedBomModel.setDependencyManagement(nestedDepMgmt);
+
+        // Create the transitive BOM (leaf)
+        Model transitiveBomModel = new Model();
+        transitiveBomModel.setModelVersion("4.0.0");
+        transitiveBomModel.setGroupId("com.example");
+        transitiveBomModel.setArtifactId("transitive-bom");
+        transitiveBomModel.setVersion("2.0.0");
+
+        // Build MavenProjects with interpolation
+        MavenProject parentProject = buildMavenProject(parentModel);
+        MavenProject nestedBomProject = buildMavenProject(nestedBomModel);
+        MavenProject transitiveBomProject = buildMavenProject(transitiveBomModel);
+
+        // Ensure artifacts are not null (MavenProject constructor should set them, but let's be explicit)
+        if (nestedBomProject.getArtifact() == null) {
+            nestedBomProject.setArtifact(new org.apache.maven.artifact.DefaultArtifact(
+                    "com.example",
+                    "parent-bom",
+                    "2.0.0",
+                    "compile",
+                    "pom",
+                    "",
+                    new org.apache.maven.artifact.handler.DefaultArtifactHandler("pom")));
+        }
+        if (transitiveBomProject.getArtifact() == null) {
+            transitiveBomProject.setArtifact(new org.apache.maven.artifact.DefaultArtifact(
+                    "com.example",
+                    "transitive-bom",
+                    "2.0.0",
+                    "compile",
+                    "pom",
+                    "",
+                    new org.apache.maven.artifact.handler.DefaultArtifactHandler("pom")));
+        }
+
+        // Mock ProjectBuilder to return our test BOMs when buildFromGav is called
+        try (var mockedProjectBuilder = mockConstruction(ProjectBuilder.class, (mock, context) -> {
+            // When buildFromGav is called with interpolated coordinates, return the appropriate BOM
+            // The key here is that if properties are interpolated correctly:
+            // - "${bom.version}" should become "2.0.0"
+            // - "${transitive.artifact}" should become "transitive-bom"
+            // - "${project.version}" should become "2.0.0" (from nested BOM)
+
+            when(mock.buildFromGav(anyString(), anyString(), anyString())).thenAnswer(invocation -> {
+                String groupId = invocation.getArgument(0);
+                String artifactId = invocation.getArgument(1);
+                String version = invocation.getArgument(2);
+
+                // Parent BOM: com.example:parent-bom:2.0.0 (from ${bom.version})
+                if ("com.example".equals(groupId) && "parent-bom".equals(artifactId) && "2.0.0".equals(version)) {
+                    return Optional.of(nestedBomProject);
+                }
+
+                // Transitive BOM: com.example:transitive-bom:2.0.0
+                // (artifactId from ${transitive.artifact}, version from ${project.version})
+                if ("com.example".equals(groupId) && "transitive-bom".equals(artifactId) && "2.0.0".equals(version)) {
+                    return Optional.of(transitiveBomProject);
+                }
+
+                // If we get unresolved properties, the test should fail
+                if (groupId.contains("${") || artifactId.contains("${") || version.contains("${")) {
+                    throw new AssertionError(
+                            "Property not interpolated: " + groupId + ":" + artifactId + ":" + version);
+                }
+
+                return Optional.empty();
+            });
+        })) {
+
+            BomResolver resolver = new BomResolver(session, repositories, checksumCalculator);
+
+            // Act
+            Set<Pom> result = resolver.resolveForProject(parentProject);
+
+            // Assert
+            assertThat(result).isNotEmpty();
+            assertThat(result).hasSize(1); // Parent BOM was resolved
+
+            // Verify the parent BOM was resolved with interpolated version "2.0.0"
+            Pom parentBom = result.iterator().next();
+            assertThat(parentBom.getGroupId()).isEqualTo(GroupId.of("com.example"));
+            assertThat(parentBom.getArtifactId()).isEqualTo(ArtifactId.of("parent-bom"));
+            assertThat(parentBom.getVersion()).isEqualTo(VersionNumber.of("2.0.0"));
+
+            // Verify the nested BOM contains the transitive BOM
+            assertThat(parentBom.getBoms()).isNotEmpty();
+            assertThat(parentBom.getBoms()).hasSize(1);
+
+            Pom transitiveBom = parentBom.getBoms().iterator().next();
+            assertThat(transitiveBom.getArtifactId()).isEqualTo(ArtifactId.of("transitive-bom"));
+            assertThat(transitiveBom.getVersion()).isEqualTo(VersionNumber.of("2.0.0"));
+        }
+    }
+
+    @Test
+    void resolveForProject_returnsEmptySetWhenNoBomDependencies() {
+        // Arrange: Create a Maven project with dependencyManagement but no BOM imports
+        Model model = getModelArtifactPlaceholder();
+
+        MavenProject project = new MavenProject(model);
+        project.setOriginalModel(model);
+        BomResolver resolver = new BomResolver(session, repositories, checksumCalculator);
+
+        // Act
+        Set<Pom> result = resolver.resolveForProject(project);
+
+        // Assert
+        assertThat(result).isEmpty();
+    }
+
+    private static @NonNull Model getModelArtifactPlaceholder() {
+        Model model = new Model();
+        model.setGroupId("com.example");
+        model.setArtifactId("test-project");
+        model.setVersion("1.0.0");
+
+        DependencyManagement depMgmt = new DependencyManagement();
+        Dependency regularDep = new Dependency();
+        regularDep.setGroupId("junit");
+        regularDep.setArtifactId("${junit.artifactId}");
+        regularDep.setVersion("4.13.2");
+        regularDep.setType("jar"); // Not a BOM (type != pom)
+        regularDep.setScope("test");
+        depMgmt.addDependency(regularDep);
+        model.setDependencyManagement(depMgmt);
+        return model;
+    }
+
+    /**
+     * Build a MavenProject from a Model with property interpolation.
+     * Uses ModelBuilder to get the effective (interpolated) model.
+     */
+    private @NonNull MavenProject buildMavenProject(Model myModel) {
+        try {
+            // Use ModelBuilder to interpolate properties in the model
+            DefaultModelBuilder modelBuilder = new DefaultModelBuilderFactory().newInstance();
+            DefaultModelBuildingRequest request = new DefaultModelBuildingRequest();
+
+            // Set the raw model
+            request.setRawModel(myModel);
+
+            // Configure the request
+            request.setSystemProperties(System.getProperties());
+            request.setUserProperties(new Properties());
+            request.setValidationLevel(ModelBuildingRequest.VALIDATION_LEVEL_MINIMAL);
+            request.setProcessPlugins(false);
+            request.setTwoPhaseBuilding(false);
+
+            // Add a no-op ModelResolver to prevent trying to resolve import BOMs
+            request.setModelResolver(new NoOpModelResolver());
+
+            // Build the model - this interpolates properties
+            ModelBuildingResult result = modelBuilder.build(request);
+            Model effectiveModel = result.getEffectiveModel();
+
+            // Create MavenProject with the interpolated model
+            MavenProject project = new MavenProject(effectiveModel);
+            project.setOriginalModel(myModel);
+
+            return project;
+
+        } catch (ModelBuildingException e) {
+            throw new BomResolutionException("Failed to build MavenProject for testing", e);
+        }
+    }
+
+    /**
+     * No-op ModelResolver that returns minimal dummy POMs.
+     * This allows property interpolation to work without accessing repositories.
+     */
+    private static class NoOpModelResolver implements ModelResolver {
+        @Override
+        public ModelSource resolveModel(String groupId, String artifactId, String version) {
+            // Return a minimal POM to prevent null errors
+            return createDummyModelSource(groupId, artifactId, version);
+        }
+
+        @Override
+        public ModelSource resolveModel(org.apache.maven.model.Parent parent) {
+            return createDummyModelSource(parent.getGroupId(), parent.getArtifactId(), parent.getVersion());
+        }
+
+        @Override
+        public ModelSource resolveModel(org.apache.maven.model.Dependency dependency) {
+            return createDummyModelSource(dependency.getGroupId(), dependency.getArtifactId(), dependency.getVersion());
+        }
+
+        private ModelSource createDummyModelSource(String groupId, String artifactId, String version) {
+            // Create a minimal POM XML
+            String pomXml = String.format(
+                    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                            + "<project xmlns=\"http://maven.apache.org/POM/4.0.0\">\n"
+                            + "  <modelVersion>4.0.0</modelVersion>\n"
+                            + "  <groupId>%s</groupId>\n"
+                            + "  <artifactId>%s</artifactId>\n"
+                            + "  <version>%s</version>\n"
+                            + "</project>",
+                    groupId, artifactId, version);
+            return new StringModelSource(pomXml, groupId + ":" + artifactId + ":" + version);
+        }
+
+        @Override
+        public void addRepository(org.apache.maven.model.Repository repository) {
+            // No-op
+        }
+
+        @Override
+        public void addRepository(org.apache.maven.model.Repository repository, boolean replace) {
+            // No-op
+        }
+
+        @Override
+        public ModelResolver newCopy() {
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
This fixes wrong property resolution in BOM poms when they have those Maven properties defined:
${project.version} and ${project.groupId}

Fail fast when BOM pom is not resolved - throw an Exception

Allow deployed within - handle very old dependencies
Some old versions of libraries within a projects dependency tree were silently (with warning only) skipped in a generated lockfile. It turns they have unsupported POM file format. With deployed
Setting buildingRequest.setValidationLevel(ModelBuildingRequest.VALIDATION_LEVEL_MINIMAL) will allow those.