### PR TITLE
fix: pin resolved plugin version when freezing dependencies

### DIFF
--- a/src/main/java/io/github/chains_project/maven_lockfile/FreezeDependencyMojo.java
+++ b/src/main/java/io/github/chains_project/maven_lockfile/FreezeDependencyMojo.java
@@ -220,6 +220,14 @@ public class FreezeDependencyMojo extends AbstractMojo {
                 plugin.setArtifactId(mavenPlugin.getArtifactId().getValue());
                 plugins.add(plugin);
             }
+            // Pin the plugin to the version resolved in the lock file, otherwise Maven
+            // falls back to a default/latest version at build time and the frozen POM
+            // no longer reproduces the original build.
+            String version = mavenPlugin.getVersion().getValue();
+            if (exactVersionStrings.equals("true")) {
+                version = convertSoftToExactVersionString(version);
+            }
+            plugin.setVersion(version);
 
             // Add plugin dependencies if they exist
             Set<DependencyNode> pluginDependencies = mavenPlugin.getDependencies();

--- a/src/test/java/it/IntegrationTestsIT.java
+++ b/src/test/java/it/IntegrationTestsIT.java
@@ -816,6 +816,12 @@ public class IntegrationTestsIT {
         assertThat(lockfilePom.getBuild().getPlugins())
                 .anyMatch(
                         p -> p.getDependencies() != null && !p.getDependencies().isEmpty());
+        // Verify the plugin version from the lock file is pinned in the frozen POM,
+        // otherwise Maven would resolve a different plugin version at build time.
+        assertThat(lockfilePom.getBuild().getPlugins())
+                .filteredOn(p -> p.getArtifactId().equals("maven-compiler-plugin"))
+                .extracting(Plugin::getVersion)
+                .containsExactly("[3.11.0]");
         // Verify plugin dependencies only have valid scopes (compile, runtime, system)
         for (Plugin plugin : lockfilePom.getBuild().getPlugins()) {
             for (Dependency dep : plugin.getDependencies()) {


### PR DESCRIPTION
`FreezeDependencyMojo.updatePlugins()` adds build plugins (and their dependencies) recorded in `lockfile.json` to the frozen `pom.lockfile.xml`, but never pins the plugin's `<version>`. A frozen POM therefore leaves plugin resolution unconstrained at build time, so a later build can pick a different plugin version than the one recorded in the lock file — defeating the purpose of `freeze` and causing non-reproducible builds (e.g. a different `maven-compiler-plugin` version producing different compile results).

Related: #1614