### PR TITLE
chore: allow environmental validation failure in release workflows

### DIFF
--- a/.github/workflows/jreleaser-beta.yml
+++ b/.github/workflows/jreleaser-beta.yml
@@ -34,7 +34,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify action checksums
-        uses: chains-project/maven-lockfile/.github/actions/ghasum@3ddcf33c03217482c614440fd714375e9053e732 # 5.16.0
+        uses: chains-project/maven-lockfile/.github/actions/ghasum@965b5aeb7c07fc4483409f041706e6642e6967a7 # 5.17.3
 
       - name: Set up JDK 17
         uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
@@ -76,10 +76,11 @@ jobs:
         shell: bash
 
       - name: run maven-lockfile (validate lockfile)
-        uses: chains-project/maven-lockfile@3ddcf33c03217482c614440fd714375e9053e732 # 5.16.0
+        uses: chains-project/maven-lockfile@965b5aeb7c07fc4483409f041706e6642e6967a7 # 5.17.3
         with:
             github-token: ${{ secrets.GITHUB_TOKEN }}
             include-maven-plugins: true
+            allow-environmental-validation-failure: true
             commit-lockfile: false
 
       - name: set branchname to next version

--- a/.github/workflows/jreleaser.yml
+++ b/.github/workflows/jreleaser.yml
@@ -40,7 +40,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Verify action checksums
-        uses: chains-project/maven-lockfile/.github/actions/ghasum@3ddcf33c03217482c614440fd714375e9053e732 # 5.16.0
+        uses: chains-project/maven-lockfile/.github/actions/ghasum@965b5aeb7c07fc4483409f041706e6642e6967a7 # 5.17.3
 
       - name: Set up JDK 17
         uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
@@ -80,10 +80,11 @@ jobs:
         run: echo "NEXT_VERSION=$(semver next ${{ github.event.inputs.version }} $CURRENT_VERSION)" >> $GITHUB_ENV
 
       - name: run maven-lockfile (validate lockfile)
-        uses: chains-project/maven-lockfile@3ddcf33c03217482c614440fd714375e9053e732 # 5.16.0
+        uses: chains-project/maven-lockfile@965b5aeb7c07fc4483409f041706e6642e6967a7 # 5.17.3
         with:
             github-token: ${{ secrets.GITHUB_TOKEN }}
             include-maven-plugins: true
+            allow-environmental-validation-failure: true
             commit-lockfile: false
 
       - name: set branchname to next version

--- a/.github/workflows/regenerate-lockfile.yml
+++ b/.github/workflows/regenerate-lockfile.yml
@@ -29,9 +29,10 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Verify action checksums
-        uses: chains-project/maven-lockfile/.github/actions/ghasum@3ddcf33c03217482c614440fd714375e9053e732 # 5.16.0
+        uses: chains-project/maven-lockfile/.github/actions/ghasum@965b5aeb7c07fc4483409f041706e6642e6967a7 # 5.17.3
 
       - name: run maven-lockfile
-        uses: chains-project/maven-lockfile@3ddcf33c03217482c614440fd714375e9053e732 # 5.16.0
+        uses: chains-project/maven-lockfile@965b5aeb7c07fc4483409f041706e6642e6967a7 # 5.17.3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          allow-environmental-validation-failure: true


### PR DESCRIPTION
The [Beta Release run](https://github.com/chains-project/maven-lockfile/actions/runs/31918094622/job/95093275032) failed because the runner's Java was bumped to 17.0.20 while the lockfile was generated with 17.0.19. #1621 fixed this for `Lockfile.yml`/`LockfilePR.yml` but missed `jreleaser-beta.yml`, `jreleaser.yml`, and `regenerate-lockfile.yml`, which were still pinned to the 5.16.0 action without `allow-environmental-validation-failure`. This applies the same update there.