### PR TITLE
refactor: break circular dependency between DependencyGraph and LockFileFacade

### DIFF
--- a/src/main/java/io/github/chains_project/maven_lockfile/LockFileFacade.java
+++ b/src/main/java/io/github/chains_project/maven_lockfile/LockFileFacade.java
@@ -565,8 +565,8 @@ public class LockFileFacade {
             String checksum;
             ResolvedUrl resolved = null;
             RepositoryId repoId = null;
-            if (isReactorLocalSnapshot(
-                    project.getGroupId(), project.getArtifactId(), project.getVersion(), reactorGavs)) {
+            if (reactorGavs.contains(
+                    project.getGroupId() + ":" + project.getArtifactId() + ":" + project.getVersion())) {
                 // Reactor-local SNAPSHOT pom is rebuilt every run, so its checksum drifts
                 // and can't be pinned; leave it empty (releases still get a real checksum).
                 checksum = "";
@@ -638,22 +638,11 @@ public class LockFileFacade {
         return "RELEASE".equals(version) || "LATEST".equals(version);
     }
 
-    /** GAVs of the modules built in the current reactor. */
-    private static Set<String> reactorGavs(MavenSession session) {
+    /** GAVs of the SNAPSHOT modules built in the current reactor. */
+    static Set<String> reactorGavs(MavenSession session) {
         return session.getProjects().stream()
+                .filter(p -> ArtifactUtils.isSnapshot(p.getVersion()))
                 .map(p -> p.getGroupId() + ":" + p.getArtifactId() + ":" + p.getVersion())
                 .collect(Collectors.toSet());
-    }
-
-    /**
-     * Whether a SNAPSHOT artifact is a module built in the current reactor. Reactor-local
-     * SNAPSHOTs are rebuilt on every run, so their checksums drift and cannot be pinned.
-     */
-    public static boolean isReactorLocalSnapshot(
-            String groupId, String artifactId, String baseVersion, Set<String> reactorGavs) {
-        if (!ArtifactUtils.isSnapshot(baseVersion)) {
-            return false;
-        }
-        return reactorGavs.contains(groupId + ":" + artifactId + ":" + baseVersion);
     }
 }

--- a/src/main/java/io/github/chains_project/maven_lockfile/graph/DependencyGraph.java
+++ b/src/main/java/io/github/chains_project/maven_lockfile/graph/DependencyGraph.java
@@ -2,7 +2,6 @@ package io.github.chains_project.maven_lockfile.graph;
 
 import com.google.common.graph.Graph;
 import com.google.common.graph.MutableGraph;
-import io.github.chains_project.maven_lockfile.LockFileFacade;
 import io.github.chains_project.maven_lockfile.checksum.AbstractChecksumCalculator;
 import io.github.chains_project.maven_lockfile.checksum.RepositoryInformation;
 import io.github.chains_project.maven_lockfile.data.ArtifactId;
@@ -134,12 +133,8 @@ public class DependencyGraph {
         // Reactor-local SNAPSHOTs are rebuilt every run, so their checksum drifts and
         // can't be pinned; leave it empty (releases still get a real checksum). See #1610.
         var nodeArtifact = node.getArtifact();
-        var checksum = isRoot
-                        || LockFileFacade.isReactorLocalSnapshot(
-                                nodeArtifact.getGroupId(),
-                                nodeArtifact.getArtifactId(),
-                                nodeArtifact.getBaseVersion(),
-                                reactorGavs)
+        var reactorGav = nodeArtifact.getGroupId() + ":" + nodeArtifact.getArtifactId() + ":" + nodeArtifact.getBaseVersion();
+        var checksum = isRoot || reactorGavs.contains(reactorGav)
                 ? ""
                 : calc.calculateArtifactChecksum(node.getArtifact());
         var scope = MavenScope.fromString(node.getArtifact().getScope());

--- a/src/main/java/io/github/chains_project/maven_lockfile/graph/DependencyGraph.java
+++ b/src/main/java/io/github/chains_project/maven_lockfile/graph/DependencyGraph.java
@@ -133,10 +133,10 @@ public class DependencyGraph {
         // Reactor-local SNAPSHOTs are rebuilt every run, so their checksum drifts and
         // can't be pinned; leave it empty (releases still get a real checksum). See #1610.
         var nodeArtifact = node.getArtifact();
-        var reactorGav = nodeArtifact.getGroupId() + ":" + nodeArtifact.getArtifactId() + ":" + nodeArtifact.getBaseVersion();
-        var checksum = isRoot || reactorGavs.contains(reactorGav)
-                ? ""
-                : calc.calculateArtifactChecksum(node.getArtifact());
+        var reactorGav =
+                nodeArtifact.getGroupId() + ":" + nodeArtifact.getArtifactId() + ":" + nodeArtifact.getBaseVersion();
+        var checksum =
+                isRoot || reactorGavs.contains(reactorGav) ? "" : calc.calculateArtifactChecksum(node.getArtifact());
         var scope = MavenScope.fromString(node.getArtifact().getScope());
         PluginLogManager.getLog().debug(String.format("Resolving repository information for %s", node.toNodeString()));
         var repositoryInformation =


### PR DESCRIPTION
Follows up on the review comment in #1613 (https://github.com/chains-project/maven-lockfile/pull/1613#discussion_r3664246530).

`DependencyGraph` was importing `LockFileFacade` to call `isReactorLocalSnapshot`, while `LockFileFacade` already imports `DependencyGraph` — a circular class dependency.

Fix: pre-filter reactor GAVs to SNAPSHOTs in `LockFileFacade.reactorGavs()`. `DependencyGraph` then uses a plain `Set.contains()` with no import of `LockFileFacade`, and the `isReactorLocalSnapshot` public static method is removed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVGKZF4fFbjcBaUy8eQUX7)_