### PR TITLE
fix: handle no prior beta versions in beta release workflow

### DIFF
--- a/.github/workflows/jreleaser-beta.yml
+++ b/.github/workflows/jreleaser-beta.yml
@@ -63,7 +63,7 @@ jobs:
 
           LAST_BETA_NUMBER="$(curl -sf "https://repo1.maven.org/maven2/io/github/chains-project/maven-lockfile/maven-metadata.xml" | \
             grep -oP "<version>${ESCAPED_VERSION}-beta-\K[0-9]+" | \
-            sort -n | tail -1)"
+            sort -n | tail -1 || true)"
 
           if [[ -z "${LAST_BETA_NUMBER:-}" || "$LAST_BETA_NUMBER" == "null" ]]; then
             LAST_BETA_NUMBER=0


### PR DESCRIPTION
When no prior betas exist for the current version on Maven Central, grep exits with code 1, killing the script under set -euo pipefail before the LAST_BETA_NUMBER=0 fallback runs. Adding   `|| true` to the grep pipeline suppresses the no-match failure and lets the existing empty-string check handle it correctly.