### PR TITLE
fix: report checksum for inital project

### DIFF
--- a/src/main/java/io/github/chains_project/maven_lockfile/LockFileFacade.java
+++ b/src/main/java/io/github/chains_project/maven_lockfile/LockFileFacade.java
@@ -639,10 +639,8 @@ public class LockFileFacade {
     }
 
     /**
-     * GAVs of the SNAPSHOT modules built in the current reactor. A build with a single
-     * project isn't a reactor at all, so it never contributes reactor-local GAVs - otherwise
-     * a single-module SNAPSHOT project would treat its own pom as a "sibling" and blank its
-     * checksum on every run.
+     * GAVs of the SNAPSHOT modules built in the current reactor. If there's only one
+     * project, it's the root project the pom is being generated for, not a sibling module.
      */
     static Set<String> reactorGavs(MavenSession session) {
         List<MavenProject> projects = session.getProjects();

--- a/src/main/java/io/github/chains_project/maven_lockfile/LockFileFacade.java
+++ b/src/main/java/io/github/chains_project/maven_lockfile/LockFileFacade.java
@@ -638,9 +638,18 @@ public class LockFileFacade {
         return "RELEASE".equals(version) || "LATEST".equals(version);
     }
 
-    /** GAVs of the SNAPSHOT modules built in the current reactor. */
+    /**
+     * GAVs of the SNAPSHOT modules built in the current reactor. A build with a single
+     * project isn't a reactor at all, so it never contributes reactor-local GAVs - otherwise
+     * a single-module SNAPSHOT project would treat its own pom as a "sibling" and blank its
+     * checksum on every run.
+     */
     static Set<String> reactorGavs(MavenSession session) {
-        return session.getProjects().stream()
+        List<MavenProject> projects = session.getProjects();
+        if (projects.size() <= 1) {
+            return Set.of();
+        }
+        return projects.stream()
                 .filter(p -> ArtifactUtils.isSnapshot(p.getVersion()))
                 .map(p -> p.getGroupId() + ":" + p.getArtifactId() + ":" + p.getVersion())
                 .collect(Collectors.toSet());

--- a/src/test/java/it/IntegrationTestsIT.java
+++ b/src/test/java/it/IntegrationTestsIT.java
@@ -105,6 +105,20 @@ public class IntegrationTestsIT {
         assertThat(lockFile.getPom().getParent().getChecksum()).isEmpty();
     }
 
+    @MavenTest
+    public void singleModuleSnapshotShouldKeepOwnPomChecksum(MavenExecutionResult result) throws Exception {
+        // contract: reactor-local snapshot detection must not treat the project's own pom
+        // as a sibling reactor module. In a single-module build the project is the only
+        // member of session.getProjects(), so a SNAPSHOT version must not blank out its
+        // own pom checksum the way a genuine sibling reactor dependency's would. See #1616.
+        System.out.println("Running 'singleModuleSnapshotShouldKeepOwnPomChecksum' integration test.");
+        assertThat(result).isSuccessful();
+        Path lockFilePath = findFile(result, "lockfile.json");
+        assertThat(lockFilePath).exists();
+        var lockFile = LockFile.readLockFile(lockFilePath);
+        assertThat(lockFile.getPom().getChecksum()).isNotEmpty();
+    }
+
     @Nested
     class SpecialVersionDependencyResolution {
         @MavenTest

--- a/src/test/resources-its/it/IntegrationTestsIT/singleModuleSnapshotShouldKeepOwnPomChecksum/pom.xml
+++ b/src/test/resources-its/it/IntegrationTestsIT/singleModuleSnapshotShouldKeepOwnPomChecksum/pom.xml
@@ -1,0 +1,35 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.mycompany.app</groupId>
+  <artifactId>single-module-snapshot</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0.0-SNAPSHOT</version>
+  <properties>
+    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+  <dependencies>
+</dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.github.chains-project</groupId>
+        <artifactId>maven-lockfile</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>
+                generate</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <checksumMode>local</checksumMode>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/test/resources-its/it/IntegrationTestsIT/singleModuleSnapshotShouldKeepOwnPomChecksum/src/main/java/HelloWorld.java
+++ b/src/test/resources-its/it/IntegrationTestsIT/singleModuleSnapshotShouldKeepOwnPomChecksum/src/main/java/HelloWorld.java
@@ -1,0 +1,5 @@
+public class HelloWorld {
+    public static void main(String[] args) {
+        System.out.println("Hello, world!");
+    }
+}


### PR DESCRIPTION
`reactorGavs(session)` includes the project being built itself, since session.getProjects() is just that one project in a single-module reactor. constructRecursivePom() then matches the project's own GAV against reactorGavs and blanks its pom checksum, even though it isn't a sibling reactor dependency whose checksum drifts run to run. Reproduces the lockfile.json diff seen in PR #1616's failing check-lockfile job.
